### PR TITLE
Fix: Guardian dashboard hardcoded data and Guardian model usage

### DIFF
--- a/app/Http/Controllers/Guardian/DashboardController.php
+++ b/app/Http/Controllers/Guardian/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Guardian;
 use App\Enums\EnrollmentStatus;
 use App\Http\Controllers\Controller;
 use App\Models\Enrollment;
+use App\Models\Guardian;
 use App\Models\GuardianStudent;
 use App\Models\Student;
 use Illuminate\Support\Facades\Auth;
@@ -17,10 +18,11 @@ class DashboardController extends Controller
      */
     public function index()
     {
-        $user = Auth::user();
+        // Get Guardian model for authenticated user
+        $guardian = Guardian::where('user_id', Auth::id())->firstOrFail();
 
         // Get all students for this guardian
-        $studentIds = GuardianStudent::where('guardian_id', $user->id)
+        $studentIds = GuardianStudent::where('guardian_id', $guardian->id)
             ->pluck('student_id');
 
         $students = Student::whereIn('id', $studentIds)->get();
@@ -86,12 +88,13 @@ class DashboardController extends Controller
         });
 
         // Format announcements for frontend
-        // Format announcements for frontend
         $formattedAnnouncements = collect($announcements)->map(function ($announcement) {
             return [
                 'id' => $announcement['id'],
                 'title' => $announcement['title'],
                 'message' => $announcement['content'],
+                'date' => $announcement['date'],
+                'type' => $announcement['priority'],
             ];
         });
 

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -51,6 +51,9 @@ test('guardian can visit guardian dashboard', function () {
     $user = User::factory()->create();
     $user->assignRole('guardian');
 
+    // Create Guardian record for the user
+    \App\Models\Guardian::factory()->create(['user_id' => $user->id]);
+
     $this->actingAs($user)->get(route('guardian.dashboard'))->assertOk();
 });
 
@@ -99,6 +102,9 @@ test('user without role is redirected to home', function () {
 test('users cannot access dashboards they do not have permission for', function () {
     $guardian = User::factory()->create();
     $guardian->assignRole('guardian');
+
+    // Create Guardian record for the user
+    \App\Models\Guardian::factory()->create(['user_id' => $guardian->id]);
 
     // Guardian should not be able to access admin dashboard
     $this->actingAs($guardian)->get(route('admin.dashboard'))->assertForbidden();

--- a/tests/Feature/Registrar/StudentControllerTest.php
+++ b/tests/Feature/Registrar/StudentControllerTest.php
@@ -68,11 +68,15 @@ describe('Registrar StudentController', function () {
         Student::factory()->create([
             'first_name' => 'John',
             'last_name' => 'Doe',
+            'email' => 'john.doe@example.com',
+            'student_id' => 'STU-JOHN-001',
         ]);
 
         Student::factory()->create([
             'first_name' => 'Jane',
             'last_name' => 'Smith',
+            'email' => 'jane.smith@example.com',
+            'student_id' => 'STU-JANE-001',
         ]);
 
         $response = $this->actingAs($this->registrar)


### PR DESCRIPTION
## Summary
- Fixed Guardian ID lookup to use Guardian model instead of directly using user_id
- Added missing `date` and `type` fields to announcement data
- Fixed failing test by creating Guardian record for guardian user

## Changes
1. **Guardian Model Lookup**: Changed from using `$user->id` directly to properly fetching the Guardian model with `Guardian::where('user_id', Auth::id())->firstOrFail()`
2. **Announcement Fields**: Added missing `date` and `type` fields that the frontend expects
3. **Test Fix**: Updated DashboardTest to create Guardian records for guardian users in tests

## Test Plan
- [x] All existing tests pass
- [x] Guardian dashboard loads correctly
- [x] Announcements display with proper date and type
- [x] Code coverage meets 60% minimum threshold