### PR TITLE
Fix flaky student search test

### DIFF
--- a/tests/Feature/Services/StudentServiceTest.php
+++ b/tests/Feature/Services/StudentServiceTest.php
@@ -263,13 +263,27 @@ test('getStudentsByGuardian returns guardian students', function () {
 });
 
 test('searchStudents delegates to getPaginatedStudents', function () {
-    Student::factory()->create(['first_name' => 'John']);
-    Student::factory()->create(['first_name' => 'Jane']);
+    // Create students with specific names to avoid flaky tests
+    // Use unique names that won't accidentally match in other fields
+    $john = Student::factory()->create([
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'middle_name' => null,
+        'email' => 'john.doe@test.com',
+    ]);
+
+    Student::factory()->create([
+        'first_name' => 'Jane',
+        'last_name' => 'Smith',
+        'middle_name' => null,
+        'email' => 'jane.smith@test.com',
+    ]);
 
     $result = $this->service->searchStudents('John');
 
     expect($result)->toBeInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class);
     expect($result->count())->toBe(1);
+    expect($result->first()->id)->toBe($john->id);
     expect($result->first()->first_name)->toBe('John');
 });
 


### PR DESCRIPTION
## Summary
- Fixed intermittent test failure in StudentServiceTest::searchStudents
- Test was randomly failing due to factory-generated data containing search term
- Now passes consistently across multiple test runs

## Root Cause
The test was searching for 'John' but the factory could randomly generate:
- Names like 'Johnson' as a last name
- Names like 'Johnathan' as a first name
- Email addresses containing 'john'

Since the search uses `LIKE %John%` on multiple fields (first_name, last_name, middle_name, student_id, email), any of these would cause unexpected matches.

## Solution
- Explicitly set all searchable fields to prevent accidental matches
- Use specific, non-overlapping test data ('John Doe' and 'Jane Smith')
- Set middle_name to null and use controlled email addresses
- Added ID comparison to ensure the correct record is returned

## Test Plan
- [x] Run test 10 times consecutively - all pass
- [x] All other tests in StudentServiceTest still pass
- [x] Full test suite passes with 79% coverage