### PR TITLE
Fix enrollment edit and create page enum data formatting

### DIFF
--- a/app/Http/Controllers/SuperAdmin/EnrollmentController.php
+++ b/app/Http/Controllers/SuperAdmin/EnrollmentController.php
@@ -81,8 +81,14 @@ class EnrollmentController extends Controller
         return Inertia::render('super-admin/enrollments/create', [
             'students' => $students,
             'guardians' => $guardians,
-            'gradelevels' => \App\Enums\GradeLevel::cases(),
-            'quarters' => \App\Enums\Quarter::cases(),
+            'gradelevels' => array_map(fn ($grade) => [
+                'label' => $grade->label(),
+                'value' => $grade->value,
+            ], \App\Enums\GradeLevel::cases()),
+            'quarters' => array_map(fn ($quarter) => [
+                'label' => $quarter->label(),
+                'value' => $quarter->value,
+            ], \App\Enums\Quarter::cases()),
         ]);
     }
 
@@ -144,9 +150,18 @@ class EnrollmentController extends Controller
             'enrollment' => $enrollment,
             'students' => $students,
             'guardians' => $guardians,
-            'gradelevels' => \App\Enums\GradeLevel::cases(),
-            'quarters' => \App\Enums\Quarter::cases(),
-            'statuses' => EnrollmentStatus::cases(),
+            'gradelevels' => array_map(fn ($grade) => [
+                'label' => $grade->label(),
+                'value' => $grade->value,
+            ], \App\Enums\GradeLevel::cases()),
+            'quarters' => array_map(fn ($quarter) => [
+                'label' => $quarter->label(),
+                'value' => $quarter->value,
+            ], \App\Enums\Quarter::cases()),
+            'statuses' => array_map(fn ($status) => [
+                'label' => $status->label(),
+                'value' => $status->value,
+            ], EnrollmentStatus::cases()),
         ]);
     }
 


### PR DESCRIPTION
## Summary
- Fixed enum data formatting for grade levels, quarters, and statuses on enrollment edit and create pages
- Transform enum cases to proper label/value structure for frontend consumption

## Problem
The enum `::cases()` method returns instances that Laravel serializes with 'name' and 'value' properties, but the TypeScript interfaces expect 'label' and 'value'. This caused the grade level, quarter, and status dropdowns on the edit page to not display their values properly.

## Solution
Transform enum data in the controller using `array_map` to call the enum's `label()` method:
- `GradeLevel::cases()` → `[{ label: 'Kinder', value: 'Kinder' }, ...]`
- `Quarter::cases()` → `[{ label: '1st Quarter', value: 'First' }, ...]`
- `EnrollmentStatus::cases()` → `[{ label: 'Pending Review', value: 'pending' }, ...]`

## Changes
- Updated `EnrollmentController@edit` to transform gradelevels, quarters, and statuses
- Updated `EnrollmentController@create` to transform gradelevels and quarters
- Now matches TypeScript interface expectations in both edit.tsx and create.tsx

## Test plan
- [x] Build assets successfully
- [x] TypeScript type checking passes
- [x] Prettier and ESLint checks pass
- [x] Pre-push hooks pass (PHP syntax, Pint, PHPStan, security audit)
- [x] Test coverage meets 60% minimum threshold
- [ ] Manual test: Visit /super-admin/enrollments/{id}/edit
- [ ] Verify grade level dropdown shows "Kinder", "Grade 1", etc. (not "KINDER", "GRADE_1")
- [ ] Verify quarter dropdown shows "1st Quarter", "2nd Quarter", etc. (not "FIRST", "SECOND")
- [ ] Verify status dropdown shows "Pending Review", "Approved - Awaiting Invoice", etc.
- [ ] Verify all dropdowns pre-select current enrollment values correctly
- [ ] Manual test: Visit /super-admin/enrollments/create
- [ ] Verify grade level and quarter dropdowns display properly formatted labels