### PR TITLE
fix: add explicit name field to package.json to prevent lock file con…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "cbhlc",
             "dependencies": {
                 "@headlessui/react": "^2.2.0",
                 "@inertiajs/react": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "cbhlc",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
…flicts

- Add "name": "cbhlc" to package.json
- Update package-lock.json to use consistent name
- Prevents package-lock.json from changing name between 'html' and 'cbhlc'
- Fixes production conflicts caused by name field changes
- Ensures consistent behavior across all environments