### PR TITLE
feat: Implement document verification UI and improve pages

### DIFF
--- a/resources/js/pages/registrar/dashboard.tsx
+++ b/resources/js/pages/registrar/dashboard.tsx
@@ -413,9 +413,9 @@ export default function RegistrarDashboard({
                                     <Users className="mr-2 h-4 w-4" />
                                     Manage Students
                                 </Button>
-                                <Button variant="outline" className="w-full" onClick={() => router.visit('/reports')}>
+                                <Button variant="outline" className="w-full" onClick={() => router.visit('/registrar/documents/pending')}>
                                     <AlertCircle className="mr-2 h-4 w-4" />
-                                    Generate Reports
+                                    Pending Documents
                                 </Button>
                                 <Button variant="outline" className="w-full" onClick={() => router.visit('/settings/profile')}>
                                     <Settings className="mr-2 h-4 w-4" />

--- a/resources/js/pages/registrar/documents/pending.tsx
+++ b/resources/js/pages/registrar/documents/pending.tsx
@@ -1,6 +1,6 @@
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
-import { Head } from '@inertiajs/react';
+import { Head, router } from '@inertiajs/react';
 
 interface Document {
     id: number;
@@ -38,13 +38,79 @@ export default function PendingDocuments({ documents }: Props) {
         { title: 'Pending', href: '/registrar/documents/pending' },
     ];
 
+    const verifyDocument = (documentId: number) => {
+        if (confirm('Are you sure you want to verify this document?')) {
+            router.post(`/registrar/documents/${documentId}/verify`);
+        }
+    };
+
+    const rejectDocument = (documentId: number) => {
+        const reason = prompt('Please enter the reason for rejection:');
+        if (reason) {
+            router.post(`/registrar/documents/${documentId}/reject`, {
+                notes: reason,
+            });
+        }
+    };
+
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Pending Documents" />
             <div className="px-4 py-6">
                 <h1 className="mb-4 text-2xl font-bold">Pending Documents</h1>
-                <div className="rounded bg-yellow-50 p-4 text-yellow-800">TODO: UI implementation pending</div>
-                <pre className="mt-4 overflow-auto rounded bg-gray-100 p-4">{JSON.stringify({ documents }, null, 2)}</pre>
+                <div className="rounded-lg border">
+                    <table className="min-w-full divide-y divide-gray-200">
+                        <thead className="bg-gray-50">
+                            <tr>
+                                <th scope="col" className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                                    Student
+                                </th>
+                                <th scope="col" className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                                    Document Type
+                                </th>
+                                <th scope="col" className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase">
+                                    Upload Date
+                                </th>
+                                <th scope="col" className="relative px-6 py-3">
+                                    <span className="sr-only">Actions</span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-200 bg-white">
+                            {documents.data.length > 0 ? (
+                                documents.data.map((document) => (
+                                    <tr key={document.id}>
+                                        <td className="px-6 py-4 whitespace-nowrap">
+                                            <div className="text-sm font-medium text-gray-900">
+                                                {document.student?.first_name} {document.student?.last_name}
+                                            </div>
+                                            <div className="text-sm text-gray-500">{document.student?.student_id}</div>
+                                        </td>
+                                        <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500">{document.document_type}</td>
+                                        <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500">
+                                            {new Date(document.upload_date).toLocaleDateString()}
+                                        </td>
+                                        <td className="px-6 py-4 text-right text-sm font-medium whitespace-nowrap">
+                                            <button onClick={() => verifyDocument(document.id)} className="text-indigo-600 hover:text-indigo-900">
+                                                Verify
+                                            </button>
+                                            <button onClick={() => rejectDocument(document.id)} className="ml-4 text-red-600 hover:text-red-900">
+                                                Reject
+                                            </button>
+                                        </td>
+                                    </tr>
+                                ))
+                            ) : (
+                                <tr>
+                                    <td colSpan={4} className="py-12 text-center">
+                                        <h3 className="text-lg font-medium text-gray-900">No pending documents</h3>
+                                        <p className="mt-1 text-sm text-gray-500">There are no documents to verify at this time.</p>
+                                    </td>
+                                </tr>
+                            )}
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </AppLayout>
     );


### PR DESCRIPTION
This commit introduces several UI improvements and features:

- **Pending Documents Page:** Replaces the JSON output on the registrars pending documents page with a functional UI. Registrars can now view, verify, and reject documents directly from the table.
- **Registrar Dashboard:** Updates the quick actions on the registrars dashboard, replacing "Generate Reports" with a more relevant "Pending Documents" link.
