### PR TITLE
fix: consistent navigation for public pages

### DIFF
--- a/resources/js/components/public-nav.tsx
+++ b/resources/js/components/public-nav.tsx
@@ -1,0 +1,57 @@
+import { Icon } from '@/components/icon';
+import { LoginDialog } from '@/components/login-dialog';
+import { Button } from '@/components/ui/button';
+import { type SharedData } from '@/types';
+import { Link, usePage } from '@inertiajs/react';
+import { GraduationCap } from 'lucide-react';
+
+interface PublicNavProps {
+    currentPage?: 'home' | 'about';
+}
+
+export function PublicNav({ currentPage }: PublicNavProps) {
+    const { auth } = usePage<SharedData>().props;
+
+    // Helper function to get dashboard URL based on user role
+    const getDashboardUrl = () => {
+        if (!auth.user) return '/login';
+        // The server will redirect to the correct dashboard after login
+        return '/admin/dashboard';
+    };
+
+    return (
+        <header className="fixed top-0 left-0 z-50 w-full border-b bg-white/80 backdrop-blur-md">
+            <div className="container mx-auto flex h-16 items-center justify-between px-6">
+                <Link href="/" className="flex items-center space-x-2 text-xl font-bold text-slate-800 transition-colors hover:text-blue-600">
+                    <Icon iconNode={GraduationCap} className="h-6 w-6" />
+                    <span>CBHLC</span>
+                </Link>
+                <nav className="flex items-center space-x-8">
+                    <Link
+                        href="/"
+                        className={`font-medium transition-colors ${
+                            currentPage === 'home' ? 'text-blue-600' : 'text-slate-600 hover:text-slate-800'
+                        }`}
+                    >
+                        Home
+                    </Link>
+                    <Link
+                        href="/about"
+                        className={`font-medium transition-colors ${
+                            currentPage === 'about' ? 'text-blue-600' : 'text-slate-600 hover:text-slate-800'
+                        }`}
+                    >
+                        About
+                    </Link>
+                    {auth.user ? (
+                        <Button asChild variant="default">
+                            <Link href={getDashboardUrl()}>Dashboard</Link>
+                        </Button>
+                    ) : (
+                        <LoginDialog trigger={<Button variant="outline">Login</Button>} />
+                    )}
+                </nav>
+            </div>
+        </header>
+    );
+}

--- a/resources/js/pages/about.tsx
+++ b/resources/js/pages/about.tsx
@@ -1,22 +1,12 @@
 import { Icon } from '@/components/icon';
