### PR TITLE
feat: setup Resend email service for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,10 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="admissions@cbhlc.edu.ph"
 MAIL_FROM_NAME="CBHLC Admissions"
 
+# Resend API Key (for production email delivery)
+# Get your API key from: https://resend.com/api-keys
+RESEND_API_KEY=
+
 # School Configuration
 SCHOOL_CONTACT_PHONE="+63 123 456 7890"
 SCHOOL_CONTACT_EMAIL="${MAIL_FROM_ADDRESS}"

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "laravel/telescope": "^5.12",
         "laravel/tinker": "^2.10.1",
         "laravel/wayfinder": "^0.1.9",
+        "resend/resend-laravel": "^0.23.0",
         "spatie/laravel-activitylog": "^4.10",
         "spatie/laravel-permission": "^6.21"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "570515020e5257327a51d1f1f2472e7e",
+    "content-hash": "aaae60f669a0779f331e6ca68c22ef0d",
     "packages": [
         {
             "name": "brick/math",
@@ -3596,6 +3596,132 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.1"
             },
             "time": "2025-09-04T20:59:21+00:00"
+        },
+        {
+            "name": "resend/resend-laravel",
+            "version": "v0.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/resend/resend-laravel.git",
+                "reference": "a40ee95d5976eaf79e594a1f793d3e7c8648c66c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/resend/resend-laravel/zipball/a40ee95d5976eaf79e594a1f793d3e7c8648c66c",
+                "reference": "a40ee95d5976eaf79e594a1f793d3e7c8648c66c",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": "^8.1",
+                "resend/resend-php": "^0.21.0",
+                "symfony/mailer": "^6.2|^7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^8.17|^9.0|^10.0",
+                "pestphp/pest": "^2.0|^3.7"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Resend\\Laravel\\ResendServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Resend\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Resend and contributors",
+                    "homepage": "https://github.com/resend/resend-laravel/contributors"
+                }
+            ],
+            "description": "Resend for Laravel",
+            "homepage": "https://resend.com/",
+            "keywords": [
+                "api",
+                "client",
+                "laravel",
+                "php",
+                "resend",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/resend/resend-laravel/issues",
+                "source": "https://github.com/resend/resend-laravel/tree/v0.23.0"
+            },
+            "time": "2025-10-11T04:19:52+00:00"
+        },
+        {
+            "name": "resend/resend-php",
+            "version": "v0.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/resend/resend-php.git",
+                "reference": "16d481c8347d2b2aa9910ca0ae7f252b2f7d8b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/resend/resend-php/zipball/16d481c8347d2b2aa9910ca0ae7f252b2f7d8b8c",
+                "reference": "16d481c8347d2b2aa9910ca0ae7f252b2f7d8b8c",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.5",
+                "php": "^8.1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.13",
+                "mockery/mockery": "^1.6",
+                "pestphp/pest": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resend.php"
+                ],
+                "psr-4": {
+                    "Resend\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Resend and contributors",
+                    "homepage": "https://github.com/resend/resend-php/contributors"
+                }
+            ],
+            "description": "Resend PHP library.",
+            "homepage": "https://resend.com/",
+            "keywords": [
+                "api",
+                "client",
+                "php",
+                "resend",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/resend/resend-php/issues",
+                "source": "https://github.com/resend/resend-php/tree/v0.21.0"
+            },
+            "time": "2025-09-24T05:02:03+00:00"
         },
         {
             "name": "spatie/laravel-activitylog",


### PR DESCRIPTION
## Summary
Sets up Resend email service for sending transactional emails in production.

## Changes
- Install `resend/resend-laravel` package via Composer
- Add `RESEND_API_KEY` configuration to `.env.example` with documentation

## Configuration Required After Merge

### Local Development
No changes needed - emails will continue using Mailpit for testing.

### Production Server
After merging, update the production `.env` file on the server:

```bash
MAIL_MAILER=resend
MAIL_FROM_ADDRESS="noreply@cbhlc.com"
MAIL_FROM_NAME="CBHLC"
RESEND_API_KEY=your_actual_api_key_here
```

## DNS Configuration Required

To verify the domain and send emails, add these DNS records to Namecheap:

### 1. Add Domain to Resend
1. Go to https://resend.com/domains
2. Add `cbhlc.com` as a domain
3. Copy the DNS records provided

### 2. Add DNS Records to Namecheap
In Namecheap → cbhlc.com → Advanced DNS, add:

**SPF Record (TXT)**
- Type: TXT Record
- Host: `@`
- Value: `v=spf1 include:amazonses.com ~all`
- TTL: Automatic

**DKIM Record (TXT)**
- Type: TXT Record
- Host: `resend._domainkey`
- Value: Copy from Resend dashboard (starts with `p=`)
- TTL: Automatic

**MX Record (Optional)**
- Type: MX Record
- Host: `@`
- Value: Copy from Resend dashboard
- Priority: 10
- TTL: Automatic

### 3. Verify Domain
- Wait 5-30 minutes for DNS propagation
- Go back to Resend dashboard and click "Verify Domain"

## Testing
After domain verification, test email sending:
```bash
php artisan tinker
Mail::raw('Test email', fn($m) => $m->to('your-email@example.com')->subject('Test'));
```

## Related Documentation
- [Resend Laravel Docs](https://resend.com/docs/send-with-laravel)
- [Resend Namecheap DNS Guide](https://resend.com/docs/knowledge-base/namecheap)

Closes #N/A