### PR TITLE
fix: correct guardian relationship in Enrollment, Student, and GuardianStudent models

### DIFF
--- a/app/Enums/DocumentType.php
+++ b/app/Enums/DocumentType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+enum DocumentType: string
+{
+    case BIRTH_CERTIFICATE = 'birth_certificate';
+    case REPORT_CARD = 'report_card';
+    case FORM_138 = 'form_138';
+    case GOOD_MORAL = 'good_moral';
+    case OTHER = 'other';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::BIRTH_CERTIFICATE => 'Birth Certificate',
+            self::REPORT_CARD => 'Report Card',
+            self::FORM_138 => 'Form 138',
+            self::GOOD_MORAL => 'Good Moral Certificate',
+            self::OTHER => 'Other Document',
+        };
+    }
+}

--- a/app/Enums/VerificationStatus.php
+++ b/app/Enums/VerificationStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+enum VerificationStatus: string
+{
+    case PENDING = 'pending';
+    case VERIFIED = 'verified';
+    case REJECTED = 'rejected';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::PENDING => 'Pending Verification',
+            self::VERIFIED => 'Verified',
+            self::REJECTED => 'Rejected',
+        };
+    }
+
+    public function color(): string
+    {
+        return match ($this) {
+            self::PENDING => 'yellow',
+            self::VERIFIED => 'green',
+            self::REJECTED => 'red',
+        };
+    }
+}

--- a/app/Http/Controllers/Guardian/EnrollmentController.php
+++ b/app/Http/Controllers/Guardian/EnrollmentController.php
@@ -114,9 +114,12 @@ class EnrollmentController extends Controller
         $amountPaidCents = 0;
         $balanceCents = $netAmountCents - $amountPaidCents;
 
+        // Get Guardian model ID for the authenticated user
+        $guardian = \App\Models\Guardian::where('user_id', Auth::id())->firstOrFail();
+
         $enrollment = Enrollment::create([
             'student_id' => $validated['student_id'],
-            'guardian_id' => Auth::id(),
+            'guardian_id' => $guardian->id,
             'school_year' => $validated['school_year'],
             'quarter' => Quarter::from($validated['quarter']),
             'grade_level' => GradeLevel::from($validated['grade_level']),

--- a/app/Http/Controllers/Registrar/StudentController.php
+++ b/app/Http/Controllers/Registrar/StudentController.php
@@ -6,7 +6,6 @@ use App\Enums\GradeLevel;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Registrar\StoreStudentRequest;
 use App\Http\Requests\Registrar\UpdateStudentRequest;
-use App\Models\Guardian;
 use App\Models\Student;
 use Illuminate\Http\Request;
 use Inertia\Inertia;

--- a/app/Http/Controllers/Registrar/StudentController.php
+++ b/app/Http/Controllers/Registrar/StudentController.php
@@ -101,7 +101,7 @@ class StudentController extends Controller
                     return [
                         'id' => $guardian->user_id,
                         'name' => $guardian->first_name.' '.$guardian->last_name,
-                        'email' => $guardian->user?->email ?? 'N/A',
+                        'email' => $guardian->user->email ?? 'N/A',
                         'relationship_type' => $gs->relationship_type,
                         'is_primary_contact' => $gs->is_primary_contact,
                     ];

--- a/app/Http/Controllers/Registrar/StudentController.php
+++ b/app/Http/Controllers/Registrar/StudentController.php
@@ -58,7 +58,7 @@ class StudentController extends Controller
      */
     public function show(Student $student)
     {
-        $student->load(['enrollments.guardian', 'guardianStudents.guardian']);
+        $student->load(['enrollments.guardian.user', 'guardianStudents.guardian.user']);
 
         return Inertia::render('registrar/students/show', [
             'student' => [
@@ -93,19 +93,20 @@ class StudentController extends Controller
                 }),
                 /** @phpstan-ignore-next-line */
                 'guardians' => $student->guardianStudents->map(function ($gs) {
-                    $guardianUser = $gs->guardian;
-                    $guardianModel = Guardian::where('user_id', $guardianUser->id)->first();
+                    $guardian = $gs->guardian;
+
+                    if (! $guardian) {
+                        return null;
+                    }
 
                     return [
-                        'id' => $guardianUser->id,
-                        'name' => $guardianModel ?
-                            $guardianModel->first_name.' '.$guardianModel->last_name :
-                            $guardianUser->name,
-                        'email' => $guardianUser->email,
+                        'id' => $guardian->user_id,
+                        'name' => $guardian->first_name.' '.$guardian->last_name,
+                        'email' => $guardian->user?->email ?? 'N/A',
                         'relationship_type' => $gs->relationship_type,
                         'is_primary_contact' => $gs->is_primary_contact,
                     ];
-                }),
+                })->filter(),
             ],
         ]);
     }

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\DocumentType;
+use App\Enums\VerificationStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Storage;
+
+class Document extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    protected $fillable = [
+        'student_id',
+        'document_type',
+        'original_filename',
+        'stored_filename',
+        'file_path',
+        'file_size',
+        'mime_type',
+        'upload_date',
+        'verification_status',
+        'verified_by',
+        'verified_at',
+        'rejection_reason',
+    ];
+
+    protected $casts = [
+        'document_type' => DocumentType::class,
+        'verification_status' => VerificationStatus::class,
+        'upload_date' => 'datetime',
+        'verified_at' => 'datetime',
+        'file_size' => 'integer',
+    ];
+
+    /**
+     * Get the student that owns the document.
+     */
+    public function student(): BelongsTo
+    {
+        return $this->belongsTo(Student::class);
+    }
+
+    /**
+     * Get the user who verified the document.
+     */
+    public function verifiedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'verified_by');
+    }
+
+    /**
+     * Get the URL for the document.
+     */
+    public function getUrlAttribute(): string
+    {
+        return Storage::disk('private')->url($this->file_path);
+    }
+
+    /**
+     * Get the file size in a human-readable format.
+     */
+    public function getHumanFileSizeAttribute(): string
+    {
+        $bytes = $this->file_size;
+        $units = ['B', 'KB', 'MB', 'GB'];
+
+        for ($i = 0; $bytes > 1024; $i++) {
+            $bytes /= 1024;
+        }
+
+        return round($bytes, 2).' '.$units[$i];
+    }
+
+    /**
+     * Check if document is verified.
+     */
+    public function isVerified(): bool
+    {
+        return $this->verification_status === VerificationStatus::VERIFIED;
+    }
+
+    /**
+     * Check if document is pending.
+     */
+    public function isPending(): bool
+    {
+        return $this->verification_status === VerificationStatus::PENDING;
+    }
+
+    /**
+     * Check if document is rejected.
+     */
+    public function isRejected(): bool
+    {
+        return $this->verification_status === VerificationStatus::REJECTED;
+    }
+
+    /**
+     * Verify the document.
+     */
+    public function verify(User $user): void
+    {
+        $this->update([
+            'verification_status' => VerificationStatus::VERIFIED,
+            'verified_by' => $user->id,
+            'verified_at' => now(),
+            'rejection_reason' => null,
+        ]);
+    }
+
+    /**
+     * Reject the document.
+     */
+    public function reject(User $user, string $reason): void
+    {
+        $this->update([
+            'verification_status' => VerificationStatus::REJECTED,
+            'verified_by' => $user->id,
+            'verified_at' => now(),
+            'rejection_reason' => $reason,
+        ]);
+    }
+
+    /**
+     * Delete the document file from storage.
+     */
+    protected static function booted(): void
+    {
+        static::deleted(function (Document $document) {
+            if ($document->file_path && Storage::disk('private')->exists($document->file_path)) {
+                Storage::disk('private')->delete($document->file_path);
+            }
+        });
+    }
+}

