### PR TITLE
feat(documents): Document Model and Migration (TICKET-001)

### DIFF
--- a/database/factories/DocumentFactory.php
+++ b/database/factories/DocumentFactory.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DocumentType;
+use App\Enums\VerificationStatus;
+use App\Models\Student;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Document>
+ */
+class DocumentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $originalFilename = fake()->word().'.'.fake()->randomElement(['pdf', 'jpg', 'png']);
+
+        return [
+            'student_id' => Student::factory(),
+            'document_type' => fake()->randomElement(DocumentType::cases()),
+            'original_filename' => $originalFilename,
+            'stored_filename' => fake()->uuid().'_'.$originalFilename,
+            'file_path' => 'documents/'.fake()->uuid().'/'.fake()->uuid().'_'.$originalFilename,
+            'file_size' => fake()->numberBetween(1024, 50 * 1024 * 1024), // 1KB to 50MB
+            'mime_type' => fake()->randomElement(['application/pdf', 'image/jpeg', 'image/png']),
+            'upload_date' => fake()->dateTimeBetween('-1 month', 'now'),
+            'verification_status' => VerificationStatus::PENDING,
+            'verified_by' => null,
+            'verified_at' => null,
+            'rejection_reason' => null,
+        ];
+    }
+
+    /**
+     * Indicate that the document is verified.
+     */
+    public function verified(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'verification_status' => VerificationStatus::VERIFIED,
+            'verified_by' => User::factory(),
+            'verified_at' => fake()->dateTimeBetween('-1 week', 'now'),
+            'rejection_reason' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the document is rejected.
+     */
+    public function rejected(string $reason = 'Document is not clear or incomplete'): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'verification_status' => VerificationStatus::REJECTED,
+            'verified_by' => User::factory(),
+            'verified_at' => fake()->dateTimeBetween('-1 week', 'now'),
+            'rejection_reason' => $reason,
+        ]);
+    }
+
+    /**
+     * Indicate that the document is pending verification.
+     */
+    public function pending(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'verification_status' => VerificationStatus::PENDING,
+            'verified_by' => null,
+            'verified_at' => null,
+            'rejection_reason' => null,
+        ]);
+    }
+
+    /**
+     * Indicate the document type is birth certificate.
+     */
+    public function birthCertificate(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'document_type' => DocumentType::BIRTH_CERTIFICATE,
+        ]);
+    }
+
+    /**
+     * Indicate the document type is report card.
+     */
+    public function reportCard(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'document_type' => DocumentType::REPORT_CARD,
+        ]);
+    }
+
+    /**
+     * Indicate the document type is Form 138.
+     */
+    public function form138(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'document_type' => DocumentType::FORM_138,
+        ]);
+    }
+
+    /**
+     * Indicate the document type is good moral certificate.
+     */
+    public function goodMoral(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'document_type' => DocumentType::GOOD_MORAL,
+        ]);
+    }
+}

--- a/tests/Feature/DocumentModelTest.php
+++ b/tests/Feature/DocumentModelTest.php
@@ -24,7 +24,7 @@ test('documents table has required columns', function () {
 });
 
 test('document model can be instantiated', function () {
-    $document = new Document();
+    $document = new Document;
 
     expect($document)->toBeInstanceOf(Document::class);
 });

