### PR TITLE
feat: Super Admin Invoices CRUD pages (TICKET-028)

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -18,6 +18,7 @@ class Invoice extends Model
     protected $fillable = [
         'invoice_number',
         'enrollment_id',
+        'invoice_date',
         'total_amount',
         'paid_amount',
         'status',
@@ -30,6 +31,7 @@ class Invoice extends Model
         'status' => InvoiceStatus::class,
         'total_amount' => 'decimal:2',
         'paid_amount' => 'decimal:2',
+        'invoice_date' => 'date',
         'due_date' => 'date',
         'paid_at' => 'datetime',
     ];

--- a/app/Services/BillingService.php
+++ b/app/Services/BillingService.php
@@ -84,6 +84,7 @@ class BillingService extends BaseService implements BillingServiceInterface
             $invoice = $this->model->create([
                 'invoice_number' => $this->generateInvoiceNumber(),
                 'enrollment_id' => $enrollment->id,
+                'invoice_date' => now(),
                 'total_amount' => $totalAmount,
                 'paid_amount' => 0,
                 'status' => InvoiceStatus::DRAFT,

--- a/database/factories/InvoiceFactory.php
+++ b/database/factories/InvoiceFactory.php
@@ -26,6 +26,7 @@ class InvoiceFactory extends Factory
         return [
             'invoice_number' => 'INV-'.fake()->unique()->numberBetween(100000, 999999),
             'enrollment_id' => Enrollment::factory(),
+            'invoice_date' => fake()->dateTimeBetween('-30 days', 'now'),
             'total_amount' => $totalAmount,
             'paid_amount' => $paidAmount,
             'status' => $status,

--- a/database/migrations/2025_10_17_160518_add_invoice_date_to_invoices_table.php
+++ b/database/migrations/2025_10_17_160518_add_invoice_date_to_invoices_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->date('invoice_date')->nullable()->after('enrollment_id');
+        });
+
+        // Backfill existing invoices with created_at as invoice_date
+        DB::table('invoices')->whereNull('invoice_date')->update([
+            'invoice_date' => DB::raw('DATE(created_at)'),
+        ]);
+
+        // Make invoice_date not nullable after backfilling
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->date('invoice_date')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropColumn('invoice_date');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -20,5 +20,11 @@ class DatabaseSeeder extends Seeder
 
         // Seed settings
         $this->call(SettingsSeeder::class);
+
+        // Seed enrollments (includes students and guardians if needed)
+        $this->call(EnrollmentSeeder::class);
+
+        // Seed invoices for enrollments
+        $this->call(InvoiceSeeder::class);
     }
 }

--- a/database/seeders/EnrollmentSeeder.php
+++ b/database/seeders/EnrollmentSeeder.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\EnrollmentStatus;
+use App\Enums\GradeLevel;
+use App\Enums\PaymentStatus;
+use App\Models\Enrollment;
+use App\Models\EnrollmentPeriod;
+use App\Models\GradeLevelFee;
+use App\Models\Guardian;
+use App\Models\Student;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class EnrollmentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * Idempotent: Checks if enrollments already exist before creating
+     */
+    public function run(): void
+    {
+        // Check if enrollments already exist
+        if (Enrollment::count() > 0) {
+            $this->command->info('Enrollments already exist. Skipping enrollment seeder.');
+
+            return;
+        }
+
+        $this->command->info('Seeding enrollments...');
+
+        // Get or create enrollment period
+        $enrollmentPeriod = EnrollmentPeriod::firstOrCreate(
+            ['school_year' => '2024-2025'],
+            [
+                'start_date' => '2024-06-01',
+                'end_date' => '2025-03-31',
+                'early_registration_deadline' => '2024-07-15',
+                'regular_registration_deadline' => '2024-08-15',
+                'late_registration_deadline' => '2024-09-15',
+                'status' => 'active',
+                'allow_new_students' => true,
+                'allow_returning_students' => true,
+            ]
+        );
+
+        // Get super admin for approvals
+        $superAdmin = User::role('super_admin')->first();
+
+        if (! $superAdmin) {
+            $this->command->error('No super admin found. Please run UserSeeder first.');
+
+            return;
+        }
+
+        // Get students and guardians
+        $students = Student::with('guardians')->get();
+
+        if ($students->isEmpty()) {
+            $this->command->warn('No students found. Creating sample students...');
+            $students = Student::factory()->count(10)->create();
+        }
+
+        $guardians = Guardian::all();
+
+        if ($guardians->isEmpty()) {
+            $this->command->warn('No guardians found. Creating sample guardians...');
+            $guardians = Guardian::factory()->count(5)->create();
+        }
+
+        $enrollmentCount = 0;
+
+        foreach ($students as $student) {
+            // Get or assign guardian
+            $guardian = $student->guardians()->first() ?? $guardians->random();
+
+            // Ensure student has a guardian relationship if not
+            if (! $student->guardians()->where('guardian_id', $guardian->id)->exists()) {
+                $student->guardians()->attach($guardian->id, [
+                    'relationship_type' => 'parent',
+                    'is_primary_contact' => true,
+                ]);
+            }
+
+            // Get or create grade level fee
+            $gradeLevel = $student->grade_level ?? GradeLevel::GRADE_1;
+            $gradeLevelFee = GradeLevelFee::where('grade_level', $gradeLevel)->first();
+
+            if (! $gradeLevelFee) {
+                $gradeLevelFee = GradeLevelFee::factory()->create([
+                    'grade_level' => $gradeLevel,
+                ]);
+            }
+
+            // Calculate fees (in cents)
+            $tuitionFeeCents = $gradeLevelFee->tuition_fee_cents;
+            $miscellaneousFeeCents = $gradeLevelFee->miscellaneous_fee_cents;
+            $laboratoryFeeCents = $gradeLevelFee->laboratory_fee_cents ?? 0;
+            $libraryFeeCents = $gradeLevelFee->library_fee_cents ?? 0;
+            $sportsFeeCents = $gradeLevelFee->sports_fee_cents ?? 0;
+
+            $totalAmountCents = $tuitionFeeCents + $miscellaneousFeeCents + $laboratoryFeeCents + $libraryFeeCents + $sportsFeeCents;
+            $discountCents = 0; // No discount for seeded data
+            $netAmountCents = $totalAmountCents - $discountCents;
+
+            // Randomly decide payment status
+            $paymentStatuses = [PaymentStatus::PENDING, PaymentStatus::PARTIAL, PaymentStatus::PAID];
+            $paymentStatus = fake()->randomElement($paymentStatuses);
+
+            $amountPaidCents = match ($paymentStatus) {
+                PaymentStatus::PAID => $netAmountCents,
+                PaymentStatus::PARTIAL => (int) ($netAmountCents * fake()->randomFloat(2, 0.3, 0.7)),
+                default => 0,
+            };
+
+            $balanceCents = $netAmountCents - $amountPaidCents;
+
+            // Create enrollment
+            $enrollment = Enrollment::create([
+                'enrollment_id' => 'ENR-'.now()->format('Ym').'-'.str_pad($enrollmentCount + 1, 4, '0', STR_PAD_LEFT),
+                'student_id' => $student->id,
+                'guardian_id' => $guardian->id,
+                'school_year' => '2024-2025',
+                'enrollment_period_id' => $enrollmentPeriod->id,
+                'quarter' => 'first',
+                'grade_level' => $gradeLevel,
+                'status' => EnrollmentStatus::APPROVED,
+                'tuition_fee_cents' => $tuitionFeeCents,
+                'miscellaneous_fee_cents' => $miscellaneousFeeCents,
+                'laboratory_fee_cents' => $laboratoryFeeCents,
+                'library_fee_cents' => $libraryFeeCents,
+                'sports_fee_cents' => $sportsFeeCents,
+                'total_amount_cents' => $totalAmountCents,
+                'discount_cents' => $discountCents,
+                'net_amount_cents' => $netAmountCents,
+                'payment_status' => $paymentStatus,
+                'amount_paid_cents' => $amountPaidCents,
+                'balance_cents' => $balanceCents,
+                'payment_due_date' => now()->addDays(30),
+                'approved_at' => now()->subDays(rand(1, 30)),
+                'approved_by' => $superAdmin->id,
+            ]);
+
+            $enrollmentCount++;
+        }
+
+        $this->command->info("Created {$enrollmentCount} enrollments successfully.");
+    }
+}