--- a/app/Models/Enrollment.php
+++ b/app/Models/Enrollment.php
@@ -88,7 +88,7 @@ class Enrollment extends Model
      */
     public function guardian(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'guardian_id');
+        return $this->belongsTo(Guardian::class);
     }
 
     /**
@@ -105,8 +105,8 @@ class Enrollment extends Model
     public function calculateTotalAmount(): float
     {
         return ($this->tuition_fee_cents + $this->miscellaneous_fee_cents +
-                $this->laboratory_fee_cents + $this->library_fee_cents +
-                $this->sports_fee_cents) / 100;
+            $this->laboratory_fee_cents + $this->library_fee_cents +
+            $this->sports_fee_cents) / 100;
     }
 
     /**

--- a/app/Models/GuardianStudent.php
+++ b/app/Models/GuardianStudent.php
@@ -23,10 +23,11 @@ class GuardianStudent extends Model
 
     /**
      * Get the guardian (user) associated with this relationship
+     * Note: guardian_id references users.id, not guardians.id
      */
     public function guardian(): BelongsTo
     {
-        return $this->belongsTo(Guardian::class);
+        return $this->belongsTo(Guardian::class, 'guardian_id', 'user_id');
     }
 
     /**

--- a/app/Models/GuardianStudent.php
+++ b/app/Models/GuardianStudent.php
@@ -26,7 +26,7 @@ class GuardianStudent extends Model
      */
     public function guardian(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'guardian_id');
+        return $this->belongsTo(Guardian::class);
     }
 
     /**

--- a/app/Models/Student.php
+++ b/app/Models/Student.php
@@ -57,7 +57,7 @@ class Student extends Model
      */
     public function guardian(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'guardian_id');
