### PR TITLE
fix: make admin New Enrollment button functional

### DIFF
--- a/app/Http/Controllers/Admin/EnrollmentController.php
+++ b/app/Http/Controllers/Admin/EnrollmentController.php
@@ -2,8 +2,14 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\EnrollmentStatus;
+use App\Enums\GradeLevel;
+use App\Enums\Quarter;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Guardian\StoreEnrollmentRequest;
 use App\Models\Enrollment;
+use App\Models\Guardian;
+use App\Models\Student;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 
@@ -46,6 +52,106 @@ class EnrollmentController extends Controller
             'filters' => $request->only(['search', 'status', 'grade']),
             'statusCounts' => $statusCounts,
         ]);
+    }
+
+    public function create(Request $request)
+    {
+        $currentSchoolYear = date('Y').'-'.(date('Y') + 1);
+        $selectedStudentId = $request->query('student_id');
+
+        // Get all students for admin (unlike guardian who only sees their students)
+        $studentsQuery = Student::query()->get();
+
+        $students = $studentsQuery->map(function ($student) use ($currentSchoolYear) {
+            return [
+                'id' => $student->id,
+                'first_name' => $student->first_name,
+                'middle_name' => $student->middle_name,
+                'last_name' => $student->last_name,
+                'student_id' => $student->student_id,
+                'is_new_student' => $student->isNewStudent(),
+                'current_grade_level' => $student->getCurrentGradeLevel()?->value,
+                'available_grade_levels' => array_map(
+                    fn ($grade) => $grade->value,
+                    $student->getAvailableGradeLevels($currentSchoolYear)
+                ),
+            ];
+        });
+
+        return Inertia::render('shared/enrollments/create', [
+            'students' => $students,
+            'gradeLevels' => GradeLevel::values(),
+            'quarters' => Quarter::values(),
+            'currentSchoolYear' => $currentSchoolYear,
+            'selectedStudentId' => $selectedStudentId,
+            'submitRoute' => route('admin.enrollments.store'),
+            'indexRoute' => route('admin.enrollments.index'),
+        ]);
+    }
+
+    public function store(StoreEnrollmentRequest $request)
+    {
+        $validated = $request->validated();
+
+        $student = Student::findOrFail($validated['student_id']);
+
+        // Check if student is an existing student (has previous enrollments)
+        $previousEnrollments = Enrollment::where('student_id', $validated['student_id'])
+            ->orderBy('created_at', 'desc')
+            ->first();
+
+        if ($previousEnrollments) {
+            // Business Rule 1: Existing students must enroll in First quarter
+            $validated['quarter'] = Quarter::FIRST->value;
+        }
+
+        // Get the fee for the selected grade level and school year
+        $gradeLevelFee = \App\Models\GradeLevelFee::where('grade_level', $validated['grade_level'])
+            ->where('school_year', $validated['school_year'])
+            ->first();
+
+        $tuitionFeeCents = ($gradeLevelFee ? $gradeLevelFee->tuition_fee : 0) * 100;
+        $miscFeeCents = ($gradeLevelFee ? $gradeLevelFee->miscellaneous_fee : 0) * 100;
+        $laboratoryFeeCents = 0;
+        $libraryFeeCents = 0;
+        $sportsFeeCents = 0;
+        $discountCents = 0;
+
+        // Calculate totals
+        $totalAmountCents = $tuitionFeeCents + $miscFeeCents + $laboratoryFeeCents + $libraryFeeCents + $sportsFeeCents;
+        $netAmountCents = $totalAmountCents - $discountCents;
+        $amountPaidCents = 0;
+        $balanceCents = $netAmountCents - $amountPaidCents;
+
+        // Get the guardian for this student (use the first guardian)
+        $guardian = $student->guardians()->first();
+
+        if (! $guardian) {
+            return back()->withErrors(['student_id' => 'This student does not have an associated guardian.']);
+        }
+
+        /** @var Guardian $guardian */
+        $enrollment = Enrollment::create([
+            'student_id' => $validated['student_id'],
+            'guardian_id' => $guardian->id,
+            'school_year' => $validated['school_year'],
+            'quarter' => Quarter::from($validated['quarter']),
+            'grade_level' => GradeLevel::from($validated['grade_level']),
+            'status' => EnrollmentStatus::PENDING,
+            'tuition_fee_cents' => $tuitionFeeCents,
+            'miscellaneous_fee_cents' => $miscFeeCents,
+            'laboratory_fee_cents' => $laboratoryFeeCents,
+            'library_fee_cents' => $libraryFeeCents,
+            'sports_fee_cents' => $sportsFeeCents,
+            'total_amount_cents' => $totalAmountCents,
+            'discount_cents' => $discountCents,
+            'net_amount_cents' => $netAmountCents,
+            'amount_paid_cents' => $amountPaidCents,
+            'balance_cents' => $balanceCents,
+        ]);
+
+        return redirect()->route('admin.enrollments.index')
+            ->with('success', 'Enrollment application submitted successfully.');
     }
 
     public function show($id)

