### PR TITLE
cleanup: remove redundant test@example.com user from seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -72,14 +72,5 @@ class DatabaseSeeder extends Seeder
             'password' => bcrypt('password'),
         ]);
         $student->assignRole('student');
-
-        // Additional test parent user
-        $testUser = User::create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-            'email_verified_at' => now(),
-            'password' => bcrypt('password'),
-        ]);
-        $testUser->assignRole('parent');
     }
 }


### PR DESCRIPTION
- Remove unnecessary 'Test User' with test@example.com
- Keep only one test user per role for cleaner database
- parent@example.com already serves as the test parent user