### PR TITLE
feat: implement guardian student detail page

### DIFF
--- a/resources/js/pages/guardian/students/show.tsx
+++ b/resources/js/pages/guardian/students/show.tsx
@@ -1,20 +1,278 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
-import { Head } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
+import { Calendar, Edit, GraduationCap, Mail, MapPin, Phone, User } from 'lucide-react';
 
-export default function GuardianStudentsShow(props: unknown) {
+interface Enrollment {
+    id: number;
+    school_year: string;
+    grade_level: string;
+    quarter: string;
+    status: string;
+    payment_status: string;
+    created_at: string;
+}
+
+interface Student {
+    id: number;
+    student_id: string;
+    first_name: string;
+    middle_name: string;
+    last_name: string;
+    birthdate: string;
+    gender: string;
+    address: string;
+    contact_number: string;
+    email: string;
+    grade_level: string;
+    section: string | null;
+    enrollments: Enrollment[];
+}
+
+interface Props {
+    student: Student;
+}
+
+const statusColors = {
+    pending: 'secondary',
+    enrolled: 'default',
+    rejected: 'destructive',
+    completed: 'outline',
+} as const;
+
+const paymentStatusColors = {
+    pending: 'secondary',
+    partial: 'outline',
+    paid: 'default',
+    overdue: 'destructive',
+} as const;
+
+export default function GuardianStudentsShow({ student }: Props) {
     const breadcrumbs: BreadcrumbItem[] = [
         { title: 'Guardian', href: '/guardian/dashboard' },
         { title: 'Students', href: '/guardian/students' },
-        { title: 'Details', href: '#' },
+        { title: `${student.first_name} ${student.last_name}`, href: `/guardian/students/${student.id}` },
     ];
+
+    const fullName = `${student.first_name} ${student.middle_name ? student.middle_name + ' ' : ''}${student.last_name}`;
 
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
-            <Head title="Students Show" />
+            <Head title={fullName} />
             <div className="px-4 py-6">
-                <h1 className="mb-4 text-2xl font-bold">Students Show</h1>
-                <pre className="overflow-auto rounded bg-gray-100 p-4">{JSON.stringify(props, null, 2)}</pre>
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold">{fullName}</h1>
+                        <p className="text-muted-foreground">Student ID: {student.student_id}</p>
+                    </div>
+                    <Link href={`/guardian/students/${student.id}/edit`}>
+                        <Button>
+                            <Edit className="mr-2 h-4 w-4" />
+                            Edit Information
+                        </Button>
+                    </Link>
+                </div>
+
+                <div className="grid gap-6 md:grid-cols-2">
+                    {/* Personal Information Card */}
+                    <Card>
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2">
+                                <User className="h-5 w-5" />
+                                Personal Information
+                            </CardTitle>
+                            <CardDescription>Basic student details</CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="grid gap-3">
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-muted-foreground">Full Name:</span>
+                                    <span className="font-semibold">{fullName}</span>
+                                </div>
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-muted-foreground">Student ID:</span>
+                                    <span className="font-semibold">{student.student_id}</span>
+                                </div>
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-muted-foreground">Birthdate:</span>
+                                    <span className="font-semibold">
+                                        {student.birthdate
+                                            ? new Date(student.birthdate).toLocaleDateString('en-US', {
+                                                  year: 'numeric',
+                                                  month: 'long',
+                                                  day: 'numeric',
+                                              })
+                                            : 'N/A'}
+                                    </span>
+                                </div>
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-muted-foreground">Gender:</span>
+                                    <span className="font-semibold capitalize">{student.gender || 'N/A'}</span>
+                                </div>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Academic Information Card */}
+                    <Card>
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2">
+                                <GraduationCap className="h-5 w-5" />
+                                Academic Information
+                            </CardTitle>
+                            <CardDescription>Current academic status</CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="grid gap-3">
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-muted-foreground">Current Grade:</span>
+                                    <span className="font-semibold">{student.grade_level || 'Not enrolled'}</span>
+                                </div>
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-muted-foreground">Section:</span>
+                                    <span className="font-semibold">{student.section || 'Not assigned'}</span>
+                                </div>
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-muted-foreground">Total Enrollments:</span>
+                                    <span className="font-semibold">{student.enrollments.length}</span>
+                                </div>
+                            </div>
+
+                            <div className="mt-4 border-t pt-4">
+                                <Link href={`/guardian/enrollments/create?student_id=${student.id}`}>
+                                    <Button className="w-full">
+                                        <Calendar className="mr-2 h-4 w-4" />
+                                        Enroll for New School Year
+                                    </Button>
+                                </Link>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    {/* Contact Information Card */}
+                    <Card>
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2">
+                                <Phone className="h-5 w-5" />
+                                Contact Information
+                            </CardTitle>
+                            <CardDescription>How to reach this student</CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <div className="grid gap-3">
+                                {student.contact_number && (
+                                    <div className="flex items-start gap-2">
+                                        <Phone className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                                        <div className="flex-1">
+                                            <p className="text-sm font-medium text-muted-foreground">Phone Number</p>
+                                            <p className="font-semibold">{student.contact_number}</p>
+                                        </div>
+                                    </div>
+                                )}
+                                {student.email && (
+                                    <div className="flex items-start gap-2">
+                                        <Mail className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                                        <div className="flex-1">
+                                            <p className="text-sm font-medium text-muted-foreground">Email Address</p>
+                                            <p className="font-semibold">{student.email}</p>
+                                        </div>
+                                    </div>
+                                )}
+                                {student.address && (
+                                    <div className="flex items-start gap-2">
+                                        <MapPin className="mt-0.5 h-4 w-4 text-muted-foreground" />
+                                        <div className="flex-1">
+                                            <p className="text-sm font-medium text-muted-foreground">Home Address</p>
+                                            <p className="font-semibold">{student.address}</p>
+                                        </div>
+                                    </div>
+                                )}
+                                {!student.contact_number && !student.email && !student.address && (
+                                    <p className="py-4 text-center text-sm text-muted-foreground">No contact information available</p>
+                                )}
+                            </div>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                {/* Enrollment History */}
+                <Card className="mt-6">
+                    <CardHeader>
+                        <CardTitle>Enrollment History</CardTitle>
+                        <CardDescription>Past and current enrollment records for {student.first_name}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                        {student.enrollments.length > 0 ? (
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>School Year</TableHead>
+                                        <TableHead>Grade Level</TableHead>
+                                        <TableHead>Quarter</TableHead>
+                                        <TableHead>Status</TableHead>
+                                        <TableHead>Payment Status</TableHead>
+                                        <TableHead>Date Enrolled</TableHead>
+                                        <TableHead className="text-right">Actions</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {student.enrollments.map((enrollment) => (
+                                        <TableRow key={enrollment.id}>
+                                            <TableCell className="font-medium">{enrollment.school_year}</TableCell>
+                                            <TableCell>{enrollment.grade_level}</TableCell>
+                                            <TableCell>{enrollment.quarter}</TableCell>
+                                            <TableCell>
+                                                <Badge variant={statusColors[enrollment.status as keyof typeof statusColors] || 'default'}>
+                                                    {enrollment.status}
+                                                </Badge>
+                                            </TableCell>
+                                            <TableCell>
+                                                <Badge
+                                                    variant={
+                                                        paymentStatusColors[enrollment.payment_status as keyof typeof paymentStatusColors] ||
+                                                        'default'
+                                                    }
+                                                >
+                                                    {enrollment.payment_status}
+                                                </Badge>
+                                            </TableCell>
+                                            <TableCell>
+                                                {new Date(enrollment.created_at).toLocaleDateString('en-US', {
+                                                    year: 'numeric',
+                                                    month: 'short',
+                                                    day: 'numeric',
+                                                })}
+                                            </TableCell>
+                                            <TableCell className="text-right">
+                                                <Link href={`/guardian/enrollments/${enrollment.id}`}>
+                                                    <Button size="sm" variant="outline">
+                                                        View Details
+                                                    </Button>
+                                                </Link>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        ) : (
+                            <div className="flex flex-col items-center justify-center py-12 text-center">
+                                <GraduationCap className="mb-4 h-12 w-12 text-muted-foreground" />
+                                <p className="mb-2 text-lg font-semibold">No Enrollment History</p>
+                                <p className="mb-4 text-sm text-muted-foreground">This student has not been enrolled yet</p>
+                                <Link href={`/guardian/enrollments/create?student_id=${student.id}`}>
+                                    <Button>
+                                        <Calendar className="mr-2 h-4 w-4" />
+                                        Create First Enrollment
+                                    </Button>
+                                </Link>
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
             </div>
         </AppLayout>
     );


### PR DESCRIPTION
## Summary
Implements complete UI for guardian student detail page, replacing JSON dump placeholder.

## Changes
- **Personal Information Card**: Displays student name, ID, birthdate, and gender
- **Academic Information Card**: Shows current grade, section, and total enrollments with "Enroll for New School Year" button
- **Contact Information Card**: Lists phone, email, and address with conditional rendering
- **Enrollment History Table**: Displays all enrollments with status badges and "View Details" actions
- **Empty State**: Helpful message and action button for students without enrollment history
- **Edit Button**: Header button linking to student edit page

## Technical Details
- Uses shadcn/ui components (Card, Table, Badge, Button)
- TypeScript interfaces for Student and Enrollment
- Status color mappings for enrollment and payment statuses
- Responsive grid layout (2 columns on desktop)
- Proper date formatting for birthdate and enrollment dates
- Pre-fills student ID in enrollment creation link

## Test Plan
- [x] Verify student information displays correctly
- [x] Check enrollment history table shows all enrollments
- [x] Confirm status badges use correct colors
- [x] Test empty state for students without enrollments
- [x] Verify edit button navigates to edit page
- [x] Test "Enroll for New School Year" button with pre-filled student ID
- [x] Check responsive layout on mobile

Fixes: http://localhost:8080/guardian/students/11 showing only JSON