-import { LoginDialog } from '@/components/login-dialog';
+import { PublicNav } from '@/components/public-nav';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { type SharedData } from '@/types';
-import { Head, Link, usePage } from '@inertiajs/react';
+import { Head } from '@inertiajs/react';
 import { Award, BookOpen, Eye, Facebook, GraduationCap, Heart, Instagram, Mail, MapPin, Phone, Star, Target, Users } from 'lucide-react';
 
 export default function About() {
-    const { auth } = usePage<SharedData>().props;
-
-    // Helper function to get dashboard URL based on user role
-    const getDashboardUrl = () => {
-        if (!auth.user) return '/login';
-        return '/admin/dashboard'; // Server will redirect to correct dashboard
-    };
-
     const values = [
         {
             icon: Heart,
@@ -64,30 +54,7 @@ export default function About() {
         <>
             <Head title="About Us" />
             <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
-                {/* Navigation Header */}
-                <header className="fixed top-0 left-0 z-50 w-full border-b bg-white/80 backdrop-blur-md">
-                    <div className="container mx-auto flex h-16 items-center justify-between px-6">
-                        <Link href="/" className="flex items-center space-x-2 text-xl font-bold text-slate-800 transition-colors hover:text-blue-600">
-                            <Icon iconNode={GraduationCap} className="h-6 w-6" />
-                            <span>CBHLC</span>
-                        </Link>
-                        <nav className="flex items-center space-x-8">
-                            <Link href="/about" className="font-medium text-blue-600">
-                                About
-                            </Link>
-                            <Link href="/" className="font-medium text-slate-600 transition-colors hover:text-slate-800">
-                                Home
-                            </Link>
-                            {auth.user ? (
-                                <Button asChild variant="default">
-                                    <Link href={getDashboardUrl()}>Dashboard</Link>
-                                </Button>
-                            ) : (
-                                <LoginDialog trigger={<Button variant="outline">Login</Button>} />
-                            )}
-                        </nav>
-                    </div>
-                </header>
+                <PublicNav currentPage="about" />
 
                 {/* Hero Section */}
                 <section className="pt-16">

--- a/resources/js/pages/landing.tsx
+++ b/resources/js/pages/landing.tsx
@@ -1,25 +1,12 @@
 import { Icon } from '@/components/icon';
-import { LoginDialog } from '@/components/login-dialog';
+import { PublicNav } from '@/components/public-nav';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { type SharedData } from '@/types';
-import { Head, Link, usePage } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 import { BookOpen, CheckCircle, Facebook, GraduationCap, Heart, Instagram, Users } from 'lucide-react';
 
 export default function Landing() {
-    const { auth } = usePage<SharedData>().props;
-
-    // Helper function to get dashboard URL based on user role
-    const getDashboardUrl = () => {
-        if (!auth.user) return '/login';
-
-        // This logic should match the User model's getDashboardRoute() method
-        // Since we don't have role info in frontend, we'll use a default
-        // The server will redirect to the correct dashboard after login
-        return '/admin/dashboard';
-    };
-
     const features = [
         {
             icon: BookOpen,
@@ -57,27 +44,7 @@ export default function Landing() {
                 <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
             </Head>
             <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50">
-                {/* Navigation Header */}
-                <header className="fixed top-0 left-0 z-50 w-full border-b bg-white/80 backdrop-blur-md">
-                    <div className="container mx-auto flex h-16 items-center justify-between px-6">
-                        <Link href="/" className="flex items-center space-x-2 text-xl font-bold text-slate-800 transition-colors hover:text-blue-600">
-                            <Icon iconNode={GraduationCap} className="h-6 w-6" />
-                            <span>CBHLC</span>
-                        </Link>
-                        <nav className="flex items-center space-x-8">
-                            <Link href="/about" className="font-medium text-slate-600 transition-colors hover:text-slate-800">
-                                About
-                            </Link>
-                            {auth.user ? (
-                                <Button asChild variant="default">
-                                    <Link href={getDashboardUrl()}>Dashboard</Link>
-                                </Button>
-                            ) : (
-                                <LoginDialog trigger={<Button variant="outline">Login</Button>} />
-                            )}
-                        </nav>
-                    </div>
-                </header>
+                <PublicNav currentPage="home" />
 
                 {/* Hero Section */}
                 <section className="pt-16">


### PR DESCRIPTION
## Summary
- Created a shared `PublicNav` component to ensure consistent navigation across public pages
- Fixed inconsistency between landing page (/) and about page (/about) navigation

## Changes
- **New component**: `PublicNav` - Reusable navigation component for public pages
- **Updated landing page**: Now uses PublicNav with "home" as active page
- **Updated about page**: Now uses PublicNav with "about" as active page
- **Navigation features**:
  - Both Home and About links are now always visible
  - Active page is highlighted in blue
  - Consistent styling and hover effects
  - Login/Dashboard button properly positioned

## Before
- Landing page had: Logo | About | Login
- About page had: Logo | About (blue) | Home | Login
- Inconsistent order and visibility of navigation items

## After  
- Both pages now have: Logo | Home | About | Login
- Active page highlighted in blue
- Consistent navigation experience

## Test Plan
- [x] Visit landing page (/) - verify Home is highlighted
- [x] Visit about page (/about) - verify About is highlighted  
- [x] Test navigation between pages
- [x] Verify Login/Dashboard button works correctly