--- a/database/seeders/EnrollmentSeeder.php
+++ b/database/seeders/EnrollmentSeeder.php
@@ -119,7 +119,7 @@ class EnrollmentSeeder extends Seeder
 
             // Create enrollment
             $enrollment = Enrollment::create([
-                'enrollment_id' => 'ENR-'.now()->format('Ym').'-'.str_pad($enrollmentCount + 1, 4, '0', STR_PAD_LEFT),
+                'enrollment_id' => 'ENR-'.now()->format('Ym').'-'.str_pad((string) ($enrollmentCount + 1), 4, '0', STR_PAD_LEFT),
                 'student_id' => $student->id,
                 'guardian_id' => $guardian->id,
                 'school_year' => '2024-2025',

--- a/database/seeders/InvoiceSeeder.php
+++ b/database/seeders/InvoiceSeeder.php
@@ -26,14 +26,14 @@ class InvoiceSeeder extends Seeder
 
         $this->command->info('Seeding invoices...');
 
-        // Get approved enrollments without invoices
+        // Get enrollments without invoices (approved, enrolled, or completed status)
         $enrollments = Enrollment::with(['student', 'guardian'])
             ->whereNull('invoice_id')
-            ->where('status', 'approved')
+            ->whereIn('status', ['approved', 'enrolled', 'completed'])
             ->get();
 
         if ($enrollments->isEmpty()) {
-            $this->command->warn('No approved enrollments found without invoices. Please run EnrollmentSeeder first.');
+            $this->command->warn('No enrollments found without invoices (approved/enrolled/completed status). Please run EnrollmentSeeder first.');
 
             return;
         }

--- a/database/seeders/InvoiceSeeder.php
+++ b/database/seeders/InvoiceSeeder.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\InvoiceStatus;
+use App\Models\Enrollment;
+use App\Models\Invoice;
+use App\Services\InvoiceService;
+use Illuminate\Database\Seeder;
+
+class InvoiceSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * Idempotent: Checks if invoices already exist before creating
+     */
+    public function run(): void
+    {
+        // Check if invoices already exist
+        if (Invoice::count() > 0) {
+            $this->command->info('Invoices already exist. Skipping invoice seeder.');
+
+            return;
+        }
+
+        $this->command->info('Seeding invoices...');
+
+        // Get approved enrollments without invoices
+        $enrollments = Enrollment::with(['student', 'guardian'])
+            ->whereNull('invoice_id')
+            ->where('status', 'approved')
+            ->get();
+
+        if ($enrollments->isEmpty()) {
+            $this->command->warn('No approved enrollments found without invoices. Please run EnrollmentSeeder first.');
+
+            return;
+        }
+
+        $invoiceService = app(InvoiceService::class);
+        $invoiceCount = 0;
+        $itemCount = 0;
+
+        foreach ($enrollments as $enrollment) {
+            // Create invoice data
+            $invoiceData = [
+                'enrollment_id' => $enrollment->id,
+                'invoice_date' => now()->subDays(rand(0, 30))->format('Y-m-d'),
+                'due_date' => now()->addDays(rand(15, 60))->format('Y-m-d'),
+                'items' => [],
+            ];
+
+            // Add tuition fee item
+            if ($enrollment->tuition_fee_cents > 0) {
+                $invoiceData['items'][] = [
+                    'description' => 'Tuition Fee - '.$enrollment->grade_level->label(),
+                    'quantity' => 1,
+                    'unit_price' => $enrollment->tuition_fee,
+                    'amount' => $enrollment->tuition_fee,
+                ];
+                $itemCount++;
+            }
+
+            // Add miscellaneous fee item
+            if ($enrollment->miscellaneous_fee_cents > 0) {
+                $invoiceData['items'][] = [
+                    'description' => 'Miscellaneous Fee',
+                    'quantity' => 1,
+                    'unit_price' => $enrollment->miscellaneous_fee,
+                    'amount' => $enrollment->miscellaneous_fee,
+                ];
+                $itemCount++;
+            }
+
+            // Add laboratory fee item if applicable
+            if ($enrollment->laboratory_fee_cents > 0) {
+                $invoiceData['items'][] = [
+                    'description' => 'Laboratory Fee',
+                    'quantity' => 1,
+                    'unit_price' => $enrollment->laboratory_fee,
+                    'amount' => $enrollment->laboratory_fee,
+                ];
+                $itemCount++;
+            }
+
+            // Add library fee item if applicable
+            if ($enrollment->library_fee_cents > 0) {
+                $invoiceData['items'][] = [
+                    'description' => 'Library Fee',
+                    'quantity' => 1,
+                    'unit_price' => $enrollment->library_fee,
+                    'amount' => $enrollment->library_fee,
+                ];
+                $itemCount++;
+            }
+
+            // Add sports fee item if applicable
+            if ($enrollment->sports_fee_cents > 0) {
+                $invoiceData['items'][] = [
+                    'description' => 'Sports Fee',
+                    'quantity' => 1,
+                    'unit_price' => $enrollment->sports_fee,
+                    'amount' => $enrollment->sports_fee,
+                ];
+                $itemCount++;
+            }
+
+            // Create invoice using the service
+            $invoice = $invoiceService->createInvoice($invoiceData);
+
+            // Update enrollment with invoice_id
+            $enrollment->update(['invoice_id' => $invoice->id]);
+
+            // Randomly set invoice status based on enrollment payment status
+            $status = match ($enrollment->payment_status->value) {
+                'paid' => InvoiceStatus::PAID,
+                'partial' => InvoiceStatus::PARTIALLY_PAID,
+                default => fake()->randomElement([InvoiceStatus::SENT, InvoiceStatus::DRAFT]),
+            };
+
+            // Update invoice status and paid amount
+            $invoice->update([
+                'status' => $status,
+                'paid_amount' => $enrollment->amount_paid,
+            ]);
+
+            // If invoice is paid, set paid_at
+            if ($status === InvoiceStatus::PAID) {
+                $invoice->update(['paid_at' => now()->subDays(rand(1, 20))]);
+            }
+
+            $invoiceCount++;
+        }
+
+        $this->command->info("Created {$invoiceCount} invoices with {$itemCount} total items successfully.");
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "laravel-vite-plugin": "^2.0",
                 "lucide-react": "^0.475.0",
                 "react": "^19.0.0",
-                "react-day-picker": "^9.11.0",
+                "react-day-picker": "^9.11.1",
                 "react-dom": "^19.0.0",
                 "tailwind-merge": "^3.0.1",
                 "tailwindcss": "^4.1.13",
@@ -7100,9 +7100,9 @@
             }
         },
         "node_modules/react-day-picker": {
-            "version": "9.11.0",
-            "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.11.0.tgz",
-            "integrity": "sha512-L4FYOaPrr3+AEROeP6IG2mCORZZfxJDkJI2df8mv1jyPrNYeccgmFPZDaHyAuPCBCddQFozkxbikj2NhMEYfDQ==",
+            "version": "9.11.1",
+            "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.11.1.tgz",
+            "integrity": "sha512-l3ub6o8NlchqIjPKrRFUCkTUEq6KwemQlfv3XZzzwpUeGwmDJ+0u0Upmt38hJyd7D/vn2dQoOoLV/qAp0o3uUw==",
             "license": "MIT",
             "dependencies": {
                 "@date-fns/tz": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "laravel-vite-plugin": "^2.0",
         "lucide-react": "^0.475.0",
         "react": "^19.0.0",
-        "react-day-picker": "^9.11.0",
+        "react-day-picker": "^9.11.1",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss": "^4.1.13",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -139,4 +139,17 @@
     body {
         @apply bg-background text-foreground;
     }
+
+    /* Override react-day-picker default blue colors with theme colors */
+    .rdp-day_button:focus-visible {
+        @apply ring-ring ring-offset-background;
+    }
+
+    .rdp-day_button[data-selected='true'] {
+        @apply bg-primary text-primary-foreground;
+    }
+
+    .rdp-day_button[data-today='true']:not([data-selected='true']) {
+        @apply bg-accent text-accent-foreground;
+    }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@import 'react-day-picker/style.css';
 
 @plugin 'tailwindcss-animate';
 

--- a/resources/js/components/sidebars/super-admin-sidebar.tsx
+++ b/resources/js/components/sidebars/super-admin-sidebar.tsx
@@ -38,7 +38,7 @@ const mainNavItems: NavItem[] = [
     },
     {
         title: 'Invoices',
-        href: '/invoices',
+        href: '/super-admin/invoices',
         icon: FileCheck,
     },
     {

--- a/resources/js/components/ui/button.tsx
+++ b/resources/js/components/ui/button.tsx
@@ -25,6 +25,8 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {

--- a/resources/js/components/ui/data-table.tsx
+++ b/resources/js/components/ui/data-table.tsx
@@ -1,0 +1,83 @@
+import {
+    type ColumnDef,
+    type ColumnFiltersState,
+    type SortingState,
+    type VisibilityState,
+    flexRender,
+    getCoreRowModel,
+    getFilteredRowModel,
+    getPaginationRowModel,
+    getSortedRowModel,
+    useReactTable,
+} from '@tanstack/react-table';
+import { useState } from 'react';
+
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+interface DataTableProps<TData, TValue> {
+    columns: ColumnDef<TData, TValue>[];
+    data: TData[];
+}
+
+export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData, TValue>) {
+    const [sorting, setSorting] = useState<SortingState>([]);
+    const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+    const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
+    const [rowSelection, setRowSelection] = useState({});
+
+    const table = useReactTable({
+        data,
+        columns,
+        onSortingChange: setSorting,
+        onColumnFiltersChange: setColumnFilters,
+        getCoreRowModel: getCoreRowModel(),
+        getPaginationRowModel: getPaginationRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        onColumnVisibilityChange: setColumnVisibility,
+        onRowSelectionChange: setRowSelection,
+        state: {
+            sorting,
+            columnFilters,
+            columnVisibility,
+            rowSelection,
+        },
+    });
+
+    return (
+        <div className="rounded-md border">
+            <Table>
+                <TableHeader>
+                    {table.getHeaderGroups().map((headerGroup) => (
+                        <TableRow key={headerGroup.id}>
+                            {headerGroup.headers.map((header) => {
+                                return (
+                                    <TableHead key={header.id}>
+                                        {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                                    </TableHead>
+                                );
+                            })}
+                        </TableRow>
+                    ))}
+                </TableHeader>
+                <TableBody>
+                    {table.getRowModel().rows?.length ? (
+                        table.getRowModel().rows.map((row) => (
+                            <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                                {row.getVisibleCells().map((cell) => (
+                                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                                ))}
+                            </TableRow>
+                        ))
+                    ) : (
+                        <TableRow>
+                            <TableCell colSpan={columns.length} className="h-24 text-center">
+                                No results.
+                            </TableCell>
+                        </TableRow>
+                    )}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}

--- a/resources/js/pages/super-admin/invoices/columns.tsx
+++ b/resources/js/pages/super-admin/invoices/columns.tsx
@@ -1,0 +1,196 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Link, router } from '@inertiajs/react';
+import { type ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown, Edit, Eye, Trash } from 'lucide-react';
+
+export interface Student {
+    id: number;
+    student_id: string;
+    first_name: string;
+    last_name: string;
+}
+
+export interface Enrollment {
+    id: number;
+    student: Student;
+}
+
+export interface Invoice {
+    id: number;
+    invoice_number: string;
+    enrollment: Enrollment;
+    total_amount: number;
+    paid_amount: number;
+    status: string;
+    due_date: string;
+    created_at: string;
+}
+
+const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('en-PH', {
+        style: 'currency',
+        currency: 'PHP',
+    }).format(amount);
+};
+
+const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+    });
+};
+
+const getStatusBadge = (status: string) => {
+    const variants: Record<string, { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }> = {
+        draft: { variant: 'outline', label: 'Draft' },
+        sent: { variant: 'default', label: 'Sent' },
+        partially_paid: { variant: 'secondary', label: 'Partially Paid' },
+        paid: { variant: 'default', label: 'Paid' },
+        cancelled: { variant: 'destructive', label: 'Cancelled' },
+        overdue: { variant: 'destructive', label: 'Overdue' },
+    };
+
+    const config = variants[status] || { variant: 'outline' as const, label: status };
+
+    return (
+        <Badge variant={config.variant} className={status === 'paid' ? 'bg-green-100 text-green-800' : ''}>
+            {config.label}
+        </Badge>
+    );
+};
+
+const handleDelete = (id: number, invoiceNumber: string) => {
+    if (confirm(`Are you sure you want to delete invoice ${invoiceNumber}? This action cannot be undone.`)) {
+        router.delete(`/super-admin/invoices/${id}`);
+    }
+};
+
+export const columns: ColumnDef<Invoice>[] = [
+    {
+        accessorKey: 'invoice_number',
+        header: ({ column }) => {
+            return (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Invoice #
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            );
+        },
+        cell: ({ row }) => <div className="font-medium">{row.getValue('invoice_number')}</div>,
+    },
+    {
+        id: 'student',
+        accessorFn: (row) => `${row.enrollment.student.first_name} ${row.enrollment.student.last_name}`,
+        header: ({ column }) => {
+            return (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Student
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            );
+        },
+        cell: ({ row }) => {
+            const invoice = row.original;
+            return (
+                <div>
+                    <div>
+                        {invoice.enrollment.student.first_name} {invoice.enrollment.student.last_name}
+                    </div>
+                    <div className="text-sm text-muted-foreground">ID: {invoice.enrollment.student.student_id}</div>
+                </div>
+            );
+        },
+    },
+    {
+        accessorKey: 'total_amount',
+        header: ({ column }) => {
+            return (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Total Amount
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            );
+        },
+        cell: ({ row }) => <div>{formatCurrency(row.getValue('total_amount'))}</div>,
+    },
+    {
+        accessorKey: 'paid_amount',
+        header: ({ column }) => {
+            return (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Paid Amount
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            );
+        },
+        cell: ({ row }) => <div className="text-green-600">{formatCurrency(row.getValue('paid_amount'))}</div>,
+    },
+    {
+        id: 'balance',
+        accessorFn: (row) => row.total_amount - row.paid_amount,
+        header: ({ column }) => {
+            return (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Balance
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            );
+        },
+        cell: ({ row }) => {
+            const invoice = row.original;
+            const balance = invoice.total_amount - invoice.paid_amount;
+            return <div className="text-red-600">{formatCurrency(balance)}</div>;
+        },
+    },
+    {
+        accessorKey: 'status',
+        header: ({ column }) => {
+            return (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Status
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            );
+        },
+        cell: ({ row }) => getStatusBadge(row.getValue('status')),
+    },
+    {
+        accessorKey: 'due_date',
+        header: ({ column }) => {
+            return (
+                <Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}>
+                    Due Date
+                    <ArrowUpDown className="ml-2 h-4 w-4" />
+                </Button>
+            );
+        },
+        cell: ({ row }) => <div>{formatDate(row.getValue('due_date'))}</div>,
+    },
+    {
+        id: 'actions',
+        header: () => <div className="text-right">Actions</div>,
+        cell: ({ row }) => {
+            const invoice = row.original;
+
+            return (
+                <div className="flex justify-end gap-2">
+                    <Link href={`/super-admin/invoices/${invoice.id}`}>
+                        <Button size="sm" variant="outline">
+                            <Eye className="h-4 w-4" />
+                        </Button>
+                    </Link>
+                    <Link href={`/super-admin/invoices/${invoice.id}/edit`}>
+                        <Button size="sm" variant="outline">
+                            <Edit className="h-4 w-4" />
+                        </Button>
+                    </Link>
+                    <Button size="sm" variant="destructive" onClick={() => handleDelete(invoice.id, invoice.invoice_number)}>
+                        <Trash className="h-4 w-4" />
+                    </Button>
+                </div>
+            );
+        },
+    },
+];

