### PR TITLE
feat: improve sidebar navigation with dropdowns

### DIFF
--- a/resources/js/components/Sidebar.tsx
+++ b/resources/js/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils';
 import { logout } from '@/routes';
 import { type SharedData } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
-import { ChevronDown, CreditCard, GraduationCap, Home, LogOut, Plus, UserCircle, Users } from 'lucide-react';
+import { Book, ChevronDown, CreditCard, GraduationCap, Home, LogOut, Plus, UserCircle, Users } from 'lucide-react';
 import { useState } from 'react';
 
 interface SidebarProps {
@@ -15,6 +15,8 @@ interface SidebarProps {
 export default function Sidebar({ currentPage = '' }: SidebarProps) {
     const { auth } = usePage<SharedData>().props;
     const [billingOpen, setBillingOpen] = useState(false);
+    const [studentsOpen, setStudentsOpen] = useState(false);
+    const [enrollmentsOpen, setEnrollmentsOpen] = useState(false);
     const isActive = (page: string) => currentPage === page;
 
     // Get the dashboard URL from the auth props (provided by backend)
@@ -54,30 +56,65 @@ export default function Sidebar({ currentPage = '' }: SidebarProps) {
                     </Link>
                 </Button>
 
-                <Button
-                    variant={isActive('enrollments') ? 'secondary' : 'ghost'}
-                    className={cn('w-full justify-start gap-3', isActive('enrollments') && 'bg-accent')}
-                    asChild
-                >
-                    <Link href="/enrollments">
-                        <Users className="h-4 w-4" />
-                        Enrollments
-                    </Link>
-                </Button>
-
-                {/* Show Add Student link only for guardians */}
+                {/* Students Section - Show only for guardians */}
                 {auth.user?.roles?.some((role) => role.name === 'guardian') && (
-                    <Button
-                        variant={isActive('guardian.students.create') ? 'secondary' : 'ghost'}
-                        className={cn('w-full justify-start gap-3', isActive('guardian.students.create') && 'bg-accent')}
-                        asChild
-                    >
-                        <Link href="/guardian/students/create">
-                            <Plus className="h-4 w-4" />
-                            Add Student
-                        </Link>
-                    </Button>
+                    <Collapsible open={studentsOpen} onOpenChange={setStudentsOpen}>
+                        <CollapsibleTrigger asChild>
+                            <Button
+                                variant={currentPage?.includes('guardian.students') ? 'secondary' : 'ghost'}
+                                className={cn('w-full justify-between gap-3', currentPage?.includes('guardian.students') && 'bg-accent')}
+                            >
+                                <Link href="/guardian/students" className="flex flex-1 items-center gap-3">
+                                    <Users className="h-4 w-4" />
+                                    Students
+                                </Link>
+                                <ChevronDown className={cn('h-4 w-4 transition-transform', studentsOpen && 'rotate-180')} />
+                            </Button>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent className="ml-7 space-y-1">
+                            <Button
+                                variant={isActive('guardian.students.create') ? 'secondary' : 'ghost'}
+                                size="sm"
+                                className={cn('w-full justify-start gap-2', isActive('guardian.students.create') && 'bg-accent')}
+                                asChild
+                            >
+                                <Link href="/guardian/students/create">
+                                    <Plus className="h-3 w-3" />
+                                    Add Student
+                                </Link>
+                            </Button>
+                        </CollapsibleContent>
+                    </Collapsible>
                 )}
+
+                {/* Enrollments Section */}
+                <Collapsible open={enrollmentsOpen} onOpenChange={setEnrollmentsOpen}>
+                    <CollapsibleTrigger asChild>
+                        <Button
+                            variant={currentPage?.includes('enrollments') ? 'secondary' : 'ghost'}
+                            className={cn('w-full justify-between gap-3', currentPage?.includes('enrollments') && 'bg-accent')}
+                        >
+                            <Link href="/enrollments" className="flex flex-1 items-center gap-3">
+                                <GraduationCap className="h-4 w-4" />
+                                Enrollments
+                            </Link>
+                            <ChevronDown className={cn('h-4 w-4 transition-transform', enrollmentsOpen && 'rotate-180')} />
+                        </Button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="ml-7 space-y-1">
+                        <Button
+                            variant={isActive('enrollments.create') ? 'secondary' : 'ghost'}
+                            size="sm"
+                            className={cn('w-full justify-start gap-2', isActive('enrollments.create') && 'bg-accent')}
+                            asChild
+                        >
+                            <Link href="/enrollments/create">
+                                <Plus className="h-3 w-3" />
+                                New Enrollment
+                            </Link>
+                        </Button>
+                    </CollapsibleContent>
+                </Collapsible>
                 <Collapsible open={billingOpen} onOpenChange={setBillingOpen}>
                     <CollapsibleTrigger asChild>
                         <Button variant="ghost" className="w-full justify-between gap-3">
@@ -114,7 +151,7 @@ export default function Sidebar({ currentPage = '' }: SidebarProps) {
                     asChild
                 >
                     <Link href="/registrar">
-                        <GraduationCap className="h-4 w-4" />
+                        <Book className="h-4 w-4" />
                         Registrar
                     </Link>
                 </Button>


### PR DESCRIPTION
## Summary
- Reorganized sidebar navigation for better UX
- Students section now appears before Enrollments (as requested)
- Added collapsible dropdown functionality to both Students and Enrollments sections

## Changes
- **Menu Order:** Students section moved above Enrollments
- **Dropdown Navigation:** 
  - Main menu items (Students, Enrollments) link to their respective index/list pages
  - Dropdown items contain create/add actions (Add Student, New Enrollment)
- **Icon Updates:** 
  - Book icon for Registrar
  - GraduationCap icon for Enrollments
  - Users icon for Students
- **Active State:** Proper highlighting for both parent and child menu items

## Test Plan
1. Navigate to the sidebar as a guardian user
2. Verify Students section appears before Enrollments
3. Click on Students - should navigate to /guardian/students
4. Click dropdown arrow - should reveal "Add Student" option
5. Click on Enrollments - should navigate to /enrollments
6. Click dropdown arrow - should reveal "New Enrollment" option
7. Verify active states highlight correctly when on nested pages

## Screenshots
The sidebar now has a cleaner, more intuitive structure with collapsible sections for better organization.