### PR TITLE
fix: resolve navigation issues in user sidebars (TICKET-025)

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -47,6 +47,7 @@ class HandleInertiaRequests extends Middleware
                     ...$request->user()->toArray(),
                     'roles' => $request->user()->roles->toArray(),
                     'dashboard_route' => route($request->user()->getDashboardRoute()),
+                    'student_id' => $request->user()->student?->id,
                 ] : null,
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,6 +80,14 @@ class User extends Authenticatable
     }
 
     /**
+     * Get the student profile associated with this user
+     */
+    public function student(): HasOne
+    {
+        return $this->hasOne(Student::class);
+    }
+
+    /**
      * Get the dashboard route based on user role
      */
     public function getDashboardRoute(): string

--- a/resources/js/components/sidebars/guardian-sidebar.tsx
+++ b/resources/js/components/sidebars/guardian-sidebar.tsx
@@ -2,7 +2,7 @@ import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
-import { ClipboardList, CreditCard, FileCheck, GraduationCap, LayoutGrid, Settings, Users } from 'lucide-react';
+import { CreditCard, FileCheck, GraduationCap, LayoutGrid, Settings, Users } from 'lucide-react';
 import AppLogo from '../app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -35,11 +35,6 @@ const mainNavItems: NavItem[] = [
         title: 'Tuition Fees',
         href: '/tuition',
         icon: CreditCard,
-    },
-    {
-        title: 'Student Reports',
-        href: '/guardian/students',
-        icon: ClipboardList,
     },
     {
         title: 'Profile Settings',

--- a/resources/js/components/sidebars/registrar-sidebar.tsx
+++ b/resources/js/components/sidebars/registrar-sidebar.tsx
@@ -2,7 +2,7 @@ import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
-import { ClipboardList, CreditCard, DollarSign, FileCheck, GraduationCap, LayoutGrid, Settings, Users } from 'lucide-react';
+import { CreditCard, DollarSign, FileCheck, FileClock, GraduationCap, LayoutGrid, Settings, Users } from 'lucide-react';
 import AppLogo from '../app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -37,9 +37,9 @@ const mainNavItems: NavItem[] = [
         icon: CreditCard,
     },
     {
-        title: 'Student Reports',
-        href: '/registrar/students',
-        icon: ClipboardList,
+        title: 'Pending Documents',
+        href: '/registrar/documents/pending',
+        icon: FileClock,
     },
     {
         title: 'Profile Settings',

--- a/resources/js/components/sidebars/student-sidebar.tsx
+++ b/resources/js/components/sidebars/student-sidebar.tsx
@@ -1,13 +1,13 @@
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
-import { type NavItem } from '@/types';
+import { type NavItem, type SharedData } from '@/types';
 import { usePage } from '@inertiajs/react';
 import { ClipboardList, CreditCard, FileCheck, LayoutGrid, Settings } from 'lucide-react';
 import AppLogo from '../app-logo';
 
 export function StudentSidebar() {
-    const { auth } = usePage().props;
+    const { auth } = usePage<SharedData>().props;
     const studentId = auth.user?.student_id;
 
     const mainNavItems: NavItem[] = [

--- a/resources/js/components/sidebars/student-sidebar.tsx
+++ b/resources/js/components/sidebars/student-sidebar.tsx
@@ -2,38 +2,46 @@ import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
+import { usePage } from '@inertiajs/react';
 import { ClipboardList, CreditCard, FileCheck, LayoutGrid, Settings } from 'lucide-react';
 import AppLogo from '../app-logo';
 
-const mainNavItems: NavItem[] = [
-    {
-        title: 'Dashboard',
-        href: '/student/dashboard',
-        icon: LayoutGrid,
-    },
-    {
-        title: 'My Invoices',
-        href: '/invoices',
-        icon: FileCheck,
-    },
-    {
-        title: 'Tuition Fees',
-        href: '/tuition',
-        icon: CreditCard,
-    },
-    {
-        title: 'My Report',
-        href: '/students/1/report',
-        icon: ClipboardList,
-    },
-    {
-        title: 'Profile Settings',
-        href: '/settings/profile',
-        icon: Settings,
-    },
-];
-
 export function StudentSidebar() {
+    const { auth } = usePage().props;
+    const studentId = auth.user?.student_id;
+
+    const mainNavItems: NavItem[] = [
+        {
+            title: 'Dashboard',
+            href: '/student/dashboard',
+            icon: LayoutGrid,
+        },
+        {
+            title: 'My Invoices',
+            href: '/invoices',
+            icon: FileCheck,
+        },
+        {
+            title: 'Tuition Fees',
+            href: '/tuition',
+            icon: CreditCard,
+        },
+        ...(studentId
+            ? [
+                  {
+                      title: 'My Report',
+                      href: `/students/${studentId}/report`,
+                      icon: ClipboardList,
+                  },
+              ]
+            : []),
+        {
+            title: 'Profile Settings',
+            href: '/settings/profile',
+            icon: Settings,
+        },
+    ];
+
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -39,6 +39,7 @@ export interface User {
     dashboard_route?: string;
     roles?: Array<{ id: number; name: string }>;
     role?: string; // Added for the single role
+    student_id?: number; // Student profile ID if user is a student
     created_at: string;
     updated_at: string;
 }


### PR DESCRIPTION
## Summary

Fixes three navigation issues across different user role sidebars:

### 1. Fixed hardcoded student ID in StudentSidebar
- Added `User->student()` relationship in User model
- Shared `student_id` via HandleInertiaRequests middleware  
- Updated TypeScript User interface with optional `student_id` property
- Made StudentSidebar dynamic using `usePage<SharedData>()` hook
- Now conditionally renders "My Report" link only when `student_id` exists
- Link correctly uses `/students/${studentId}/report` instead of hardcoded `/students/1/report`

### 2. Removed duplicate "Student Reports" link from RegistrarSidebar
- Removed duplicate nav item that was pointing to `/registrar/students` (same as "Students")
- Added "Pending Documents" link pointing to `/registrar/documents/pending`
- Used `FileClock` icon for better visual distinction

### 3. Removed duplicate "Student Reports" link from GuardianSidebar  
- Removed duplicate nav item that was pointing to `/guardian/students` (same as "My Children")
- Cleaned up navigation to prevent user confusion

All navigation links are now unique and correctly point to their respective pages.

## Test plan

- [x] Build assets successfully
- [x] All pre-push checks passed (PHP syntax, Pint, PHPStan, TypeScript, Prettier)
- [x] Tests pass with >60% coverage
- [ ] Manually verify StudentSidebar "My Report" link works with dynamic student ID
- [ ] Manually verify RegistrarSidebar shows "Pending Documents" link
- [ ] Manually verify GuardianSidebar no longer has duplicate "Student Reports" link
- [ ] Manually verify RegistrarSidebar no longer has duplicate "Student Reports" link

## Related

- Fixes TICKET-025
- Part of frontend completion work (5 tickets total)