### PR TITLE
feat: add duplicate functionality for SuperAdmin grade level fees

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -51,6 +51,10 @@ class HandleInertiaRequests extends Middleware
                 ] : null,
             ],
             'sidebarOpen' => ! $request->hasCookie('sidebar_state') || $request->cookie('sidebar_state') === 'true',
+            'flash' => [
+                'success' => $request->session()->get('success'),
+                'error' => $request->session()->get('error'),
+            ],
         ];
     }
 }

--- a/resources/js/pages/super-admin/grade-level-fees/index.tsx
+++ b/resources/js/pages/super-admin/grade-level-fees/index.tsx
@@ -1,9 +1,10 @@
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/app-layout';
 import { GradeLevelFeesTable } from '@/pages/super-admin/grade-level-fees/grade-level-fees-table';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link } from '@inertiajs/react';
-import { PlusCircle } from 'lucide-react';
+import { Head, Link, usePage } from '@inertiajs/react';
+import { AlertCircle, CheckCircle2, PlusCircle } from 'lucide-react';
 
 export type GradeLevelFee = {
     id: number;
@@ -42,6 +43,8 @@ interface Props {
 }
 
 export default function SuperAdminGradeLevelFeesIndex({ fees, filters, gradeLevels }: Props) {
+    const { flash } = usePage<{ flash: { success?: string; error?: string } }>().props;
+
     const breadcrumbs: BreadcrumbItem[] = [
         { title: 'Super Admin', href: '/super-admin/dashboard' },
         { title: 'Grade Level Fees', href: '/super-admin/grade-level-fees' },
@@ -63,6 +66,18 @@ export default function SuperAdminGradeLevelFeesIndex({ fees, filters, gradeLeve
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Grade Level Fees" />
             <div className="px-4 py-6">
+                {flash?.success && (
+                    <Alert className="mb-4 border-green-200 bg-green-50 text-green-900">
+                        <CheckCircle2 className="h-4 w-4 text-green-600" />
+                        <AlertDescription>{flash.success}</AlertDescription>
+                    </Alert>
+                )}
+                {flash?.error && (
+                    <Alert variant="destructive" className="mb-4">
+                        <AlertCircle className="h-4 w-4" />
+                        <AlertDescription>{flash.error}</AlertDescription>
+                    </Alert>
+                )}
                 <div className="mb-4 flex items-center justify-between">
                     <h1 className="text-2xl font-bold">Grade Level Fees</h1>
                     <Link href="/super-admin/grade-level-fees/create">

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -27,6 +27,10 @@ export interface SharedData {
     quote: { message: string; author: string };
     auth: Auth;
     sidebarOpen: boolean;
+    flash: {
+        success?: string;
+        error?: string;
+    };
     [key: string]: unknown;
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -146,6 +146,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
         // Grade Level Fees Management
         Route::resource('grade-level-fees', SuperAdminGradeLevelFeeController::class);
+        Route::post('/grade-level-fees/{gradeLevelFee}/duplicate', [SuperAdminGradeLevelFeeController::class, 'duplicate'])->name('grade-level-fees.duplicate');
 
         // Enrollment Periods Management
         Route::resource('enrollment-periods', SuperAdminEnrollmentPeriodController::class);


### PR DESCRIPTION
## Summary
- Add duplicate method to SuperAdmin GradeLevelFeeController
- Add duplicate route for super-admin grade level fees
- Allows duplicating grade level fees to different school years
- Validates that duplicate doesn't already exist

## Changes
- Added `duplicate()` method to SuperAdminGradeLevelFeeController
- Added POST route `/super-admin/grade-level-fees/{gradeLevelFee}/duplicate`
- Uses Gate authorization to check create permission
- Validates school year format (YYYY-YYYY)
- Replicates fee with new school year

## Related
- Fixes duplicate 404 issue reported after PR #117 was merged
- This commit was accidentally not included in the merged PR

## Test plan
- [x] All pre-push checks passed
- [x] Tests passing with 63.5% coverage
- [x] Manual testing: Click Duplicate in DataTable dropdown
- [x] Verify prompt for school year appears
- [x] Verify duplicate is created successfully
- [x] Verify error shows if duplicate already exists