### PR TITLE
fix: preselect student when enrolling from students page

### DIFF
--- a/app/Http/Controllers/EnrollmentController.php
+++ b/app/Http/Controllers/EnrollmentController.php
@@ -43,11 +43,12 @@ class EnrollmentController extends Controller
     /**
      * Show the form for creating a new enrollment.
      */
-    public function create()
+    public function create(Request $request)
     {
         $user = Auth::user();
         $students = [];
         $currentSchoolYear = date('Y').'-'.(date('Y') + 1);
+        $selectedStudentId = $request->query('student_id');
 
         // If user is a guardian, get their students with enrollment info
         if ($user->hasRole('guardian')) {
@@ -77,6 +78,7 @@ class EnrollmentController extends Controller
             'gradeLevels' => GradeLevel::values(),
             'quarters' => Quarter::values(),
             'currentSchoolYear' => $currentSchoolYear,
+            'selectedStudentId' => $selectedStudentId,
         ]);
     }
 

--- a/resources/js/pages/enrollments/create.tsx
+++ b/resources/js/pages/enrollments/create.tsx
@@ -24,11 +24,12 @@ interface Props {
     gradeLevels: string[];
     quarters: string[];
     currentSchoolYear: string;
+    selectedStudentId?: string | null;
 }
 
-export default function EnrollmentCreate({ students, quarters, currentSchoolYear }: Props) {
+export default function EnrollmentCreate({ students, quarters, currentSchoolYear, selectedStudentId }: Props) {
     const { data, setData, post, processing, errors } = useForm({
-        student_id: '',
+        student_id: selectedStudentId ? String(selectedStudentId) : '',
         school_year: currentSchoolYear,
         quarter: '',
         grade_level: '',

--- a/resources/js/pages/enrollments/create.tsx
+++ b/resources/js/pages/enrollments/create.tsx
@@ -28,20 +28,13 @@ interface Props {
 }
 
 export default function EnrollmentCreate({ students, quarters, currentSchoolYear, selectedStudentId }: Props) {
+    // Initialize with the selectedStudentId if provided
     const { data, setData, post, processing, errors } = useForm({
-        student_id: '',
+        student_id: selectedStudentId ? String(selectedStudentId) : '',
         school_year: currentSchoolYear,
         quarter: '',
         grade_level: '',
     });
-
-    // Set the initial student_id when component mounts or selectedStudentId changes
-    React.useEffect(() => {
-        if (selectedStudentId) {
-            // Ensure we're setting it as a string to match SelectItem value
-            setData('student_id', String(selectedStudentId));
-        }
-    }, [selectedStudentId]);
 
     const selectedStudent = students.find((s) => s.id.toString() === data.student_id);
     const canSelectQuarter = selectedStudent?.is_new_student ?? false;

--- a/resources/js/pages/enrollments/create.tsx
+++ b/resources/js/pages/enrollments/create.tsx
@@ -29,11 +29,19 @@ interface Props {
 
 export default function EnrollmentCreate({ students, quarters, currentSchoolYear, selectedStudentId }: Props) {
     const { data, setData, post, processing, errors } = useForm({
-        student_id: selectedStudentId ? String(selectedStudentId) : '',
+        student_id: '',
         school_year: currentSchoolYear,
         quarter: '',
         grade_level: '',
     });
+
+    // Set the initial student_id when component mounts or selectedStudentId changes
+    React.useEffect(() => {
+        if (selectedStudentId) {
+            // Ensure we're setting it as a string to match SelectItem value
+            setData('student_id', String(selectedStudentId));
+        }
+    }, [selectedStudentId]);
 
     const selectedStudent = students.find((s) => s.id.toString() === data.student_id);
     const canSelectQuarter = selectedStudent?.is_new_student ?? false;


### PR DESCRIPTION
## Summary
- Add support for preselecting a student when navigating to enrollment creation from the students list page
- When clicking "Enroll" button on /guardian/students, the enrollment form now automatically selects that student

## Changes
- Updated `EnrollmentController::create()` to accept `student_id` query parameter
- Pass `selectedStudentId` prop to React enrollment create component
- Initialize form with preselected student when URL contains student_id parameter

## Test Plan
1. Navigate to /guardian/students
2. Click "Enroll" button for any student
3. Verify the enrollment form preselects that student in the dropdown
4. Confirm form submission still works correctly