### PR TITLE
fix: use $this->faker instead of fake() helper in UserFactory

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,8 +24,8 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),


### PR DESCRIPTION
- Replace fake() helper with $this->faker for better compatibility
- Fixes production seeding error 'Call to undefined function fake()'
- Ensures UserFactory works across all environments