### PR TITLE
fix: update UserSeeder to use Guardian model IDs for enrollments

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -295,6 +295,8 @@ class UserSeeder extends Seeder
      */
     private function createPendingEnrollmentStudents(User $guardian): void
     {
+        $guardianModel = Guardian::where('user_id', $guardian->id)->first();
+
         // Student 1 - Pending enrollment for Grade 5
         $student1 = Student::firstOrCreate(
             ['first_name' => 'Miguel', 'last_name' => 'Dela Cruz', 'birthdate' => '2013-05-20'],
@@ -321,7 +323,7 @@ class UserSeeder extends Seeder
             'student_id' => $student1->id,
             'school_year' => '2025-2026',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_5->value,
             'status' => EnrollmentStatus::PENDING,
@@ -362,7 +364,7 @@ class UserSeeder extends Seeder
             'student_id' => $student2->id,
             'school_year' => '2025-2026',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_4->value,
             'status' => EnrollmentStatus::PENDING,
@@ -383,6 +385,8 @@ class UserSeeder extends Seeder
      */
     private function createMixedStatusStudents(User $guardian): void
     {
+        $guardianModel = Guardian::where('user_id', $guardian->id)->first();
+
         // Student 1 - With rejected enrollment
         $student1 = Student::firstOrCreate(
             ['first_name' => 'Carlos', 'last_name' => 'Garcia', 'birthdate' => '2011-07-15'],
@@ -409,7 +413,7 @@ class UserSeeder extends Seeder
             'student_id' => $student1->id,
             'school_year' => '2025-2026',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::SECOND,
             'grade_level' => GradeLevel::GRADE_6->value,
             'status' => EnrollmentStatus::REJECTED,
@@ -452,7 +456,7 @@ class UserSeeder extends Seeder
             'student_id' => $student2->id,
             'school_year' => '2024-2025',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_5->value,
             'status' => EnrollmentStatus::ENROLLED,
@@ -474,6 +478,8 @@ class UserSeeder extends Seeder
      */
     private function createNewStudents(User $guardian): void
     {
+        $guardianModel = Guardian::where('user_id', $guardian->id)->first();
+
         // Student 1 - New to school
         $student1 = Student::firstOrCreate(
             ['first_name' => 'Gabriel', 'last_name' => 'Mendoza', 'birthdate' => '2016-04-12'],
@@ -500,7 +506,7 @@ class UserSeeder extends Seeder
             'student_id' => $student1->id,
             'school_year' => '2025-2026',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::KINDER->value,
             'status' => EnrollmentStatus::PENDING,
@@ -541,7 +547,7 @@ class UserSeeder extends Seeder
             'student_id' => $student2->id,
             'school_year' => '2025-2026',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_1->value,
             'status' => EnrollmentStatus::PENDING,
@@ -562,13 +568,15 @@ class UserSeeder extends Seeder
      */
     private function createEnrollmentHistory(Student $student, User $guardian): void
     {
+        $guardianModel = Guardian::where('user_id', $guardian->id)->first();
+
         // Create completed enrollments for previous years
         // Juan was in Grade 4 in 2022-2023 (completed)
         Enrollment::firstOrCreate([
             'student_id' => $student->id,
             'school_year' => '2022-2023',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_4->value,
             'status' => EnrollmentStatus::COMPLETED,
@@ -588,7 +596,7 @@ class UserSeeder extends Seeder
             'student_id' => $student->id,
             'school_year' => '2023-2024',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_5->value,
             'status' => EnrollmentStatus::COMPLETED,
@@ -608,7 +616,7 @@ class UserSeeder extends Seeder
             'student_id' => $student->id,
             'school_year' => '2024-2025',
         ], [
-            'guardian_id' => $guardian->id,
+            'guardian_id' => $guardianModel->id,
             'quarter' => Quarter::FIRST,
             'grade_level' => GradeLevel::GRADE_6->value,
             'status' => EnrollmentStatus::ENROLLED,


### PR DESCRIPTION
## Summary
Fixes UserSeeder to use Guardian model IDs instead of User IDs when creating enrollment records. This aligns with the database schema changes from PR #81 where `enrollments.guardian_id` now references the `guardians` table instead of the `users` table.

## Problem
After merging PR #81, the UserSeeder was still using `$guardian->id` (User ID) when creating enrollments, which caused foreign key constraint violations since `enrollments.guardian_id` now references `guardians.id`.

## Solution
Updated 4 methods in UserSeeder:
- `createPendingEnrollmentStudents()` - Fixed 2 enrollment records
- `createMixedStatusStudents()` - Fixed 2 enrollment records  
- `createNewStudents()` - Fixed 2 enrollment records
- `createEnrollmentHistory()` - Fixed 3 enrollment records

Each method now:
1. Fetches the Guardian model: `$guardianModel = Guardian::where('user_id', $guardian->id)->first();`
2. Uses `$guardianModel->id` in all `Enrollment::firstOrCreate()` calls
3. Correctly maintains `$guardian->id` (User ID) for `GuardianStudent` relationships

## Changes
- **Total enrollment records updated:** 9
- **GuardianStudent records:** Unchanged (correctly use User IDs)
- **Database seeding:** Will now work correctly with the new schema

## Testing
- All enrollment creations now properly reference the `guardians` table
- Database seeding should work without foreign key constraint errors
- GuardianStudent pivot table relationships remain correct

## Related
- Closes issue identified after PR #81 merge
- Completes the guardian relationship foreign key migration