--- a/resources/js/components/enrollment-list.tsx
+++ b/resources/js/components/enrollment-list.tsx
@@ -28,9 +28,11 @@ export function EnrollmentList({ enrollments, filters, statusCounts }: Props) {
                         {enrollments.total} {enrollments.total === 1 ? 'enrollment' : 'enrollments'}
                     </p>
                 </div>
-                <Button className="gap-2">
-                    <Plus className="h-4 w-4" />
-                    New Enrollment
+                <Button asChild className="gap-2">
+                    <Link href="/admin/enrollments/create">
+                        <Plus className="h-4 w-4" />
+                        New Enrollment
+                    </Link>
                 </Button>
             </div>
 

--- a/resources/js/pages/shared/enrollments/create.tsx
+++ b/resources/js/pages/shared/enrollments/create.tsx
@@ -27,17 +27,26 @@ interface Props {
     quarters: string[];
     currentSchoolYear: string;
     selectedStudentId?: string | null;
+    submitRoute?: string;
+    indexRoute?: string;
 }
 
-export default function EnrollmentCreate({ students, quarters, currentSchoolYear, selectedStudentId }: Props) {
+export default function EnrollmentCreate({
+    students,
+    quarters,
+    currentSchoolYear,
+    selectedStudentId,
+    submitRoute = '/enrollments',
+    indexRoute = '/enrollments',
+}: Props) {
     const breadcrumbs: BreadcrumbItem[] = [
         {
             title: 'Enrollments',
-            href: '/enrollments',
+            href: indexRoute,
         },
         {
             title: 'New Enrollment',
-            href: '/enrollments/create',
+            href: `${indexRoute}/create`,
         },
     ];
 
@@ -62,7 +71,7 @@ export default function EnrollmentCreate({ students, quarters, currentSchoolYear
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
-        post('/enrollments', {
+        post(submitRoute, {
             preserveScroll: false,
             onSuccess: () => {
                 // The redirect is handled by the server


### PR DESCRIPTION
## Summary
Fixed the non-functional "+ New Enrollment" button on the Admin Enrollments Index page.

## Changes Made
- ✅ Added Link navigation to EnrollmentList component button
- ✅ Implemented `create()` method in AdminEnrollmentController
- ✅ Implemented `store()` method in AdminEnrollmentController  
- ✅ Made shared enrollment create form reusable with `submitRoute` and `indexRoute` props
- ✅ Added PHPDoc type hint to satisfy PHPStan requirements

## Features
- Admin can now create enrollments for any student in the system
- Automatically associates enrollment with student's first guardian
- Validates that student has an associated guardian
- Calculates tuition fees based on grade level and school year
- Enforces business rule: existing students enroll in First quarter

## Bug Report Details
- **Severity:** Major - Prevents administrators from creating new enrollments through the UI
- **Priority:** High - Core administrative function is broken
- **Affected Component:** Admin Enrollments Index (`/admin/enrollments`)

## Files Modified
- `app/Http/Controllers/Admin/EnrollmentController.php`
- `resources/js/components/enrollment-list.tsx`
- `resources/js/pages/shared/enrollments/create.tsx`

## Test Results
✅ All 21 admin controller tests passing
✅ All 561 total tests passing (2614 assertions)
✅ Code coverage: 62.86% (exceeds 60% minimum)
✅ PHPStan: No errors
✅ Laravel Pint: Code style passed
✅ Security audit: No vulnerabilities

## Related Issues
Closes bug report: Admin Enrollments New Enrollment button non-functional