+        return $this->belongsTo(Guardian::class);
     }
 
     /**
@@ -84,6 +84,14 @@ class Student extends Model
     public function guardianStudents(): HasMany
     {
         return $this->hasMany(GuardianStudent::class);
+    }
+
+    /**
+     * Get the documents for the student
+     */
+    public function documents(): HasMany
+    {
+        return $this->hasMany(Document::class);
     }
 
     /**

--- a/app/Observers/EnrollmentObserver.php
+++ b/app/Observers/EnrollmentObserver.php
@@ -45,8 +45,8 @@ class EnrollmentObserver
     public function created(Enrollment $enrollment): void
     {
         // Send enrollment submitted email
-        if ($enrollment->guardian && ! empty($enrollment->guardian->email)) {
-            Mail::to($enrollment->guardian->email)
+        if ($enrollment->guardian && $enrollment->guardian->user && ! empty($enrollment->guardian->user->email)) {
+            Mail::to($enrollment->guardian->user->email)
                 ->queue(new EnrollmentSubmitted($enrollment));
         }
 
@@ -172,12 +172,12 @@ class EnrollmentObserver
      */
     private function sendStatusChangeEmail(Enrollment $enrollment): void
     {
-        if (! $enrollment->guardian || empty($enrollment->guardian->email)) {
+        if (! $enrollment->guardian || ! $enrollment->guardian->user || empty($enrollment->guardian->user->email)) {
             return;
         }
 
         $newStatus = $enrollment->status->value;
-        $email = $enrollment->guardian->email;
+        $email = $enrollment->guardian->user->email;
 
         switch ($newStatus) {
             case 'approved':

--- a/app/Services/StudentService.php
+++ b/app/Services/StudentService.php
@@ -84,13 +84,18 @@ class StudentService extends BaseService implements StudentServiceInterface
                 $data['student_id'] = $this->generateStudentId();
             }
 
+            // Extract guardian-related data before creating student
+            $guardianId = $data['guardian_id'] ?? null;
+            $relationship = $data['relationship'] ?? 'guardian';
+            unset($data['guardian_id'], $data['relationship']);
+
             // Create the student
             /** @var Student $student */
             $student = $this->model->create($data);
 
             // Associate with guardian if guardian_id is provided
-            if (! empty($data['guardian_id'])) {
-                $this->associateGuardian($student, $data['guardian_id'], $data['relationship'] ?? 'guardian');
+            if (! empty($guardianId)) {
+                $this->associateGuardian($student, $guardianId, $relationship);
             }
 
             $this->logActivity('createStudent', ['student_id' => $student->id]);

--- a/database/factories/EnrollmentFactory.php
+++ b/database/factories/EnrollmentFactory.php
@@ -58,17 +58,15 @@ class EnrollmentFactory extends Factory
             'enrollment_id' => $enrollmentId,
             'student_id' => Student::factory(),
             'guardian_id' => function (array $attributes) {
-                // Get a guardian user or create one
-                $guardianUser = \App\Models\User::whereHas('roles', function ($q) {
-                    $q->where('name', 'guardian');
-                })->inRandomOrder()->first();
+                // Get an existing guardian or create one
+                $guardian = Guardian::inRandomOrder()->first();
 
-                if (! $guardianUser) {
+                if (! $guardian) {
                     $guardianUser = \App\Models\User::factory()->create();
                     $guardianUser->assignRole('guardian');
 
                     // Create Guardian model
-                    Guardian::create([
+                    $guardian = Guardian::create([
                         'user_id' => $guardianUser->id,
                         'first_name' => $this->faker->firstName,
                         'last_name' => $this->faker->lastName,
@@ -77,7 +75,7 @@ class EnrollmentFactory extends Factory
                     ]);
                 }
 
-                return $guardianUser->id;
+                return $guardian->id;
             },
             'school_year' => $this->faker->randomElement(['2023-2024', '2024-2025', '2025-2026']),
             'quarter' => $this->faker->randomElement(Quarter::values()),

--- a/database/factories/StudentFactory.php
+++ b/database/factories/StudentFactory.php
@@ -37,7 +37,7 @@ class StudentFactory extends Factory
             'grade_level' => fake()->randomElement(GradeLevel::cases())->value,
             'section' => fake()->optional()->word(),
             'user_id' => null, // Can be set explicitly when needed (for students with user accounts)
-            'guardian_id' => null, // Can be set explicitly when needed (references users table)
+            'guardian_id' => null, // Can be set explicitly when needed (references guardians table)
         ];
     }
 }

--- a/database/migrations/2025_10_10_125013_create_documents_table.php
+++ b/database/migrations/2025_10_10_125013_create_documents_table.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('documents', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('student_id')->constrained()->onDelete('cascade');
+            $table->enum('document_type', [
+                'birth_certificate',
+                'report_card',
+                'form_138',
+                'good_moral',
+                'other',
+            ]);
+            $table->string('original_filename');
+            $table->string('stored_filename');
+            $table->string('file_path');
+            $table->unsignedBigInteger('file_size'); // in bytes
+            $table->string('mime_type');
+            $table->timestamp('upload_date')->useCurrent();
+            $table->enum('verification_status', [
+                'pending',
+                'verified',
+                'rejected',
+            ])->default('pending');
+            $table->foreignId('verified_by')->nullable()->constrained('users')->onDelete('set null');
+            $table->timestamp('verified_at')->nullable();
+            $table->text('rejection_reason')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            // Indexes for performance
+            $table->index('student_id');
+            $table->index('document_type');
+            $table->index('verification_status');
+            $table->index(['student_id', 'document_type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('documents');
+    }
+};

--- a/database/migrations/2025_10_11_085347_update_students_guardian_id_to_reference_guardians.php
+++ b/database/migrations/2025_10_11_085347_update_students_guardian_id_to_reference_guardians.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('students', function (Blueprint $table) {
+            // Drop existing foreign key constraint to users table
+            $table->dropForeign(['guardian_id']);
+
+            // Add new foreign key constraint to guardians table
+            $table->foreign('guardian_id')
+                ->references('id')
+                ->on('guardians')
+                ->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('students', function (Blueprint $table) {
+            // Drop foreign key constraint to guardians table
+            $table->dropForeign(['guardian_id']);
+
+            // Restore original foreign key constraint to users table
+            $table->foreign('guardian_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('set null');
+        });
+    }
+};

--- a/database/migrations/2025_10_11_100724_update_enrollments_guardian_id_to_reference_guardians.php
+++ b/database/migrations/2025_10_11_100724_update_enrollments_guardian_id_to_reference_guardians.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('enrollments', function (Blueprint $table) {
+            // Drop the existing foreign key constraint
+            $table->dropForeign(['guardian_id']);
+
+            // Add the new foreign key constraint referencing guardians table
+            $table->foreign('guardian_id')
+                ->references('id')
+                ->on('guardians')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('enrollments', function (Blueprint $table) {
+            // Drop the foreign key constraint
+            $table->dropForeign(['guardian_id']);
+
+            // Restore the original foreign key constraint referencing users table
+            $table->foreign('guardian_id')
+                ->references('id')
+                ->on('users')
+                ->onDelete('cascade');
+        });
+    }
+};

--- a/tests/Feature/BillingControllerTest.php
+++ b/tests/Feature/BillingControllerTest.php
@@ -27,7 +27,7 @@ describe('invoice controller', function () {
         $enrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0001',
             'student_id' => $student->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_4,
@@ -96,7 +96,7 @@ describe('invoice controller', function () {
         $otherEnrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0003',
             'student_id' => $otherStudent->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::THIRD,
             'grade_level' => GradeLevel::GRADE_6,
@@ -212,7 +212,7 @@ describe('updatePayment method', function () {
         $enrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0006',
             'student_id' => Student::factory()->create()->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_2,
@@ -249,7 +249,7 @@ describe('updatePayment method', function () {
         $enrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0007',
             'student_id' => Student::factory()->create()->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::SECOND,
             'grade_level' => GradeLevel::GRADE_3,
@@ -282,7 +282,7 @@ describe('updatePayment method', function () {
         $enrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0008',
             'student_id' => Student::factory()->create()->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::THIRD,
             'grade_level' => GradeLevel::GRADE_4,
@@ -316,7 +316,7 @@ describe('updatePayment method', function () {
         $enrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0009',
             'student_id' => Student::factory()->create()->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FOURTH,
             'grade_level' => GradeLevel::GRADE_5,
@@ -376,7 +376,7 @@ describe('updatePayment method', function () {
         $enrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0010',
             'student_id' => Student::factory()->create()->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_6,

--- a/tests/Feature/BillingControllerTest.php
+++ b/tests/Feature/BillingControllerTest.php
@@ -77,7 +77,7 @@ describe('invoice controller', function () {
         $ownEnrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0002',
             'student_id' => $ownChild->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::SECOND,
             'grade_level' => GradeLevel::GRADE_5,
@@ -147,7 +147,7 @@ describe('invoice controller', function () {
         $oldEnrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0004',
             'student_id' => $child->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2023-2024',
             'quarter' => Quarter::FOURTH,
             'grade_level' => GradeLevel::KINDER,
@@ -171,7 +171,7 @@ describe('invoice controller', function () {
         $latestEnrollment = Enrollment::create([
             'enrollment_id' => 'ENR-0005',
             'student_id' => $child->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_1,

--- a/tests/Feature/EnrollmentControllerTest.php
+++ b/tests/Feature/EnrollmentControllerTest.php
@@ -50,7 +50,7 @@ describe('enrollment controller', function () {
         ]);
         Enrollment::factory()->create([
             'student_id' => $ownStudent->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => Guardian::factory()->create()->id,
         ]);
 
         // Create other student's enrollment
@@ -81,6 +81,15 @@ describe('enrollment controller', function () {
     test('can store new enrollment', function () {
         $guardian = User::factory()->create();
         $guardian->assignRole('guardian');
+
+        // Create Guardian model
+        $guardianModel = Guardian::create([
+            'user_id' => $guardian->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
 
         $student = Student::factory()->create();
 
@@ -157,7 +166,7 @@ describe('enrollment controller', function () {
         // Create first enrollment
         $firstEnrollment = Enrollment::create([
             'student_id' => $student->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => 'Grade 1',
@@ -215,7 +224,7 @@ describe('enrollment controller', function () {
         // Create first enrollment for 2024-2025
         Enrollment::create([
             'student_id' => $student->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => 'Kinder',
@@ -251,6 +260,15 @@ describe('enrollment controller', function () {
             $guardian = User::factory()->create();
             $guardian->assignRole('guardian');
 
+            // Create Guardian model
+            $guardianModel = Guardian::create([
+                'user_id' => $guardian->id,
+                'first_name' => 'Test',
+                'last_name' => 'Guardian',
+                'contact_number' => '09123456789',
+                'address' => '123 Test St',
+            ]);
+
             $student = Student::factory()->create();
 
             GuardianStudent::create([
@@ -279,6 +297,15 @@ describe('enrollment controller', function () {
             $guardian = User::factory()->create();
             $guardian->assignRole('guardian');
 
+            // Create Guardian model
+            $guardianModel = Guardian::create([
+                'user_id' => $guardian->id,
+                'first_name' => 'Test',
+                'last_name' => 'Guardian',
+                'contact_number' => '09123456789',
+                'address' => '123 Test St',
+            ]);
+
             $student = Student::factory()->create();
 
             GuardianStudent::create([
@@ -291,7 +318,7 @@ describe('enrollment controller', function () {
             // Create previous enrollment to make student "existing"
             Enrollment::create([
                 'student_id' => $student->id,
-                'guardian_id' => $guardian->id,
+                'guardian_id' => $guardianModel->id,
                 'school_year' => '2023-2024',
                 'quarter' => Quarter::FIRST,
                 'grade_level' => 'Kinder',
@@ -328,6 +355,15 @@ describe('enrollment controller', function () {
             $guardian = User::factory()->create();
             $guardian->assignRole('guardian');
 
+            // Create Guardian model
+            $guardianModel = Guardian::create([
+                'user_id' => $guardian->id,
+                'first_name' => 'Test',
+                'last_name' => 'Guardian',
+                'contact_number' => '09123456789',
+                'address' => '123 Test St',
+            ]);
+
             $student = Student::factory()->create();
 
             GuardianStudent::create([
@@ -356,6 +392,15 @@ describe('enrollment controller', function () {
             $guardian = User::factory()->create();
             $guardian->assignRole('guardian');
 
+            // Create Guardian model
+            $guardianModel = Guardian::create([
+                'user_id' => $guardian->id,
+                'first_name' => 'Test',
+                'last_name' => 'Guardian',
+                'contact_number' => '09123456789',
+                'address' => '123 Test St',
+            ]);
+
             $student = Student::factory()->create([
                 'grade_level' => 'Grade 3',
             ]);
@@ -370,7 +415,7 @@ describe('enrollment controller', function () {
             // Create previous enrollment to establish current grade
             Enrollment::create([
                 'student_id' => $student->id,
-                'guardian_id' => $guardian->id,
+                'guardian_id' => $guardianModel->id,
                 'school_year' => '2023-2024',
                 'quarter' => Quarter::FIRST,
                 'grade_level' => 'Grade 3',
@@ -401,6 +446,15 @@ describe('enrollment controller', function () {
             $guardian = User::factory()->create();
             $guardian->assignRole('guardian');
 
+            // Create Guardian model
+            $guardianModel = Guardian::create([
+                'user_id' => $guardian->id,
+                'first_name' => 'Test',
+                'last_name' => 'Guardian',
+                'contact_number' => '09123456789',
+                'address' => '123 Test St',
+            ]);
+
             $student = Student::factory()->create([
                 'grade_level' => 'Grade 2',
             ]);
@@ -415,7 +469,7 @@ describe('enrollment controller', function () {
             // Create previous enrollment to establish current grade
             Enrollment::create([
                 'student_id' => $student->id,
-                'guardian_id' => $guardian->id,
+                'guardian_id' => $guardianModel->id,
                 'school_year' => '2023-2024',
                 'quarter' => Quarter::FIRST,
                 'grade_level' => 'Grade 2',
@@ -450,6 +504,15 @@ describe('enrollment controller', function () {
             $guardian = User::factory()->create();
             $guardian->assignRole('guardian');
 
+            // Create Guardian model
+            $guardianModel = Guardian::create([
+                'user_id' => $guardian->id,
+                'first_name' => 'Test',
+                'last_name' => 'Guardian',
+                'contact_number' => '09123456789',
+                'address' => '123 Test St',
+            ]);
+
             $student = Student::factory()->create([
                 'grade_level' => 'Grade 1',
             ]);
@@ -464,7 +527,7 @@ describe('enrollment controller', function () {
             // Create previous enrollment to establish current grade
             Enrollment::create([
                 'student_id' => $student->id,
-                'guardian_id' => $guardian->id,
+                'guardian_id' => $guardianModel->id,
                 'school_year' => '2023-2024',
                 'quarter' => Quarter::FIRST,
                 'grade_level' => 'Grade 1',

--- a/tests/Feature/EnrollmentPendingConstraintTest.php
+++ b/tests/Feature/EnrollmentPendingConstraintTest.php
@@ -20,6 +20,14 @@ describe('enrollment pending constraint', function () {
         $guardian = User::factory()->create();
         $guardian->assignRole('guardian');
 
+        $guardianModel = \App\Models\Guardian::create([
+            'user_id' => $guardian->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+
         $student = Student::factory()->create();
 
         GuardianStudent::create([
@@ -32,7 +40,7 @@ describe('enrollment pending constraint', function () {
         // Create first pending enrollment
         Enrollment::create([
             'student_id' => $student->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => 'Grade 1',
@@ -69,6 +77,14 @@ describe('enrollment pending constraint', function () {
         $guardian = User::factory()->create();
         $guardian->assignRole('guardian');
 
+        $guardianModel = \App\Models\Guardian::create([
+            'user_id' => $guardian->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+
         // Create student with specific grade level
         $student = Student::factory()->create([
             'grade_level' => 'Kinder',
@@ -84,7 +100,7 @@ describe('enrollment pending constraint', function () {
         // Create completed enrollment for previous year
         Enrollment::create([
             'student_id' => $student->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2023-2024',
             'quarter' => Quarter::FIRST,
             'grade_level' => 'Kinder',
@@ -115,6 +131,14 @@ describe('enrollment pending constraint', function () {
         $guardian = User::factory()->create();
         $guardian->assignRole('guardian');
 
+        $guardianModel = \App\Models\Guardian::create([
+            'user_id' => $guardian->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+
         $student = Student::factory()->create();
 
         GuardianStudent::create([
@@ -127,7 +151,7 @@ describe('enrollment pending constraint', function () {
         // Create enrolled enrollment for current year
         Enrollment::create([
             'student_id' => $student->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => 'Grade 1',
@@ -157,6 +181,14 @@ describe('enrollment pending constraint', function () {
         $guardian = User::factory()->create();
         $guardian->assignRole('guardian');
 
+        $guardianModel = \App\Models\Guardian::create([
+            'user_id' => $guardian->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+
         $student = Student::factory()->create();
 
         GuardianStudent::create([
@@ -169,7 +201,7 @@ describe('enrollment pending constraint', function () {
         // Create rejected enrollment
         Enrollment::create([
             'student_id' => $student->id,
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => 'Grade 1',

--- a/tests/Feature/EnrollmentTest.php
+++ b/tests/Feature/EnrollmentTest.php
@@ -92,8 +92,16 @@ test('enrollment model isApproved works correctly', function () {
 });
 
 test('enrollment model guardian relationship works', function () {
-    $guardian = User::factory()->create();
-    $guardian->assignRole('guardian');
+    $user = User::factory()->create();
+    $user->assignRole('guardian');
+
+    $guardian = \App\Models\Guardian::create([
+        'user_id' => $user->id,
+        'first_name' => 'Test',
+        'last_name' => 'Guardian',
+        'contact_number' => '09123456789',
+        'address' => '123 Test St',
+    ]);
 
     $student = Student::factory()->create();
 

--- a/tests/Feature/Guardian/BillingControllerTest.php
+++ b/tests/Feature/Guardian/BillingControllerTest.php
@@ -333,7 +333,7 @@ describe('Guardian BillingController', function () {
         $otherStudent = Student::factory()->create();
         $enrollment = Enrollment::factory()->create([
             'student_id' => $otherStudent->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
         ]);
 
         $response = $this->actingAs($this->guardian)

--- a/tests/Feature/Guardian/BillingControllerTest.php
+++ b/tests/Feature/Guardian/BillingControllerTest.php
@@ -64,7 +64,7 @@ describe('Guardian BillingController', function () {
         // Create enrollment
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_1,
             'status' => EnrollmentStatus::ENROLLED,
@@ -95,7 +95,7 @@ describe('Guardian BillingController', function () {
         // Create enrollment
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_2,
             'status' => EnrollmentStatus::ENROLLED,
@@ -125,13 +125,13 @@ describe('Guardian BillingController', function () {
         // Create enrollments
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'status' => EnrollmentStatus::ENROLLED,
         ]);
 
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'status' => EnrollmentStatus::REJECTED,
         ]);
 
@@ -157,7 +157,7 @@ describe('Guardian BillingController', function () {
         // Create multiple enrollments with different payment statuses
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_1,
             'status' => EnrollmentStatus::ENROLLED,
@@ -174,7 +174,7 @@ describe('Guardian BillingController', function () {
 
         Enrollment::factory()->create([
             'student_id' => $student2->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_1,
             'status' => EnrollmentStatus::ENROLLED,
@@ -221,7 +221,7 @@ describe('Guardian BillingController', function () {
 
         $enrollment = Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_3,
             'status' => EnrollmentStatus::ENROLLED,
@@ -251,7 +251,7 @@ describe('Guardian BillingController', function () {
 
         $enrollment = Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_4,
             'status' => EnrollmentStatus::ENROLLED,
@@ -286,7 +286,7 @@ describe('Guardian BillingController', function () {
 
         $enrollment = Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_5,
         ]);
@@ -310,7 +310,7 @@ describe('Guardian BillingController', function () {
     test('billing show includes payment instructions', function () {
         $enrollment = Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'status' => EnrollmentStatus::PENDING->value,
         ]);
 
@@ -346,7 +346,7 @@ describe('Guardian BillingController', function () {
         // Create enrollment without corresponding grade level fee
         $enrollment = Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_6,
         ]);
@@ -367,13 +367,22 @@ describe('Guardian BillingController', function () {
         // Create enrollment for guardian's child with explicit non-rejected status
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'status' => EnrollmentStatus::PENDING->value,
         ]);
 
         // Create another student and enrollment for different guardian
         $otherGuardian = User::factory()->create();
         $otherGuardian->assignRole('guardian');
+
+        $otherGuardianModel = Guardian::create([
+            'user_id' => $otherGuardian->id,
+            'first_name' => 'Other',
+            'last_name' => 'Guardian',
+            'contact_number' => '09987654321',
+            'address' => '456 Other St',
+        ]);
+
         $otherStudent = Student::factory()->create();
 
         GuardianStudent::create([
@@ -384,7 +393,7 @@ describe('Guardian BillingController', function () {
 
         Enrollment::factory()->create([
             'student_id' => $otherStudent->id,
-            'guardian_id' => $otherGuardian->id,
+            'guardian_id' => $otherGuardianModel->id,
             'status' => EnrollmentStatus::PENDING->value,
         ]);
 
@@ -414,7 +423,7 @@ describe('Guardian BillingController', function () {
 
         $enrollment = Enrollment::factory()->create([
             'student_id' => $studentNoMiddle->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'status' => EnrollmentStatus::PENDING->value,
         ]);
 
@@ -431,7 +440,7 @@ describe('Guardian BillingController', function () {
     test('billing payment schedule uses correct school years', function () {
         $enrollment = Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'status' => EnrollmentStatus::PENDING->value,
         ]);

--- a/tests/Feature/Guardian/EnrollmentControllerTest.php
+++ b/tests/Feature/Guardian/EnrollmentControllerTest.php
@@ -271,7 +271,7 @@ class EnrollmentControllerTest extends TestCase
         $otherStudent = Student::factory()->create();
         $enrollment = Enrollment::factory()->create([
             'student_id' => $otherStudent->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
         ]);
 
         $response = $this->actingAs($this->guardian)

--- a/tests/Feature/Guardian/StudentControllerTest.php
+++ b/tests/Feature/Guardian/StudentControllerTest.php
@@ -73,7 +73,7 @@ describe('Guardian StudentController', function () {
         // Create enrollment for first student
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_3,
             'status' => EnrollmentStatus::ENROLLED,
@@ -102,7 +102,7 @@ describe('Guardian StudentController', function () {
         // Create multiple enrollments
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2023-2024',
             'grade_level' => GradeLevel::GRADE_2,
             'status' => EnrollmentStatus::COMPLETED,
@@ -111,7 +111,7 @@ describe('Guardian StudentController', function () {
 
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_3,
             'status' => EnrollmentStatus::ENROLLED,
@@ -137,7 +137,7 @@ describe('Guardian StudentController', function () {
         // Create enrollment for context
         Enrollment::factory()->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
             'school_year' => '2024-2025',
             'grade_level' => GradeLevel::GRADE_3,
             'quarter' => Quarter::FIRST,
@@ -424,7 +424,7 @@ describe('Guardian StudentController', function () {
         // Create multiple enrollments
         Enrollment::factory()->count(3)->create([
             'student_id' => $this->student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
         ]);
 
         $response = $this->actingAs($this->guardian)

--- a/tests/Feature/GuardianStudentRelationshipTest.php
+++ b/tests/Feature/GuardianStudentRelationshipTest.php
@@ -142,19 +142,27 @@ test('guardian student relationship uses correct table and column names', functi
 });
 
 test('guardian student model relationships work correctly', function () {
-    $guardian = User::factory()->create();
-    $guardian->assignRole('guardian');
+    $user = User::factory()->create();
+    $user->assignRole('guardian');
+
+    $guardian = \App\Models\Guardian::create([
+        'user_id' => $user->id,
+        'first_name' => 'Test',
+        'last_name' => 'Guardian',
+        'contact_number' => '09123456789',
+        'address' => '789 Test Blvd',
+    ]);
 
     $student = Student::factory()->create();
 
     $relationship = GuardianStudent::create([
-        'guardian_id' => $guardian->id,
+        'guardian_id' => $user->id,
         'student_id' => $student->id,
         'relationship_type' => RelationshipType::OTHER->value,
         'is_primary_contact' => true,
     ]);
 
-    expect($relationship->guardian->id)->toBe($guardian->id);
+    expect($relationship->guardian->user_id)->toBe($user->id);
     expect($relationship->student->id)->toBe($student->id);
     expect($relationship->relationship_type)->toBe('other');
     expect($relationship->is_primary_contact)->toBeTrue();

--- a/tests/Feature/Observers/EnrollmentObserverTest.php
+++ b/tests/Feature/Observers/EnrollmentObserverTest.php
@@ -72,7 +72,7 @@ class EnrollmentObserverTest extends TestCase
             'contact_number' => '09123456789',
             'address' => '123 Test St',
         ]);
-        $student = Student::factory()->create(['guardian_id' => $user->id]);
+        $student = Student::factory()->create();
 
         $enrollment = Enrollment::factory()->create([
             'student_id' => $student->id,
@@ -120,7 +120,7 @@ class EnrollmentObserverTest extends TestCase
             'contact_number' => '09123456789',
             'address' => '123 Test St',
         ]);
-        $student = Student::factory()->create(['guardian_id' => $user->id]);
+        $student = Student::factory()->create();
         $enrollment = Enrollment::factory()->create([
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,

--- a/tests/Feature/Observers/EnrollmentObserverTest.php
+++ b/tests/Feature/Observers/EnrollmentObserverTest.php
@@ -64,16 +64,23 @@ class EnrollmentObserverTest extends TestCase
 
     public function test_email_is_sent_when_enrollment_is_created(): void
     {
-        $guardian = User::factory()->create(['email' => 'guardian@test.com']);
-        $student = Student::factory()->create(['guardian_id' => $guardian->id]);
+        $user = User::factory()->create(['email' => 'guardian@test.com']);
+        $guardian = \App\Models\Guardian::create([
+            'user_id' => $user->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+        $student = Student::factory()->create(['guardian_id' => $user->id]);
 
         $enrollment = Enrollment::factory()->create([
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
         ]);
 
-        Mail::assertQueued(EnrollmentSubmitted::class, function ($mail) use ($guardian, $enrollment) {
-            return $mail->hasTo($guardian->email) &&
+        Mail::assertQueued(EnrollmentSubmitted::class, function ($mail) use ($user, $enrollment) {
+            return $mail->hasTo($user->email) &&
                    $mail->enrollment->id === $enrollment->id;
         });
     }
@@ -105,8 +112,15 @@ class EnrollmentObserverTest extends TestCase
     {
         $this->actingAs(User::factory()->create());
 
-        $guardian = User::factory()->create(['email' => 'guardian@test.com']);
-        $student = Student::factory()->create(['guardian_id' => $guardian->id]);
+        $user = User::factory()->create(['email' => 'guardian@test.com']);
+        $guardian = \App\Models\Guardian::create([
+            'user_id' => $user->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+        $student = Student::factory()->create(['guardian_id' => $user->id]);
         $enrollment = Enrollment::factory()->create([
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
@@ -117,8 +131,8 @@ class EnrollmentObserverTest extends TestCase
 
         $enrollment->update(['status' => 'approved']);
 
-        Mail::assertQueued(EnrollmentApproved::class, function ($mail) use ($guardian, $enrollment) {
-            return $mail->hasTo($guardian->email) &&
+        Mail::assertQueued(EnrollmentApproved::class, function ($mail) use ($user, $enrollment) {
+            return $mail->hasTo($user->email) &&
                    $mail->enrollment->id === $enrollment->id;
         });
     }

--- a/tests/Feature/Registrar/StudentControllerTest.php
+++ b/tests/Feature/Registrar/StudentControllerTest.php
@@ -164,7 +164,7 @@ describe('Registrar StudentController', function () {
         // Create enrollment
         Enrollment::factory()->create([
             'student_id' => $student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
         ]);
 
         $response = $this->actingAs($this->registrar)
@@ -378,7 +378,7 @@ describe('Registrar StudentController', function () {
         // Create enrollment
         Enrollment::factory()->create([
             'student_id' => $student->id,
-            'guardian_id' => $this->guardian->id,
+            'guardian_id' => $this->guardianModel->id,
         ]);
 
         $response = $this->actingAs($this->registrar)

--- a/tests/Feature/Services/DashboardServiceTest.php
+++ b/tests/Feature/Services/DashboardServiceTest.php
@@ -85,7 +85,14 @@ test('getRegistrarDashboardData returns registrar-specific data', function () {
 });
 
 test('getParentDashboardData returns parent-specific data', function () {
-    $guardian = \App\Models\User::factory()->create();
+    $user = \App\Models\User::factory()->create();
+    $guardian = \App\Models\Guardian::create([
+        'user_id' => $user->id,
+        'first_name' => 'Test',
+        'last_name' => 'Guardian',
+        'contact_number' => '09123456789',
+        'address' => '123 Test St',
+    ]);
     $student = Student::factory()->create(['guardian_id' => $guardian->id]);
     $enrollment = Enrollment::factory()->create([
         'student_id' => $student->id,

--- a/tests/Feature/Services/EmailNotificationTest.php
+++ b/tests/Feature/Services/EmailNotificationTest.php
@@ -37,7 +37,7 @@ class EmailNotificationTest extends TestCase
             'contact_number' => '09123456789',
             'address' => '123 Test St',
         ]);
-        $student = Student::factory()->create(['guardian_id' => $user->id]);
+        $student = Student::factory()->create();
 
         $enrollmentData = [
             'student_id' => $student->id,
@@ -68,7 +68,7 @@ class EmailNotificationTest extends TestCase
             'contact_number' => '09123456789',
             'address' => '123 Test St',
         ]);
-        $student = Student::factory()->create(['guardian_id' => $user->id]);
+        $student = Student::factory()->create();
         $enrollment = Enrollment::factory()->create([
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
@@ -98,7 +98,7 @@ class EmailNotificationTest extends TestCase
             'contact_number' => '09123456789',
             'address' => '123 Test St',
         ]);
-        $student = Student::factory()->create(['guardian_id' => $user->id]);
+        $student = Student::factory()->create();
         $enrollment = Enrollment::factory()->create([
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
@@ -136,7 +136,7 @@ class EmailNotificationTest extends TestCase
             ]);
             $guardians[] = $guardian;
 
-            $student = Student::factory()->create(['guardian_id' => $user->id]);
+            $student = Student::factory()->create();
             $enrollments[] = Enrollment::factory()->create([
                 'student_id' => $student->id,
                 'guardian_id' => $guardian->id,
@@ -176,7 +176,7 @@ class EmailNotificationTest extends TestCase
             'contact_number' => '09123456789',
             'address' => '123 Test St',
         ]);
-        $student = Student::factory()->create(['guardian_id' => $user->id]);
+        $student = Student::factory()->create();
 
         $enrollmentData = [
             'student_id' => $student->id,
@@ -205,7 +205,6 @@ class EmailNotificationTest extends TestCase
             'address' => '123 Test St',
         ]);
         $student = Student::factory()->create([
-            'guardian_id' => $user->id,
             'first_name' => 'John',
             'last_name' => 'Doe',
         ]);

--- a/tests/Feature/Services/EmailNotificationTest.php
+++ b/tests/Feature/Services/EmailNotificationTest.php
@@ -29,8 +29,15 @@ class EmailNotificationTest extends TestCase
     public function test_sends_email_when_enrollment_is_submitted(): void
     {
         // Arrange
-        $guardian = User::factory()->create(['email' => 'guardian@test.com']);
-        $student = Student::factory()->create(['guardian_id' => $guardian->id]);
+        $user = User::factory()->create(['email' => 'guardian@test.com']);
+        $guardian = \App\Models\Guardian::create([
+            'user_id' => $user->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+        $student = Student::factory()->create(['guardian_id' => $user->id]);
 
         $enrollmentData = [
             'student_id' => $student->id,
@@ -44,8 +51,8 @@ class EmailNotificationTest extends TestCase
         $enrollment = $this->service->createEnrollment($enrollmentData);
 
         // Assert
-        Mail::assertQueued(EnrollmentSubmitted::class, function ($mail) use ($guardian, $enrollment) {
-            return $mail->hasTo($guardian->email) &&
+        Mail::assertQueued(EnrollmentSubmitted::class, function ($mail) use ($user, $enrollment) {
+            return $mail->hasTo($user->email) &&
                    $mail->enrollment->id === $enrollment->id;
         });
     }
@@ -53,8 +60,15 @@ class EmailNotificationTest extends TestCase
     public function test_sends_email_when_enrollment_is_approved(): void
     {
         // Arrange
-        $guardian = User::factory()->create(['email' => 'guardian@test.com']);
-        $student = Student::factory()->create(['guardian_id' => $guardian->id]);
+        $user = User::factory()->create(['email' => 'guardian@test.com']);
+        $guardian = \App\Models\Guardian::create([
+            'user_id' => $user->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+        $student = Student::factory()->create(['guardian_id' => $user->id]);
         $enrollment = Enrollment::factory()->create([
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
@@ -67,8 +81,8 @@ class EmailNotificationTest extends TestCase
         $this->service->approveEnrollment($enrollment);
 
         // Assert
-        Mail::assertQueued(EnrollmentApproved::class, function ($mail) use ($guardian, $enrollment) {
-            return $mail->hasTo($guardian->email) &&
+        Mail::assertQueued(EnrollmentApproved::class, function ($mail) use ($user, $enrollment) {
+            return $mail->hasTo($user->email) &&
                    $mail->enrollment->id === $enrollment->id;
         });
     }
@@ -76,8 +90,15 @@ class EmailNotificationTest extends TestCase
     public function test_sends_email_when_enrollment_is_rejected(): void
     {
         // Arrange
-        $guardian = User::factory()->create(['email' => 'guardian@test.com']);
-        $student = Student::factory()->create(['guardian_id' => $guardian->id]);
+        $user = User::factory()->create(['email' => 'guardian@test.com']);
+        $guardian = \App\Models\Guardian::create([
+            'user_id' => $user->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+        $student = Student::factory()->create(['guardian_id' => $user->id]);
         $enrollment = Enrollment::factory()->create([
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
@@ -91,8 +112,8 @@ class EmailNotificationTest extends TestCase
         $this->service->rejectEnrollment($enrollment, $reason);
 
         // Assert
-        Mail::assertQueued(EnrollmentRejected::class, function ($mail) use ($guardian, $enrollment, $reason) {
-            return $mail->hasTo($guardian->email) &&
+        Mail::assertQueued(EnrollmentRejected::class, function ($mail) use ($user, $enrollment, $reason) {
+            return $mail->hasTo($user->email) &&
                    $mail->enrollment->id === $enrollment->id &&
                    $mail->reason === $reason;
         });
@@ -101,11 +122,21 @@ class EmailNotificationTest extends TestCase
     public function test_sends_multiple_emails_when_bulk_approving_enrollments(): void
     {
         // Arrange
-        $guardians = User::factory()->count(3)->create();
+        $users = User::factory()->count(3)->create();
+        $guardians = [];
         $enrollments = [];
 
-        foreach ($guardians as $guardian) {
-            $student = Student::factory()->create(['guardian_id' => $guardian->id]);
+        foreach ($users as $user) {
+            $guardian = \App\Models\Guardian::create([
+                'user_id' => $user->id,
+                'first_name' => 'Test',
+                'last_name' => 'Guardian',
+                'contact_number' => '09123456789',
+                'address' => '123 Test St',
+            ]);
+            $guardians[] = $guardian;
+
+            $student = Student::factory()->create(['guardian_id' => $user->id]);
             $enrollments[] = Enrollment::factory()->create([
                 'student_id' => $student->id,
                 'guardian_id' => $guardian->id,
@@ -127,8 +158,8 @@ class EmailNotificationTest extends TestCase
         Mail::assertQueuedCount(3);
 
         foreach ($enrollments as $index => $enrollment) {
-            Mail::assertQueued(EnrollmentApproved::class, function ($mail) use ($guardians, $enrollment, $index) {
-                return $mail->hasTo($guardians[$index]->email) &&
+            Mail::assertQueued(EnrollmentApproved::class, function ($mail) use ($users, $enrollment, $index) {
+                return $mail->hasTo($users[$index]->email) &&
                        $mail->enrollment->id === $enrollment->id;
             });
         }
@@ -137,8 +168,15 @@ class EmailNotificationTest extends TestCase
     public function test_does_not_send_email_when_guardian_has_no_email(): void
     {
         // Arrange
-        $guardian = User::factory()->create(['email' => '']);
-        $student = Student::factory()->create(['guardian_id' => $guardian->id]);
+        $user = User::factory()->create(['email' => '']);
+        $guardian = \App\Models\Guardian::create([
+            'user_id' => $user->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
+        $student = Student::factory()->create(['guardian_id' => $user->id]);
 
         $enrollmentData = [
             'student_id' => $student->id,
@@ -158,9 +196,16 @@ class EmailNotificationTest extends TestCase
     public function test_email_contains_correct_enrollment_details(): void
     {
         // Arrange
-        $guardian = User::factory()->create(['email' => 'guardian@test.com']);
+        $user = User::factory()->create(['email' => 'guardian@test.com']);
+        $guardian = \App\Models\Guardian::create([
+            'user_id' => $user->id,
+            'first_name' => 'Test',
+            'last_name' => 'Guardian',
+            'contact_number' => '09123456789',
+            'address' => '123 Test St',
+        ]);
         $student = Student::factory()->create([
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $user->id,
             'first_name' => 'John',
             'last_name' => 'Doe',
         ]);
@@ -170,7 +215,7 @@ class EmailNotificationTest extends TestCase
             'guardian_id' => $guardian->id,
             'school_year' => '2024-2025',
             'grade_level' => 'Grade 5',
-            'section' => 'B',
+            'section' => 'A',
         ];
 
         // Act

--- a/tests/Feature/Services/EnrollmentServiceTest.php
+++ b/tests/Feature/Services/EnrollmentServiceTest.php
@@ -77,7 +77,14 @@ test('findWithRelations returns enrollment with relationships', function () {
 });
 
 test('createEnrollment creates new enrollment with pending status', function () {
-    $guardian = \App\Models\User::factory()->create();
+    $guardianUser = \App\Models\User::factory()->create();
+    $guardian = \App\Models\Guardian::create([
+        'user_id' => $guardianUser->id,
+        'first_name' => 'Test',
+        'last_name' => 'Guardian',
+        'contact_number' => '09123456789',
+        'address' => '123 Test St',
+    ]);
     $student = Student::factory()->create();
 
     $data = [
@@ -101,7 +108,14 @@ test('createEnrollment creates new enrollment with pending status', function () 
 });
 
 test('createEnrollment generates reference number', function () {
-    $guardian = \App\Models\User::factory()->create();
+    $guardianUser = \App\Models\User::factory()->create();
+    $guardian = \App\Models\Guardian::create([
+        'user_id' => $guardianUser->id,
+        'first_name' => 'Test',
+        'last_name' => 'Guardian',
+        'contact_number' => '09123456789',
+        'address' => '123 Test St',
+    ]);
     $student = Student::factory()->create();
 
     $data = [

--- a/tests/Feature/TuitionControllerTest.php
+++ b/tests/Feature/TuitionControllerTest.php
@@ -100,7 +100,7 @@ describe('tuition controller', function () {
             Enrollment::create([
                 'enrollment_id' => 'ENR-'.str_pad($child->id, 4, '0', STR_PAD_LEFT),
                 'student_id' => $child->id,
-                'guardian_id' => $guardian->id,  // Use user id
+                'guardian_id' => $guardianModel->id,
                 'school_year' => '2024-2025',
                 'quarter' => Quarter::FIRST,
                 'grade_level' => GradeLevel::GRADE_1,

--- a/tests/Feature/TuitionControllerTest.php
+++ b/tests/Feature/TuitionControllerTest.php
@@ -31,7 +31,7 @@ describe('tuition controller', function () {
             $enrollments[] = Enrollment::create([
                 'enrollment_id' => 'ENR-'.str_pad($student->id, 4, '0', STR_PAD_LEFT),
                 'student_id' => $student->id,
-                'guardian_id' => Guardian::factory()->create()->user_id,
+                'guardian_id' => Guardian::factory()->create()->id,
                 'school_year' => '2024-2025',
                 'quarter' => Quarter::FIRST,
                 'grade_level' => GradeLevel::GRADE_1,
@@ -120,7 +120,7 @@ describe('tuition controller', function () {
         Enrollment::create([
             'enrollment_id' => 'ENR-9999',
             'student_id' => $otherStudent->id,
-            'guardian_id' => Guardian::factory()->create()->user_id,
+            'guardian_id' => Guardian::factory()->create()->id,
             'school_year' => '2024-2025',
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_2,
@@ -151,7 +151,7 @@ describe('tuition controller', function () {
             Enrollment::create([
                 'enrollment_id' => 'ENR-'.str_pad($student->id, 4, '0', STR_PAD_LEFT),
                 'student_id' => $student->id,
-                'guardian_id' => Guardian::factory()->create()->user_id,
+                'guardian_id' => Guardian::factory()->create()->id,
                 'school_year' => '2024-2025',
                 'quarter' => Quarter::FIRST,
                 'grade_level' => GradeLevel::GRADE_1,


### PR DESCRIPTION
## Summary
Fixed `RelationNotFoundException` by updating guardian relationships to properly reference the Guardian model instead of User model. This establishes the correct relationship chain: Enrollment → Guardian → User.

## Changes
- Updated `Enrollment::guardian()` to `belongsTo(Guardian::class)`
- Updated `Student::guardian()` to `belongsTo(Guardian::class)`
- Updated `GuardianStudent::guardian()` to `belongsTo(Guardian::class)`
- Added `Student::documents()` relationship for document management
- Added `DocumentType` and `VerificationStatus` enums
- Added `Document` model and migration

## Problem Solved
This fix resolves the error when accessing `/super-admin/enrollments` where the system was trying to load a non-existent 'user' relationship on the User model.

Previously, the code was attempting `guardian.user` but the `guardian()` relationship was incorrectly returning a `User` directly. Now it correctly returns a `Guardian`, and the relationship chain `guardian.user` works as expected.

## Test Plan
- [x] Branch pushed successfully
- [ ] Tests need to be fixed for new relationship structure
- [ ] Manual testing of enrollment pages

## Notes
⚠️ **Test failures**: There are some failing tests related to the guardian relationship changes that need to be addressed. These tests were written for the old relationship structure and need to be updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)