--- a/resources/js/pages/super-admin/invoices/create.tsx
+++ b/resources/js/pages/super-admin/invoices/create.tsx
@@ -1,0 +1,338 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link, useForm } from '@inertiajs/react';
+import { ArrowLeft, Plus, Save, Trash } from 'lucide-react';
+import { useEffect } from 'react';
+
+interface Student {
+    id: number;
+    student_id: string;
+    first_name: string;
+    last_name: string;
+}
+
+interface User {
+    id: number;
+    name: string;
+}
+
+interface Guardian {
+    id: number;
+    first_name: string;
+    last_name: string;
+    user: User;
+}
+
+interface Enrollment {
+    id: number;
+    enrollment_id: string;
+    student: Student;
+    guardian: Guardian;
+}
+
+interface InvoiceItem {
+    description: string;
+    quantity: number;
+    unit_price: number;
+    amount: number;
+}
+
+interface FormData {
+    enrollment_id: string;
+    invoice_date: string;
+    due_date: string;
+    items: InvoiceItem[];
+}
+
+interface Props {
+    enrollments: Enrollment[];
+}
+
+export default function SuperAdminInvoicesCreate({ enrollments }: Props) {
+    const { data, setData, post, processing, errors } = useForm<FormData>({
+        enrollment_id: '',
+        invoice_date: new Date().toISOString().split('T')[0],
+        due_date: '',
+        items: [
+            {
+                description: '',
+                quantity: 1,
+                unit_price: 0,
+                amount: 0,
+            },
+        ],
+    });
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Super Admin', href: '/super-admin/dashboard' },
+        { title: 'Invoices', href: '/super-admin/invoices' },
+        { title: 'Create', href: '#' },
+    ];
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        post('/super-admin/invoices');
+    };
+
+    const addItem = () => {
+        setData('items', [
+            ...data.items,
+            {
+                description: '',
+                quantity: 1,
+                unit_price: 0,
+                amount: 0,
+            },
+        ]);
+    };
+
+    const removeItem = (index: number) => {
+        if (data.items.length === 1) {
+            alert('At least one item is required.');
+            return;
+        }
+        const newItems = data.items.filter((_, i) => i !== index);
+        setData('items', newItems);
+    };
+
+    const updateItem = (index: number, field: keyof InvoiceItem, value: string | number) => {
+        const newItems = [...data.items];
+        newItems[index] = {
+            ...newItems[index],
+            [field]: value,
+        };
+
+        // Recalculate amount if quantity or unit_price changed
+        if (field === 'quantity' || field === 'unit_price') {
+            const quantity = field === 'quantity' ? Number(value) : newItems[index].quantity;
+            const unitPrice = field === 'unit_price' ? Number(value) : newItems[index].unit_price;
+            newItems[index].amount = quantity * unitPrice;
+        }
+
+        setData('items', newItems);
+    };
+
+    const calculateTotal = () => {
+        return data.items.reduce((sum, item) => sum + item.amount, 0);
+    };
+
+    const formatCurrency = (amount: number) => {
+        return new Intl.NumberFormat('en-PH', {
+            style: 'currency',
+            currency: 'PHP',
+        }).format(amount);
+    };
+
+    const getEnrollmentDisplay = (enrollment: Enrollment) => {
+        return `${enrollment.student.first_name} ${enrollment.student.last_name} (${enrollment.student.student_id}) - ${enrollment.enrollment_id}`;
+    };
+
+    // Set due date 30 days after invoice date by default
+    useEffect(() => {
+        if (data.invoice_date && !data.due_date) {
+            const invoiceDate = new Date(data.invoice_date);
+            const dueDate = new Date(invoiceDate);
+            dueDate.setDate(dueDate.getDate() + 30);
+            setData('due_date', dueDate.toISOString().split('T')[0]);
+        }
+    }, [data.invoice_date]);
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Create Invoice" />
+            <div className="container mx-auto max-w-4xl px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <h1 className="text-2xl font-bold">Create Invoice</h1>
+                    <Link href="/super-admin/invoices">
+                        <Button variant="outline">
+                            <ArrowLeft className="mr-2 h-4 w-4" />
+                            Back to List
+                        </Button>
+                    </Link>
+                </div>
+
+                <form onSubmit={handleSubmit}>
+                    <div className="space-y-6">
+                        {/* Invoice Information */}
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Invoice Information</CardTitle>
+                                <CardDescription>Basic invoice details and enrollment selection.</CardDescription>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="enrollment_id">
+                                        Enrollment <span className="text-red-600">*</span>
+                                    </Label>
+                                    <Select value={data.enrollment_id} onValueChange={(value) => setData('enrollment_id', value)}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Select enrollment" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {enrollments.map((enrollment) => (
+                                                <SelectItem key={enrollment.id} value={enrollment.id.toString()}>
+                                                    {getEnrollmentDisplay(enrollment)}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    {errors.enrollment_id && <p className="text-sm text-red-600">{errors.enrollment_id}</p>}
+                                </div>
+
+                                <div className="grid gap-4 md:grid-cols-2">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="invoice_date">
+                                            Invoice Date <span className="text-red-600">*</span>
+                                        </Label>
+                                        <Input
+                                            id="invoice_date"
+                                            type="date"
+                                            value={data.invoice_date}
+                                            onChange={(e) => setData('invoice_date', e.target.value)}
+                                        />
+                                        {errors.invoice_date && <p className="text-sm text-red-600">{errors.invoice_date}</p>}
+                                    </div>
+
+                                    <div className="space-y-2">
+                                        <Label htmlFor="due_date">
+                                            Due Date <span className="text-red-600">*</span>
+                                        </Label>
+                                        <Input
+                                            id="due_date"
+                                            type="date"
+                                            value={data.due_date}
+                                            onChange={(e) => setData('due_date', e.target.value)}
+                                        />
+                                        {errors.due_date && <p className="text-sm text-red-600">{errors.due_date}</p>}
+                                    </div>
+                                </div>
+                            </CardContent>
+                        </Card>
+
+                        {/* Invoice Items */}
+                        <Card>
+                            <CardHeader>
+                                <div className="flex items-center justify-between">
+                                    <div>
+                                        <CardTitle>Invoice Items</CardTitle>
+                                        <CardDescription>Add items to this invoice. At least one item is required.</CardDescription>
+                                    </div>
+                                    <Button type="button" variant="outline" size="sm" onClick={addItem}>
+                                        <Plus className="mr-2 h-4 w-4" />
+                                        Add Item
+                                    </Button>
+                                </div>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                {data.items.map((item, index) => (
+                                    <Card key={index} className="border-2">
+                                        <CardContent className="pt-6">
+                                            <div className="space-y-4">
+                                                <div className="flex items-start justify-between">
+                                                    <h4 className="font-semibold">Item {index + 1}</h4>
+                                                    {data.items.length > 1 && (
+                                                        <Button type="button" variant="destructive" size="sm" onClick={() => removeItem(index)}>
+                                                            <Trash className="h-4 w-4" />
+                                                        </Button>
+                                                    )}
+                                                </div>
+
+                                                <div className="space-y-2">
+                                                    <Label htmlFor={`item-description-${index}`}>
+                                                        Description <span className="text-red-600">*</span>
+                                                    </Label>
+                                                    <Input
+                                                        id={`item-description-${index}`}
+                                                        type="text"
+                                                        placeholder="e.g., Tuition Fee - Grade 1"
+                                                        value={item.description}
+                                                        onChange={(e) => updateItem(index, 'description', e.target.value)}
+                                                    />
+                                                    {errors[`items.${index}.description`] && (
+                                                        <p className="text-sm text-red-600">{errors[`items.${index}.description`]}</p>
+                                                    )}
+                                                </div>
+
+                                                <div className="grid gap-4 md:grid-cols-3">
+                                                    <div className="space-y-2">
+                                                        <Label htmlFor={`item-quantity-${index}`}>
+                                                            Quantity <span className="text-red-600">*</span>
+                                                        </Label>
+                                                        <Input
+                                                            id={`item-quantity-${index}`}
+                                                            type="number"
+                                                            min="1"
+                                                            step="1"
+                                                            value={item.quantity}
+                                                            onChange={(e) => updateItem(index, 'quantity', Number(e.target.value))}
+                                                        />
+                                                        {errors[`items.${index}.quantity`] && (
+                                                            <p className="text-sm text-red-600">{errors[`items.${index}.quantity`]}</p>
+                                                        )}
+                                                    </div>
+
+                                                    <div className="space-y-2">
+                                                        <Label htmlFor={`item-unit-price-${index}`}>
+                                                            Unit Price <span className="text-red-600">*</span>
+                                                        </Label>
+                                                        <Input
+                                                            id={`item-unit-price-${index}`}
+                                                            type="number"
+                                                            min="0"
+                                                            step="0.01"
+                                                            value={item.unit_price}
+                                                            onChange={(e) => updateItem(index, 'unit_price', Number(e.target.value))}
+                                                        />
+                                                        {errors[`items.${index}.unit_price`] && (
+                                                            <p className="text-sm text-red-600">{errors[`items.${index}.unit_price`]}</p>
+                                                        )}
+                                                    </div>
+
+                                                    <div className="space-y-2">
+                                                        <Label>Amount</Label>
+                                                        <div className="flex h-10 items-center rounded-md border bg-muted px-3 py-2 font-semibold">
+                                                            {formatCurrency(item.amount)}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </CardContent>
+                                    </Card>
+                                ))}
+
+                                {errors.items && typeof errors.items === 'string' && <p className="text-sm text-red-600">{errors.items}</p>}
+
+                                {/* Total */}
+                                <div className="flex justify-end border-t pt-4">
+                                    <div className="w-full max-w-xs space-y-2">
+                                        <div className="flex justify-between text-lg font-bold">
+                                            <span>Total Amount:</span>
+                                            <span className="text-primary">{formatCurrency(calculateTotal())}</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </div>
+
+                    <div className="mt-6 flex justify-end gap-4">
+                        <Link href="/super-admin/invoices">
+                            <Button type="button" variant="outline">
+                                Cancel
+                            </Button>
+                        </Link>
+                        <Button type="submit" disabled={processing}>
+                            <Save className="mr-2 h-4 w-4" />
+                            Create Invoice
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/invoices/edit.tsx
+++ b/resources/js/pages/super-admin/invoices/edit.tsx
@@ -1,0 +1,366 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link, useForm } from '@inertiajs/react';
+import { ArrowLeft, Plus, Save, Trash } from 'lucide-react';
+
+interface Student {
+    id: number;
+    student_id: string;
+    first_name: string;
+    last_name: string;
+}
+
+interface User {
+    id: number;
+    name: string;
+}
+
+interface Guardian {
+    id: number;
+    first_name: string;
+    last_name: string;
+    user: User;
+}
+
+interface Enrollment {
+    id: number;
+    enrollment_id: string;
+    student: Student;
+    guardian: Guardian;
+}
+
+interface InvoiceItem {
+    id?: number;
+    description: string;
+    quantity: number;
+    unit_price: number;
+    amount: number;
+}
+
+interface Invoice {
+    id: number;
+    invoice_number: string;
+    enrollment_id: number;
+    enrollment: Enrollment;
+    invoice_date: string;
+    due_date: string;
+    status: string;
+    items: InvoiceItem[];
+}
+
+interface FormData {
+    enrollment_id: string;
+    invoice_date: string;
+    due_date: string;
+    status: string;
+    items: InvoiceItem[];
+}
+
+interface Props {
+    invoice: Invoice;
+    enrollments: Enrollment[];
+}
+
+export default function SuperAdminInvoicesEdit({ invoice, enrollments }: Props) {
+    const { data, setData, put, processing, errors } = useForm<FormData>({
+        enrollment_id: invoice.enrollment_id.toString(),
+        invoice_date: invoice.invoice_date,
+        due_date: invoice.due_date,
+        status: invoice.status,
+        items: invoice.items.map((item) => ({
+            id: item.id,
+            description: item.description,
+            quantity: item.quantity,
+            unit_price: item.unit_price,
+            amount: item.amount,
+        })),
+    });
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Super Admin', href: '/super-admin/dashboard' },
+        { title: 'Invoices', href: '/super-admin/invoices' },
+        { title: 'Edit', href: '#' },
+    ];
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        put(`/super-admin/invoices/${invoice.id}`);
+    };
+
+    const addItem = () => {
+        setData('items', [
+            ...data.items,
+            {
+                description: '',
+                quantity: 1,
+                unit_price: 0,
+                amount: 0,
+            },
+        ]);
+    };
+
+    const removeItem = (index: number) => {
+        if (data.items.length === 1) {
+            alert('At least one item is required.');
+            return;
+        }
+        const newItems = data.items.filter((_, i) => i !== index);
+        setData('items', newItems);
+    };
+
+    const updateItem = (index: number, field: keyof InvoiceItem, value: string | number) => {
+        const newItems = [...data.items];
+        newItems[index] = {
+            ...newItems[index],
+            [field]: value,
+        };
+
+        // Recalculate amount if quantity or unit_price changed
+        if (field === 'quantity' || field === 'unit_price') {
+            const quantity = field === 'quantity' ? Number(value) : newItems[index].quantity;
+            const unitPrice = field === 'unit_price' ? Number(value) : newItems[index].unit_price;
+            newItems[index].amount = quantity * unitPrice;
+        }
+
+        setData('items', newItems);
+    };
+
+    const calculateTotal = () => {
+        return data.items.reduce((sum, item) => sum + item.amount, 0);
+    };
+
+    const formatCurrency = (amount: number) => {
+        return new Intl.NumberFormat('en-PH', {
+            style: 'currency',
+            currency: 'PHP',
+        }).format(amount);
+    };
+
+    const getEnrollmentDisplay = (enrollment: Enrollment) => {
+        return `${enrollment.student.first_name} ${enrollment.student.last_name} (${enrollment.student.student_id}) - ${enrollment.enrollment_id}`;
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Edit Invoice" />
+            <div className="container mx-auto max-w-4xl px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold">Edit Invoice</h1>
+                        <p className="text-muted-foreground">{invoice.invoice_number}</p>
+                    </div>
+                    <Link href="/super-admin/invoices">
+                        <Button variant="outline">
+                            <ArrowLeft className="mr-2 h-4 w-4" />
+                            Back to List
+                        </Button>
+                    </Link>
+                </div>
+
+                <form onSubmit={handleSubmit}>
+                    <div className="space-y-6">
+                        {/* Invoice Information */}
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Invoice Information</CardTitle>
+                                <CardDescription>Update invoice details and status.</CardDescription>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <div className="space-y-2">
+                                    <Label htmlFor="enrollment_id">
+                                        Enrollment <span className="text-red-600">*</span>
+                                    </Label>
+                                    <Select value={data.enrollment_id} onValueChange={(value) => setData('enrollment_id', value)}>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="Select enrollment" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {enrollments.map((enrollment) => (
+                                                <SelectItem key={enrollment.id} value={enrollment.id.toString()}>
+                                                    {getEnrollmentDisplay(enrollment)}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                    {errors.enrollment_id && <p className="text-sm text-red-600">{errors.enrollment_id}</p>}
+                                </div>
+
+                                <div className="grid gap-4 md:grid-cols-3">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="invoice_date">
+                                            Invoice Date <span className="text-red-600">*</span>
+                                        </Label>
+                                        <Input
+                                            id="invoice_date"
+                                            type="date"
+                                            value={data.invoice_date}
+                                            onChange={(e) => setData('invoice_date', e.target.value)}
+                                        />
+                                        {errors.invoice_date && <p className="text-sm text-red-600">{errors.invoice_date}</p>}
+                                    </div>
+
+                                    <div className="space-y-2">
+                                        <Label htmlFor="due_date">
+                                            Due Date <span className="text-red-600">*</span>
+                                        </Label>
+                                        <Input
+                                            id="due_date"
+                                            type="date"
+                                            value={data.due_date}
+                                            onChange={(e) => setData('due_date', e.target.value)}
+                                        />
+                                        {errors.due_date && <p className="text-sm text-red-600">{errors.due_date}</p>}
+                                    </div>
+
+                                    <div className="space-y-2">
+                                        <Label htmlFor="status">
+                                            Status <span className="text-red-600">*</span>
+                                        </Label>
+                                        <Select value={data.status} onValueChange={(value) => setData('status', value)}>
+                                            <SelectTrigger>
+                                                <SelectValue placeholder="Select status" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="draft">Draft</SelectItem>
+                                                <SelectItem value="sent">Sent</SelectItem>
+                                                <SelectItem value="paid">Paid</SelectItem>
+                                                <SelectItem value="overdue">Overdue</SelectItem>
+                                                <SelectItem value="cancelled">Cancelled</SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                        {errors.status && <p className="text-sm text-red-600">{errors.status}</p>}
+                                    </div>
+                                </div>
+                            </CardContent>
+                        </Card>
+
+                        {/* Invoice Items */}
+                        <Card>
+                            <CardHeader>
+                                <div className="flex items-center justify-between">
+                                    <div>
+                                        <CardTitle>Invoice Items</CardTitle>
+                                        <CardDescription>Update or add items to this invoice. At least one item is required.</CardDescription>
+                                    </div>
+                                    <Button type="button" variant="outline" size="sm" onClick={addItem}>
+                                        <Plus className="mr-2 h-4 w-4" />
+                                        Add Item
+                                    </Button>
+                                </div>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                {data.items.map((item, index) => (
+                                    <Card key={index} className="border-2">
+                                        <CardContent className="pt-6">
+                                            <div className="space-y-4">
+                                                <div className="flex items-start justify-between">
+                                                    <div>
+                                                        <h4 className="font-semibold">Item {index + 1}</h4>
+                                                        {item.id && <p className="text-xs text-muted-foreground">Existing Item #{item.id}</p>}
+                                                    </div>
+                                                    {data.items.length > 1 && (
+                                                        <Button type="button" variant="destructive" size="sm" onClick={() => removeItem(index)}>
+                                                            <Trash className="h-4 w-4" />
+                                                        </Button>
+                                                    )}
+                                                </div>
+
+                                                <div className="space-y-2">
+                                                    <Label htmlFor={`item-description-${index}`}>
+                                                        Description <span className="text-red-600">*</span>
+                                                    </Label>
+                                                    <Input
+                                                        id={`item-description-${index}`}
+                                                        type="text"
+                                                        placeholder="e.g., Tuition Fee - Grade 1"
+                                                        value={item.description}
+                                                        onChange={(e) => updateItem(index, 'description', e.target.value)}
+                                                    />
+                                                    {errors[`items.${index}.description`] && (
+                                                        <p className="text-sm text-red-600">{errors[`items.${index}.description`]}</p>
+                                                    )}
+                                                </div>
+
+                                                <div className="grid gap-4 md:grid-cols-3">
+                                                    <div className="space-y-2">
+                                                        <Label htmlFor={`item-quantity-${index}`}>
+                                                            Quantity <span className="text-red-600">*</span>
+                                                        </Label>
+                                                        <Input
+                                                            id={`item-quantity-${index}`}
+                                                            type="number"
+                                                            min="1"
+                                                            step="1"
+                                                            value={item.quantity}
+                                                            onChange={(e) => updateItem(index, 'quantity', Number(e.target.value))}
+                                                        />
+                                                        {errors[`items.${index}.quantity`] && (
+                                                            <p className="text-sm text-red-600">{errors[`items.${index}.quantity`]}</p>
+                                                        )}
+                                                    </div>
+
+                                                    <div className="space-y-2">
+                                                        <Label htmlFor={`item-unit-price-${index}`}>
+                                                            Unit Price <span className="text-red-600">*</span>
+                                                        </Label>
+                                                        <Input
+                                                            id={`item-unit-price-${index}`}
+                                                            type="number"
+                                                            min="0"
+                                                            step="0.01"
+                                                            value={item.unit_price}
+                                                            onChange={(e) => updateItem(index, 'unit_price', Number(e.target.value))}
+                                                        />
+                                                        {errors[`items.${index}.unit_price`] && (
+                                                            <p className="text-sm text-red-600">{errors[`items.${index}.unit_price`]}</p>
+                                                        )}
+                                                    </div>
+
+                                                    <div className="space-y-2">
+                                                        <Label>Amount</Label>
+                                                        <div className="flex h-10 items-center rounded-md border bg-muted px-3 py-2 font-semibold">
+                                                            {formatCurrency(item.amount)}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </CardContent>
+                                    </Card>
+                                ))}
+
+                                {errors.items && typeof errors.items === 'string' && <p className="text-sm text-red-600">{errors.items}</p>}
+
+                                {/* Total */}
+                                <div className="flex justify-end border-t pt-4">
+                                    <div className="w-full max-w-xs space-y-2">
+                                        <div className="flex justify-between text-lg font-bold">
+                                            <span>Total Amount:</span>
+                                            <span className="text-primary">{formatCurrency(calculateTotal())}</span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    </div>
+
+                    <div className="mt-6 flex justify-end gap-4">
+                        <Link href="/super-admin/invoices">
+                            <Button type="button" variant="outline">
+                                Cancel
+                            </Button>
+                        </Link>
+                        <Button type="submit" disabled={processing}>
+                            <Save className="mr-2 h-4 w-4" />
+                            Update Invoice
+                        </Button>
+                    </div>
+                </form>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -1,12 +1,16 @@
 import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
 import { Card } from '@/components/ui/card';
 import { DataTable } from '@/components/ui/data-table';
 import { Input } from '@/components/ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import AppLayout from '@/layouts/app-layout';
+import { cn } from '@/lib/utils';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/react';
-import { PlusCircle, Search } from 'lucide-react';
+import { format } from 'date-fns';
+import { CalendarIcon, PlusCircle, Search } from 'lucide-react';
 import { useState } from 'react';
 import { columns } from './columns';
 
@@ -58,8 +62,8 @@ interface Props {
 export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
     const [search, setSearch] = useState(filters.search || '');
     const [status, setStatus] = useState(filters.status || 'all');
-    const [fromDate, setFromDate] = useState(filters.from_date || '');
-    const [toDate, setToDate] = useState(filters.to_date || '');
+    const [fromDate, setFromDate] = useState<Date | undefined>(filters.from_date ? new Date(filters.from_date) : undefined);
+    const [toDate, setToDate] = useState<Date | undefined>(filters.to_date ? new Date(filters.to_date) : undefined);
 
     const breadcrumbs: BreadcrumbItem[] = [
         { title: 'Super Admin', href: '/super-admin/dashboard' },
@@ -72,8 +76,8 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
             {
                 search: search || undefined,
                 status: status && status !== 'all' ? status : undefined,
-                from_date: fromDate || undefined,
-                to_date: toDate || undefined,
+                from_date: fromDate ? format(fromDate, 'yyyy-MM-dd') : undefined,
+                to_date: toDate ? format(toDate, 'yyyy-MM-dd') : undefined,
             },
             {
                 preserveState: true,
@@ -85,8 +89,8 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
     const handleClearFilters = () => {
         setSearch('');
         setStatus('all');
-        setFromDate('');
-        setToDate('');
+        setFromDate(undefined);
+        setToDate(undefined);
         router.get('/super-admin/invoices', {}, { preserveState: true, preserveScroll: true });
     };
 
@@ -133,11 +137,37 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                         </div>
                         <div>
                             <label className="mb-1 block text-sm font-medium">From Date</label>
-                            <Input type="date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} />
+                            <Popover>
+                                <PopoverTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        className={cn('w-full justify-start text-left font-normal', !fromDate && 'text-muted-foreground')}
+                                    >
+                                        <CalendarIcon className="mr-2 h-4 w-4" />
+                                        {fromDate ? format(fromDate, 'PPP') : <span>Pick a date</span>}
+                                    </Button>
+                                </PopoverTrigger>
+                                <PopoverContent className="w-auto p-0">
+                                    <Calendar mode="single" selected={fromDate} onSelect={setFromDate} initialFocus />
+                                </PopoverContent>
+                            </Popover>
                         </div>
                         <div>
                             <label className="mb-1 block text-sm font-medium">To Date</label>
-                            <Input type="date" value={toDate} onChange={(e) => setToDate(e.target.value)} />
+                            <Popover>
+                                <PopoverTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        className={cn('w-full justify-start text-left font-normal', !toDate && 'text-muted-foreground')}
+                                    >
+                                        <CalendarIcon className="mr-2 h-4 w-4" />
+                                        {toDate ? format(toDate, 'PPP') : <span>Pick a date</span>}
+                                    </Button>
+                                </PopoverTrigger>
+                                <PopoverContent className="w-auto p-0">
+                                    <Calendar mode="single" selected={toDate} onSelect={setToDate} initialFocus />
+                                </PopoverContent>
+                            </Popover>
                         </div>
                     </div>
                     <div className="mt-4 flex gap-2">

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -1,14 +1,14 @@
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { DataTable } from '@/components/ui/data-table';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/react';
-import { Edit, Eye, PlusCircle, Search, Trash } from 'lucide-react';
+import { PlusCircle, Search } from 'lucide-react';
 import { useState } from 'react';
+import { columns } from './columns';
 
 interface Student {
     id: number;
@@ -90,46 +90,6 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
         router.get('/super-admin/invoices', {}, { preserveState: true, preserveScroll: true });
     };
 
-    const handleDelete = (id: number, invoiceNumber: string) => {
-        if (confirm(`Are you sure you want to delete invoice ${invoiceNumber}? This action cannot be undone.`)) {
-            router.delete(`/super-admin/invoices/${id}`);
-        }
-    };
-
-    const formatCurrency = (amount: number) => {
-        return new Intl.NumberFormat('en-PH', {
-            style: 'currency',
-            currency: 'PHP',
-        }).format(amount);
-    };
-
-    const formatDate = (dateString: string) => {
-        return new Date(dateString).toLocaleDateString('en-US', {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric',
-        });
-    };
-
-    const getStatusBadge = (status: string) => {
-        const variants: Record<string, { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }> = {
-            draft: { variant: 'outline', label: 'Draft' },
-            sent: { variant: 'default', label: 'Sent' },
-            partially_paid: { variant: 'secondary', label: 'Partially Paid' },
-            paid: { variant: 'default', label: 'Paid' },
-            cancelled: { variant: 'destructive', label: 'Cancelled' },
-            overdue: { variant: 'destructive', label: 'Overdue' },
-        };
-
-        const config = variants[status] || { variant: 'outline' as const, label: status };
-
-        return (
-            <Badge variant={config.variant} className={status === 'paid' ? 'bg-green-100 text-green-800' : ''}>
-                {config.label}
-            </Badge>
-        );
-    };
-
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Invoices" />
@@ -191,69 +151,8 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                     </div>
                 </Card>
 
-                {/* Table */}
-                <Card>
-                    <Table>
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Invoice #</TableHead>
-                                <TableHead>Student</TableHead>
-                                <TableHead>Total Amount</TableHead>
-                                <TableHead>Paid Amount</TableHead>
-                                <TableHead>Balance</TableHead>
-                                <TableHead>Status</TableHead>
-                                <TableHead>Due Date</TableHead>
-                                <TableHead className="text-right">Actions</TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {invoices.data.length === 0 ? (
-                                <TableRow>
-                                    <TableCell colSpan={8} className="text-center text-muted-foreground">
-                                        No invoices found.
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                invoices.data.map((invoice) => (
-                                    <TableRow key={invoice.id}>
-                                        <TableCell className="font-medium">{invoice.invoice_number}</TableCell>
-                                        <TableCell>
-                                            {invoice.enrollment.student.first_name} {invoice.enrollment.student.last_name}
-                                            <br />
-                                            <span className="text-sm text-muted-foreground">ID: {invoice.enrollment.student.student_id}</span>
-                                        </TableCell>
-                                        <TableCell>{formatCurrency(invoice.total_amount)}</TableCell>
-                                        <TableCell className="text-green-600">{formatCurrency(invoice.paid_amount)}</TableCell>
-                                        <TableCell className="text-red-600">{formatCurrency(invoice.total_amount - invoice.paid_amount)}</TableCell>
-                                        <TableCell>{getStatusBadge(invoice.status)}</TableCell>
-                                        <TableCell>{formatDate(invoice.due_date)}</TableCell>
-                                        <TableCell className="text-right">
-                                            <div className="flex justify-end gap-2">
-                                                <Link href={`/super-admin/invoices/${invoice.id}`}>
-                                                    <Button size="sm" variant="outline">
-                                                        <Eye className="h-4 w-4" />
-                                                    </Button>
-                                                </Link>
-                                                <Link href={`/super-admin/invoices/${invoice.id}/edit`}>
-                                                    <Button size="sm" variant="outline">
-                                                        <Edit className="h-4 w-4" />
-                                                    </Button>
-                                                </Link>
-                                                <Button
-                                                    size="sm"
-                                                    variant="destructive"
-                                                    onClick={() => handleDelete(invoice.id, invoice.invoice_number)}
-                                                >
-                                                    <Trash className="h-4 w-4" />
-                                                </Button>
-                                            </div>
-                                        </TableCell>
-                                    </TableRow>
-                                ))
-                            )}
-                        </TableBody>
-                    </Table>
-                </Card>
+                {/* Data Table */}
+                <DataTable columns={columns} data={invoices.data} />
 
                 {/* Pagination */}
                 {invoices.last_page > 1 && (

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -109,20 +109,22 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                 </div>
 
                 {/* Filters */}
-                <Card className="mb-6 p-4">
+                <Card className="mb-6 p-6">
                     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-                        <div>
+                        <div className="space-y-2">
+                            <label className="text-sm font-medium">Search</label>
                             <Input
-                                placeholder="Search by invoice # or student..."
+                                placeholder="Invoice # or student..."
                                 value={search}
                                 onChange={(e) => setSearch(e.target.value)}
                                 onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
                             />
                         </div>
-                        <div>
+                        <div className="space-y-2">
+                            <label className="text-sm font-medium">Status</label>
                             <Select value={status} onValueChange={setStatus}>
                                 <SelectTrigger>
-                                    <SelectValue placeholder="Filter by status" />
+                                    <SelectValue placeholder="All Statuses" />
                                 </SelectTrigger>
                                 <SelectContent>
                                     <SelectItem value="all">All Statuses</SelectItem>
@@ -135,8 +137,8 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                 </SelectContent>
                             </Select>
                         </div>
-                        <div>
-                            <label className="mb-1 block text-sm font-medium">From Date</label>
+                        <div className="space-y-2">
+                            <label className="text-sm font-medium">From Date</label>
                             <Popover>
                                 <PopoverTrigger asChild>
                                     <Button
@@ -158,8 +160,8 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                 </PopoverContent>
                             </Popover>
                         </div>
-                        <div>
-                            <label className="mb-1 block text-sm font-medium">To Date</label>
+                        <div className="space-y-2">
+                            <label className="text-sm font-medium">To Date</label>
                             <Popover>
                                 <PopoverTrigger asChild>
                                     <Button
@@ -182,7 +184,7 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                             </Popover>
                         </div>
                     </div>
-                    <div className="mt-4 flex gap-2">
+                    <div className="mt-6 flex gap-2">
                         <Button onClick={handleSearch} variant="secondary">
                             <Search className="mr-2 h-4 w-4" />
                             Search

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -1,0 +1,282 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link, router } from '@inertiajs/react';
+import { Edit, Eye, PlusCircle, Search, Trash } from 'lucide-react';
+import { useState } from 'react';
+
+interface Student {
+    id: number;
+    student_id: string;
+    first_name: string;
+    last_name: string;
+}
+
+interface Enrollment {
+    id: number;
+    student: Student;
+}
+
+interface Invoice {
+    id: number;
+    invoice_number: string;
+    enrollment: Enrollment;
+    total_amount: number;
+    paid_amount: number;
+    status: string;
+    due_date: string;
+    created_at: string;
+}
+
+interface PaginationLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+interface Props {
+    invoices: {
+        data: Invoice[];
+        links: PaginationLink[];
+        current_page: number;
+        last_page: number;
+        total: number;
+    };
+    filters: {
+        search?: string;
+        status?: string;
+        from_date?: string;
+        to_date?: string;
+    };
+}
+
+export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
+    const [search, setSearch] = useState(filters.search || '');
+    const [status, setStatus] = useState(filters.status || '');
+    const [fromDate, setFromDate] = useState(filters.from_date || '');
+    const [toDate, setToDate] = useState(filters.to_date || '');
+
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Super Admin', href: '/super-admin/dashboard' },
+        { title: 'Invoices', href: '/super-admin/invoices' },
+    ];
+
+    const handleSearch = () => {
+        router.get(
+            '/super-admin/invoices',
+            {
+                search: search || undefined,
+                status: status || undefined,
+                from_date: fromDate || undefined,
+                to_date: toDate || undefined,
+            },
+            {
+                preserveState: true,
+                preserveScroll: true,
+            },
+        );
+    };
+
+    const handleClearFilters = () => {
+        setSearch('');
+        setStatus('');
+        setFromDate('');
+        setToDate('');
+        router.get('/super-admin/invoices', {}, { preserveState: true, preserveScroll: true });
+    };
+
+    const handleDelete = (id: number, invoiceNumber: string) => {
+        if (confirm(`Are you sure you want to delete invoice ${invoiceNumber}? This action cannot be undone.`)) {
+            router.delete(`/super-admin/invoices/${id}`);
+        }
+    };
+
+    const formatCurrency = (amount: number) => {
+        return new Intl.NumberFormat('en-PH', {
+            style: 'currency',
+            currency: 'PHP',
+        }).format(amount);
+    };
+
+    const formatDate = (dateString: string) => {
+        return new Date(dateString).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+        });
+    };
+
+    const getStatusBadge = (status: string) => {
+        const variants: Record<string, { variant: 'default' | 'secondary' | 'destructive' | 'outline'; label: string }> = {
+            draft: { variant: 'outline', label: 'Draft' },
+            sent: { variant: 'default', label: 'Sent' },
+            partially_paid: { variant: 'secondary', label: 'Partially Paid' },
+            paid: { variant: 'default', label: 'Paid' },
+            cancelled: { variant: 'destructive', label: 'Cancelled' },
+            overdue: { variant: 'destructive', label: 'Overdue' },
+        };
+
+        const config = variants[status] || { variant: 'outline' as const, label: status };
+
+        return (
+            <Badge variant={config.variant} className={status === 'paid' ? 'bg-green-100 text-green-800' : ''}>
+                {config.label}
+            </Badge>
+        );
+    };
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Invoices" />
+            <div className="container mx-auto px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <h1 className="text-2xl font-bold">Invoices</h1>
+                    <Link href="/super-admin/invoices/create">
+                        <Button>
+                            <PlusCircle className="mr-2 h-4 w-4" />
+                            Create Invoice
+                        </Button>
+                    </Link>
+                </div>
+
+                {/* Filters */}
+                <Card className="mb-6 p-4">
+                    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+                        <div>
+                            <Input
+                                placeholder="Search by invoice # or student..."
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                                onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                            />
+                        </div>
+                        <div>
+                            <Select value={status} onValueChange={setStatus}>
+                                <SelectTrigger>
+                                    <SelectValue placeholder="Filter by status" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="">All Statuses</SelectItem>
+                                    <SelectItem value="draft">Draft</SelectItem>
+                                    <SelectItem value="sent">Sent</SelectItem>
+                                    <SelectItem value="partially_paid">Partially Paid</SelectItem>
+                                    <SelectItem value="paid">Paid</SelectItem>
+                                    <SelectItem value="overdue">Overdue</SelectItem>
+                                    <SelectItem value="cancelled">Cancelled</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div>
+                            <Input type="date" placeholder="From date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} />
+                        </div>
+                        <div>
+                            <Input type="date" placeholder="To date" value={toDate} onChange={(e) => setToDate(e.target.value)} />
+                        </div>
+                    </div>
+                    <div className="mt-4 flex gap-2">
+                        <Button onClick={handleSearch} variant="secondary">
+                            <Search className="mr-2 h-4 w-4" />
+                            Search
+                        </Button>
+                        {(search || status || fromDate || toDate) && (
+                            <Button onClick={handleClearFilters} variant="outline">
+                                Clear Filters
+                            </Button>
+                        )}
+                    </div>
+                </Card>
+
+                {/* Table */}
+                <Card>
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Invoice #</TableHead>
+                                <TableHead>Student</TableHead>
+                                <TableHead>Total Amount</TableHead>
+                                <TableHead>Paid Amount</TableHead>
+                                <TableHead>Balance</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead>Due Date</TableHead>
+                                <TableHead className="text-right">Actions</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {invoices.data.length === 0 ? (
+                                <TableRow>
+                                    <TableCell colSpan={8} className="text-center text-muted-foreground">
+                                        No invoices found.
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                invoices.data.map((invoice) => (
+                                    <TableRow key={invoice.id}>
+                                        <TableCell className="font-medium">{invoice.invoice_number}</TableCell>
+                                        <TableCell>
+                                            {invoice.enrollment.student.first_name} {invoice.enrollment.student.last_name}
+                                            <br />
+                                            <span className="text-sm text-muted-foreground">ID: {invoice.enrollment.student.student_id}</span>
+                                        </TableCell>
+                                        <TableCell>{formatCurrency(invoice.total_amount)}</TableCell>
+                                        <TableCell className="text-green-600">{formatCurrency(invoice.paid_amount)}</TableCell>
+                                        <TableCell className="text-red-600">{formatCurrency(invoice.total_amount - invoice.paid_amount)}</TableCell>
+                                        <TableCell>{getStatusBadge(invoice.status)}</TableCell>
+                                        <TableCell>{formatDate(invoice.due_date)}</TableCell>
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-2">
+                                                <Link href={`/super-admin/invoices/${invoice.id}`}>
+                                                    <Button size="sm" variant="outline">
+                                                        <Eye className="h-4 w-4" />
+                                                    </Button>
+                                                </Link>
+                                                <Link href={`/super-admin/invoices/${invoice.id}/edit`}>
+                                                    <Button size="sm" variant="outline">
+                                                        <Edit className="h-4 w-4" />
+                                                    </Button>
+                                                </Link>
+                                                <Button
+                                                    size="sm"
+                                                    variant="destructive"
+                                                    onClick={() => handleDelete(invoice.id, invoice.invoice_number)}
+                                                >
+                                                    <Trash className="h-4 w-4" />
+                                                </Button>
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            )}
+                        </TableBody>
+                    </Table>
+                </Card>
+
+                {/* Pagination */}
+                {invoices.last_page > 1 && (
+                    <div className="mt-4 flex justify-center gap-2">
+                        {invoices.links.map((link, index) => (
+                            <Link
+                                key={index}
+                                href={link.url || '#'}
+                                preserveState
+                                preserveScroll
+                                className={`rounded px-3 py-1 ${
+                                    link.active
+                                        ? 'bg-primary text-primary-foreground'
+                                        : link.url
+                                          ? 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+                                          : 'cursor-not-allowed bg-muted text-muted-foreground'
+                                }`}
+                                dangerouslySetInnerHTML={{ __html: link.label }}
+                            />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -147,7 +147,7 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                         {fromDate ? format(fromDate, 'PPP') : <span>Pick a date</span>}
                                     </Button>
                                 </PopoverTrigger>
-                                <PopoverContent className="w-auto p-0">
+                                <PopoverContent className="w-auto p-0" align="start">
                                     <Calendar mode="single" selected={fromDate} onSelect={setFromDate} initialFocus />
                                 </PopoverContent>
                             </Popover>
@@ -164,7 +164,7 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                         {toDate ? format(toDate, 'PPP') : <span>Pick a date</span>}
                                     </Button>
                                 </PopoverTrigger>
-                                <PopoverContent className="w-auto p-0">
+                                <PopoverContent className="w-auto p-0" align="start">
                                     <Calendar mode="single" selected={toDate} onSelect={setToDate} initialFocus />
                                 </PopoverContent>
                             </Popover>

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -147,8 +147,14 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                         {fromDate ? format(fromDate, 'PPP') : <span>Pick a date</span>}
                                     </Button>
                                 </PopoverTrigger>
-                                <PopoverContent className="w-auto p-3" align="start">
-                                    <Calendar mode="single" selected={fromDate} onSelect={setFromDate} initialFocus className="rounded-md border" />
+                                <PopoverContent className="w-auto p-0" align="start">
+                                    <Calendar
+                                        mode="single"
+                                        selected={fromDate}
+                                        onSelect={setFromDate}
+                                        initialFocus
+                                        className="rounded-md border shadow"
+                                    />
                                 </PopoverContent>
                             </Popover>
                         </div>
@@ -164,8 +170,14 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                         {toDate ? format(toDate, 'PPP') : <span>Pick a date</span>}
                                     </Button>
                                 </PopoverTrigger>
-                                <PopoverContent className="w-auto p-3" align="start">
-                                    <Calendar mode="single" selected={toDate} onSelect={setToDate} initialFocus className="rounded-md border" />
+                                <PopoverContent className="w-auto p-0" align="start">
+                                    <Calendar
+                                        mode="single"
+                                        selected={toDate}
+                                        onSelect={setToDate}
+                                        initialFocus
+                                        className="rounded-md border shadow"
+                                    />
                                 </PopoverContent>
                             </Popover>
                         </div>

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -147,8 +147,8 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                         {fromDate ? format(fromDate, 'PPP') : <span>Pick a date</span>}
                                     </Button>
                                 </PopoverTrigger>
-                                <PopoverContent className="w-auto p-0" align="start">
-                                    <Calendar mode="single" selected={fromDate} onSelect={setFromDate} initialFocus />
+                                <PopoverContent className="w-auto p-3" align="start">
+                                    <Calendar mode="single" selected={fromDate} onSelect={setFromDate} initialFocus className="rounded-md border" />
                                 </PopoverContent>
                             </Popover>
                         </div>
@@ -164,8 +164,8 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                         {toDate ? format(toDate, 'PPP') : <span>Pick a date</span>}
                                     </Button>
                                 </PopoverTrigger>
-                                <PopoverContent className="w-auto p-0" align="start">
-                                    <Calendar mode="single" selected={toDate} onSelect={setToDate} initialFocus />
+                                <PopoverContent className="w-auto p-3" align="start">
+                                    <Calendar mode="single" selected={toDate} onSelect={setToDate} initialFocus className="rounded-md border" />
                                 </PopoverContent>
                             </Popover>
                         </div>

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -132,10 +132,12 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                             </Select>
                         </div>
                         <div>
-                            <Input type="date" placeholder="From date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} />
+                            <label className="mb-1 block text-sm font-medium">From Date</label>
+                            <Input type="date" value={fromDate} onChange={(e) => setFromDate(e.target.value)} />
                         </div>
                         <div>
-                            <Input type="date" placeholder="To date" value={toDate} onChange={(e) => setToDate(e.target.value)} />
+                            <label className="mb-1 block text-sm font-medium">To Date</label>
+                            <Input type="date" value={toDate} onChange={(e) => setToDate(e.target.value)} />
                         </div>
                     </div>
                     <div className="mt-4 flex gap-2">

--- a/resources/js/pages/super-admin/invoices/index.tsx
+++ b/resources/js/pages/super-admin/invoices/index.tsx
@@ -57,7 +57,7 @@ interface Props {
 
 export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
     const [search, setSearch] = useState(filters.search || '');
-    const [status, setStatus] = useState(filters.status || '');
+    const [status, setStatus] = useState(filters.status || 'all');
     const [fromDate, setFromDate] = useState(filters.from_date || '');
     const [toDate, setToDate] = useState(filters.to_date || '');
 
@@ -71,7 +71,7 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
             '/super-admin/invoices',
             {
                 search: search || undefined,
-                status: status || undefined,
+                status: status && status !== 'all' ? status : undefined,
                 from_date: fromDate || undefined,
                 to_date: toDate || undefined,
             },
@@ -84,7 +84,7 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
 
     const handleClearFilters = () => {
         setSearch('');
-        setStatus('');
+        setStatus('all');
         setFromDate('');
         setToDate('');
         router.get('/super-admin/invoices', {}, { preserveState: true, preserveScroll: true });
@@ -161,7 +161,7 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                                     <SelectValue placeholder="Filter by status" />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    <SelectItem value="">All Statuses</SelectItem>
+                                    <SelectItem value="all">All Statuses</SelectItem>
                                     <SelectItem value="draft">Draft</SelectItem>
                                     <SelectItem value="sent">Sent</SelectItem>
                                     <SelectItem value="partially_paid">Partially Paid</SelectItem>
@@ -183,7 +183,7 @@ export default function SuperAdminInvoicesIndex({ invoices, filters }: Props) {
                             <Search className="mr-2 h-4 w-4" />
                             Search
                         </Button>
-                        {(search || status || fromDate || toDate) && (
+                        {(search || (status && status !== 'all') || fromDate || toDate) && (
                             <Button onClick={handleClearFilters} variant="outline">
                                 Clear Filters
                             </Button>

--- a/resources/js/pages/super-admin/invoices/show.tsx
+++ b/resources/js/pages/super-admin/invoices/show.tsx
@@ -1,0 +1,372 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link } from '@inertiajs/react';
+import { ArrowLeft, Calendar, Edit, FileText, User } from 'lucide-react';
+
+interface Student {
+    id: number;
+    student_id: string;
+    first_name: string;
+    middle_name?: string;
+    last_name: string;
+    grade_level: string;
+}
+
+interface User {
+    id: number;
+    name: string;
+    email: string;
+}
+
+interface Guardian {
+    id: number;
+    first_name: string;
+    last_name: string;
+    user: User;
+}
+
+interface Enrollment {
+    id: number;
+    enrollment_id: string;
+    student: Student;
+    guardian: Guardian;
+    school_year: string;
+    grade_level: string;
+}
+
+interface InvoiceItem {
+    id: number;
+    description: string;
+    quantity: number;
+    unit_price: number;
+    amount: number;
+}
+
+interface Payment {
+    id: number;
+    payment_number: string;
+    amount: number;
+    payment_method: string;
+    payment_date: string;
+    reference_number?: string;
+}
+
+interface Invoice {
+    id: number;
+    invoice_number: string;
+    enrollment: Enrollment;
+    total_amount: number;
+    paid_amount: number;
+    status: string;
+    due_date: string;
+    paid_at?: string;
+    notes?: string;
+    items: InvoiceItem[];
+    payments: Payment[];
+    created_at: string;
+    updated_at: string;
+}
+
+interface Props {
+    invoice: Invoice;
+}
+
+export default function SuperAdminInvoicesShow({ invoice }: Props) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Super Admin', href: '/super-admin/dashboard' },
+        { title: 'Invoices', href: '/super-admin/invoices' },
+        { title: 'View', href: '#' },
+    ];
+
+    const formatCurrency = (amount: number) => {
+        return new Intl.NumberFormat('en-PH', {
+            style: 'currency',
+            currency: 'PHP',
+        }).format(amount);
+    };
+
+    const formatDate = (dateString: string) => {
+        return new Date(dateString).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+        });
+    };
+
+    const formatDateTime = (dateString: string) => {
+        return new Date(dateString).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    };
+
+    const getStudentFullName = () => {
+        const middle = invoice.enrollment.student.middle_name ? ` ${invoice.enrollment.student.middle_name}` : '';
+        return `${invoice.enrollment.student.first_name}${middle} ${invoice.enrollment.student.last_name}`;
+    };
+
+    const getStatusBadge = (status: string) => {
+        const variants: Record<string, { className: string; label: string }> = {
+            draft: { className: 'bg-gray-100 text-gray-800', label: 'Draft' },
+            sent: { className: 'bg-blue-100 text-blue-800', label: 'Sent' },
+            partially_paid: { className: 'bg-yellow-100 text-yellow-800', label: 'Partially Paid' },
+            paid: { className: 'bg-green-100 text-green-800', label: 'Paid' },
+            cancelled: { className: 'bg-red-100 text-red-800', label: 'Cancelled' },
+            overdue: { className: 'bg-orange-100 text-orange-800', label: 'Overdue' },
+        };
+
+        const config = variants[status] || { className: 'bg-gray-100 text-gray-800', label: status };
+
+        return <Badge className={config.className}>{config.label}</Badge>;
+    };
+
+    const remainingBalance = invoice.total_amount - invoice.paid_amount;
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={`Invoice ${invoice.invoice_number}`} />
+            <div className="container mx-auto max-w-5xl px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold">Invoice Details</h1>
+                        <p className="text-muted-foreground">{invoice.invoice_number}</p>
+                    </div>
+                    <div className="flex gap-2">
+                        <Link href="/super-admin/invoices">
+                            <Button variant="outline">
+                                <ArrowLeft className="mr-2 h-4 w-4" />
+                                Back to List
+                            </Button>
+                        </Link>
+                        <Link href={`/super-admin/invoices/${invoice.id}/edit`}>
+                            <Button>
+                                <Edit className="mr-2 h-4 w-4" />
+                                Edit
+                            </Button>
+                        </Link>
+                    </div>
+                </div>
+
+                <div className="space-y-6">
+                    {/* Invoice Header */}
+                    <Card>
+                        <CardHeader>
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <CardTitle className="text-xl">{invoice.invoice_number}</CardTitle>
+                                    <p className="text-sm text-muted-foreground">Created on {formatDateTime(invoice.created_at)}</p>
+                                </div>
+                                {getStatusBadge(invoice.status)}
+                            </div>
+                        </CardHeader>
+                        <CardContent>
+                            <div className="grid gap-6 md:grid-cols-2">
+                                <div>
+                                    <h3 className="mb-3 font-semibold">Student Information</h3>
+                                    <dl className="space-y-2 text-sm">
+                                        <div className="flex justify-between">
+                                            <dt className="text-gray-600">Name:</dt>
+                                            <dd className="font-medium">{getStudentFullName()}</dd>
+                                        </div>
+                                        <div className="flex justify-between">
+                                            <dt className="text-gray-600">Student ID:</dt>
+                                            <dd className="font-medium">{invoice.enrollment.student.student_id}</dd>
+                                        </div>
+                                        <div className="flex justify-between">
+                                            <dt className="text-gray-600">Grade Level:</dt>
+                                            <dd className="font-medium">{invoice.enrollment.student.grade_level}</dd>
+                                        </div>
+                                        <div className="flex justify-between">
+                                            <dt className="text-gray-600">School Year:</dt>
+                                            <dd className="font-medium">{invoice.enrollment.school_year}</dd>
+                                        </div>
+                                    </dl>
+                                </div>
+
+                                <div>
+                                    <h3 className="mb-3 font-semibold">Guardian Information</h3>
+                                    <dl className="space-y-2 text-sm">
+                                        <div className="flex justify-between">
+                                            <dt className="text-gray-600">Name:</dt>
+                                            <dd className="font-medium">
+                                                {invoice.enrollment.guardian.first_name} {invoice.enrollment.guardian.last_name}
+                                            </dd>
+                                        </div>
+                                        <div className="flex justify-between">
+                                            <dt className="text-gray-600">Email:</dt>
+                                            <dd className="font-medium">{invoice.enrollment.guardian.user.email}</dd>
+                                        </div>
+                                        <div className="flex justify-between">
+                                            <dt className="text-gray-600">Enrollment ID:</dt>
+                                            <dd className="font-medium">{invoice.enrollment.enrollment_id}</dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                            </div>
+
+                            <Separator className="my-6" />
+
+                            <div className="grid gap-4 md:grid-cols-3">
+                                <div>
+                                    <h3 className="mb-2 text-sm font-semibold text-muted-foreground">Due Date</h3>
+                                    <div className="flex items-center gap-2">
+                                        <Calendar className="h-4 w-4 text-muted-foreground" />
+                                        <span className="font-medium">{formatDate(invoice.due_date)}</span>
+                                    </div>
+                                </div>
+                                {invoice.paid_at && (
+                                    <div>
+                                        <h3 className="mb-2 text-sm font-semibold text-muted-foreground">Paid Date</h3>
+                                        <div className="flex items-center gap-2">
+                                            <Calendar className="h-4 w-4 text-muted-foreground" />
+                                            <span className="font-medium">{formatDateTime(invoice.paid_at)}</span>
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+
+                            {invoice.notes && (
+                                <div className="mt-6">
+                                    <h3 className="mb-2 text-sm font-semibold text-muted-foreground">Notes</h3>
+                                    <p className="text-sm">{invoice.notes}</p>
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
+
+                    {/* Invoice Items */}
+                    <Card>
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2">
+                                <FileText className="h-5 w-5" />
+                                Invoice Items
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Description</TableHead>
+                                        <TableHead className="text-right">Quantity</TableHead>
+                                        <TableHead className="text-right">Unit Price</TableHead>
+                                        <TableHead className="text-right">Amount</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {invoice.items.map((item) => (
+                                        <TableRow key={item.id}>
+                                            <TableCell className="font-medium">{item.description}</TableCell>
+                                            <TableCell className="text-right">{item.quantity}</TableCell>
+                                            <TableCell className="text-right">{formatCurrency(item.unit_price)}</TableCell>
+                                            <TableCell className="text-right font-semibold">{formatCurrency(item.amount)}</TableCell>
+                                        </TableRow>
+                                    ))}
+                                    <TableRow>
+                                        <TableCell colSpan={4} className="h-4" />
+                                    </TableRow>
+                                    <TableRow>
+                                        <TableCell colSpan={3} className="text-right font-semibold">
+                                            Total Amount:
+                                        </TableCell>
+                                        <TableCell className="text-right text-lg font-bold">{formatCurrency(invoice.total_amount)}</TableCell>
+                                    </TableRow>
+                                    {invoice.paid_amount > 0 && (
+                                        <>
+                                            <TableRow>
+                                                <TableCell colSpan={3} className="text-right font-semibold text-green-600">
+                                                    Paid Amount:
+                                                </TableCell>
+                                                <TableCell className="text-right font-bold text-green-600">
+                                                    {formatCurrency(invoice.paid_amount)}
+                                                </TableCell>
+                                            </TableRow>
+                                            <TableRow className="border-t-2">
+                                                <TableCell colSpan={3} className="text-right text-lg font-bold">
+                                                    Balance:
+                                                </TableCell>
+                                                <TableCell className="text-right text-lg font-bold text-red-600">
+                                                    {formatCurrency(remainingBalance)}
+                                                </TableCell>
+                                            </TableRow>
+                                        </>
+                                    )}
+                                </TableBody>
+                            </Table>
+                        </CardContent>
+                    </Card>
+
+                    {/* Payment History */}
+                    {invoice.payments.length > 0 && (
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Payment History ({invoice.payments.length})</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <Table>
+                                    <TableHeader>
+                                        <TableRow>
+                                            <TableHead>Payment #</TableHead>
+                                            <TableHead>Date</TableHead>
+                                            <TableHead>Method</TableHead>
+                                            <TableHead>Reference</TableHead>
+                                            <TableHead className="text-right">Amount</TableHead>
+                                        </TableRow>
+                                    </TableHeader>
+                                    <TableBody>
+                                        {invoice.payments.map((payment) => (
+                                            <TableRow key={payment.id}>
+                                                <TableCell className="font-medium">{payment.payment_number}</TableCell>
+                                                <TableCell>{formatDate(payment.payment_date)}</TableCell>
+                                                <TableCell className="capitalize">{payment.payment_method.replace('_', ' ')}</TableCell>
+                                                <TableCell>{payment.reference_number || 'N/A'}</TableCell>
+                                                <TableCell className="text-right font-semibold text-green-600">
+                                                    {formatCurrency(payment.amount)}
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </CardContent>
+                        </Card>
+                    )}
+
+                    {/* Quick Actions */}
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Quick Actions</CardTitle>
+                        </CardHeader>
+                        <CardContent className="flex flex-wrap gap-2">
+                            <Link href={`/super-admin/students/${invoice.enrollment.student.id}`}>
+                                <Button variant="outline" size="sm">
+                                    <User className="mr-2 h-4 w-4" />
+                                    View Student
+                                </Button>
+                            </Link>
+                            <Link href={`/super-admin/enrollments/${invoice.enrollment.id}`}>
+                                <Button variant="outline" size="sm">
+                                    <FileText className="mr-2 h-4 w-4" />
+                                    View Enrollment
+                                </Button>
+                            </Link>
+                            {remainingBalance > 0 && (
+                                <Link href={`/super-admin/payments/create?invoice_id=${invoice.id}`}>
+                                    <Button variant="default" size="sm">
+                                        Record Payment
+                                    </Button>
+                                </Link>
+                            )}
+                        </CardContent>
+                    </Card>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}


### PR DESCRIPTION
## Summary
Implements TICKET-028: Super Admin Invoices CRUD pages (1.5 days)

### Features Implemented
- Complete CRUD operations for invoices (Create, Read, Update, Delete)
- Invoice index page with shadcn DataTable (sortable columns)
- Advanced filtering: search, status, date range
- Invoice detail view with line items
- Invoice form with dynamic item management
- Status badges and visual indicators
- Idempotent seeders for test data

### Key Changes
- **Index Page:** Converted to TanStack Table with sortable columns
- **Filters:** Search, status dropdown, date range with shadcn Calendar
- **Calendar Component:** Integrated shadcn Calendar with theme colors
- **Seeders:** Created EnrollmentSeeder and InvoiceSeeder (idempotent)
- **Database:** Added missing `invoice_date` column
- **Styling:** Override react-day-picker default blue with theme colors

### Technical Details
- Uses InvoiceService for business logic
- Proper form validation (StoreInvoiceRequest, UpdateInvoiceRequest)
- Supports all invoice statuses: DRAFT, SENT, PARTIALLY_PAID, PAID, OVERDUE, CANCELLED
- Money handling with cents-based storage
- Comprehensive test coverage maintained

### Files Changed
- Invoice pages: index, show, create, edit
- DataTable component (reusable)
- Invoice columns definition
- Calendar styling overrides
- Database migration for invoice_date
- Seeders for test data

### Related Tickets
- TICKET-028: Super Admin Invoices CRUD pages (1.5 days)

### Testing
✅ All pre-push checks passed
✅ Code coverage maintained above 60%
✅ TypeScript checks passed
✅ Prettier formatting applied