--- a/tests/Feature/DocumentModelTest.php
+++ b/tests/Feature/DocumentModelTest.php
@@ -1,0 +1,209 @@
+<?php
+
+use App\Enums\DocumentType;
+use App\Enums\VerificationStatus;
+use App\Models\Document;
+use App\Models\Student;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('documents table exists', function () {
+    expect(Schema::hasTable('documents'))->toBeTrue();
+});
+
+test('documents table has required columns', function () {
+    expect(Schema::hasColumns('documents', [
+        'id', 'student_id', 'document_type', 'original_filename',
+        'stored_filename', 'file_path', 'file_size', 'mime_type',
+        'upload_date', 'verification_status', 'verified_by',
+        'verified_at', 'rejection_reason', 'created_at',
+        'updated_at', 'deleted_at',
+    ]))->toBeTrue();
+});
+
+test('document model can be instantiated', function () {
+    $document = new Document();
+
+    expect($document)->toBeInstanceOf(Document::class);
+});
+
+test('document belongs to student', function () {
+    $student = Student::factory()->create();
+    $document = Document::factory()->create(['student_id' => $student->id]);
+
+    expect($document->student)->toBeInstanceOf(Student::class)
+        ->and($document->student->id)->toBe($student->id);
+});
+
+test('document belongs to verified by user', function () {
+    $user = User::factory()->create();
+    $document = Document::factory()->create([
+        'verified_by' => $user->id,
+        'verification_status' => VerificationStatus::VERIFIED,
+    ]);
+
+    expect($document->verifiedBy)->toBeInstanceOf(User::class)
+        ->and($document->verifiedBy->id)->toBe($user->id);
+});
+
+test('document type enum casts properly', function () {
+    $document = Document::factory()->create([
+        'document_type' => DocumentType::BIRTH_CERTIFICATE,
+    ]);
+
+    expect($document->document_type)->toBeInstanceOf(DocumentType::class)
+        ->and($document->document_type)->toBe(DocumentType::BIRTH_CERTIFICATE);
+});
+
+test('verification status enum casts properly', function () {
+    $document = Document::factory()->create([
+        'verification_status' => VerificationStatus::PENDING,
+    ]);
+
+    expect($document->verification_status)->toBeInstanceOf(VerificationStatus::class)
+        ->and($document->verification_status)->toBe(VerificationStatus::PENDING);
+});
+
+test('upload date casts to datetime', function () {
+    $document = Document::factory()->create([
+        'upload_date' => now(),
+    ]);
+
+    expect($document->upload_date)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+});
+
+test('verified at casts to datetime', function () {
+    $document = Document::factory()->create([
+        'verified_at' => now(),
+    ]);
+
+    expect($document->verified_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+});
+
+test('document has soft deletes', function () {
+    $document = Document::factory()->create();
+
+    $document->delete();
+
+    expect($document->trashed())->toBeTrue()
+        ->and(Document::withTrashed()->find($document->id))->not->toBeNull();
+});
+
+test('deleting student cascades to documents', function () {
+    $student = Student::factory()->create();
+    $document = Document::factory()->create(['student_id' => $student->id]);
+
+    $student->delete();
+
+    expect(Document::find($document->id))->toBeNull();
+});
+
+test('deleting verifier sets verified by to null', function () {
+    $user = User::factory()->create();
+    $document = Document::factory()->create([
+        'verified_by' => $user->id,
+        'verification_status' => VerificationStatus::VERIFIED,
+    ]);
+
+    $user->delete();
+    $document->refresh();
+
+    expect($document->verified_by)->toBeNull();
+});
+
+test('document has required fields', function () {
+    $document = Document::factory()->create();
+
+    expect($document->student_id)->not->toBeNull()
+        ->and($document->document_type)->not->toBeNull()
+        ->and($document->original_filename)->not->toBeNull()
+        ->and($document->stored_filename)->not->toBeNull()
+        ->and($document->file_path)->not->toBeNull()
+        ->and($document->file_size)->not->toBeNull()
+        ->and($document->mime_type)->not->toBeNull()
+        ->and($document->upload_date)->not->toBeNull()
+        ->and($document->verification_status)->not->toBeNull();
+});
+
+test('verification status defaults to pending', function () {
+    $document = Document::factory()->create([
+        'verification_status' => VerificationStatus::PENDING,
+    ]);
+
+    expect($document->verification_status)->toBe(VerificationStatus::PENDING);
+});
+
+test('document can be verified', function () {
+    $user = User::factory()->create();
+    $document = Document::factory()->create([
+        'verification_status' => VerificationStatus::PENDING,
+    ]);
+
+    $document->verify($user);
+
+    expect($document->verification_status)->toBe(VerificationStatus::VERIFIED)
+        ->and($document->verified_by)->toBe($user->id)
+        ->and($document->verified_at)->not->toBeNull()
+        ->and($document->rejection_reason)->toBeNull();
+});
+
+test('document can be rejected', function () {
+    $user = User::factory()->create();
+    $document = Document::factory()->create([
+        'verification_status' => VerificationStatus::PENDING,
+    ]);
+
+    $reason = 'Document is not clear';
+    $document->reject($user, $reason);
+
+    expect($document->verification_status)->toBe(VerificationStatus::REJECTED)
+        ->and($document->verified_by)->toBe($user->id)
+        ->and($document->verified_at)->not->toBeNull()
+        ->and($document->rejection_reason)->toBe($reason);
+});
+
+test('is verified method works correctly', function () {
+    $document = Document::factory()->create([
+        'verification_status' => VerificationStatus::VERIFIED,
+    ]);
+
+    expect($document->isVerified())->toBeTrue();
+
+    $document->verification_status = VerificationStatus::PENDING;
+    expect($document->isVerified())->toBeFalse();
+});
+
+test('is pending method works correctly', function () {
+    $document = Document::factory()->create([
+        'verification_status' => VerificationStatus::PENDING,
+    ]);
+
+    expect($document->isPending())->toBeTrue();
+
+    $document->verification_status = VerificationStatus::VERIFIED;
+    expect($document->isPending())->toBeFalse();
+});
+
+test('is rejected method works correctly', function () {
+    $document = Document::factory()->create([
+        'verification_status' => VerificationStatus::REJECTED,
+    ]);
+
+    expect($document->isRejected())->toBeTrue();
+
+    $document->verification_status = VerificationStatus::PENDING;
+    expect($document->isRejected())->toBeFalse();
+});
+
+test('human file size attribute formats correctly', function () {
+    $document = Document::factory()->create(['file_size' => 1024]); // 1 KB
+    expect($document->human_file_size)->toBe('1 KB');
+
+    $document = Document::factory()->create(['file_size' => 1024 * 1024]); // 1 MB
+    expect($document->human_file_size)->toBe('1 MB');
+
+    $document = Document::factory()->create(['file_size' => 500]); // 500 B
+    expect($document->human_file_size)->toBe('500 B');
+});


### PR DESCRIPTION
## Summary
Implements TICKET-001: Create Document Model and Migration

## Changes
- ✅ Document model created with all required relationships
- ✅ Migration for documents table (already existed from 2025-10-10)
- ✅ DocumentFactory with multiple states (verified, rejected, pending)
- ✅ Comprehensive test suite with 20 tests
- ✅ Soft deletes support
- ✅ Helper methods for verification workflow
- ✅ Human-readable file size accessor

## Acceptance Criteria
- [x] Migration created: `create_documents_table.php`
- [x] Document model created with relationships
- [x] Model includes casts for `upload_date`, `verified_at`
- [x] Relationships defined: `student()`, `verifiedBy()`
- [x] Enum for `document_type` includes: birth_certificate, report_card, form_138, good_moral_certificate, other
- [x] Enum for `verification_status` includes: pending, verified, rejected
- [x] Migration can be run and rolled back successfully

## Testing
- All 20 tests passing (44 assertions)
- Coverage includes model relationships, enums, methods, and database constraints

## Related
- Epic: EPIC-001 Document Management System
- Ticket: TICKET-001
