### PR TITLE
fix: prevent permission denied errors in PHP syntax check

### DIFF
--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -8,7 +8,7 @@ echo "================================"
 
 # PHP Syntax Check
 echo "✓ Checking PHP syntax..."
-find . -name "*.php" -not -path "./vendor/*" -not -path "./storage/*" | xargs -n1 php -l > /dev/null
+find . -path "./vendor" -prune -o -path "./storage" -prune -o -name "*.php" -print 2>/dev/null | xargs -n1 php -l > /dev/null
 echo "  PHP syntax: ✅ PASSED"
 
 # Laravel Pint (Code Style)


### PR DESCRIPTION
## Summary
- Fixed permission denied errors in PHP syntax check during pre-push hooks
- Updated `find` command to properly prune vendor and storage directories
- Added error suppression for test artifact directories

## Problem
The pre-push hook was showing permission denied errors when scanning for PHP files:
```
find: './storage/framework/testing/disks/private_test_3': Permission denied
find: './storage/framework/testing/disks/private_test_10': Permission denied
find: './storage/framework/testing/disks/private_test_14': Permission denied
find: './storage/framework/testing/disks/private_test_8': Permission denied
```

## Solution
Changed the `find` command in `scripts/test-local.sh` from:
```bash
find . -name "*.php" -not -path "./vendor/*" -not -path "./storage/*" | xargs -n1 php -l > /dev/null
```

To:
```bash
find . -path "./vendor" -prune -o -path "./storage" -prune -o -name "*.php" -print 2>/dev/null | xargs -n1 php -l > /dev/null
```

The `-prune` flag properly excludes directories before descending into them, preventing permission errors.

## Test Plan
- [x] Run `git push` and verify no permission denied errors appear
- [x] All 561 tests passed with 63.68% coverage
- [x] PHP syntax check completes successfully
- [x] All pre-push checks pass cleanly

## Impact
- ✅ Cleaner pre-push hook output
- ✅ No more permission denied errors
- ✅ Faster PHP syntax checking (skips vendor and storage entirely)