### PR TITLE
Ticket 006: Official Payment Receipt PDF Download

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Guardian;
+use App\Models\GuardianStudent;
+use App\Models\Payment;
+use Barryvdh\DomPDF\Facade\Pdf;
+
+class PaymentController extends Controller
+{
+    /**
+     * Download official receipt for a payment
+     */
+    public function downloadReceipt(Payment $payment)
+    {
+        $user = auth()->user();
+
+        // Authorization: Admin or guardian who owns the student
+        if (! $user->hasRole(['super_admin', 'administrator', 'registrar'])) {
+            // Guardian must own the student
+            $guardian = Guardian::where('user_id', $user->id)->first();
+            if (! $guardian) {
+                abort(404);
+            }
+
+            $enrollment = $payment->invoice; // invoice_id is enrollment_id
+            $hasAccess = GuardianStudent::where('guardian_id', $guardian->id)
+                ->where('student_id', $enrollment->student_id)
+                ->exists();
+
+            if (! $hasAccess) {
+                abort(404);
+            }
+        }
+
+        $payment->load(['invoice.student', 'processedBy']);
+
+        // Generate receipt number if not exists
+        if (! $payment->receipt_number) {
+            $payment->receipt_number = $this->generateReceiptNumber($payment);
+            $payment->save();
+        }
+
+        $pdf = Pdf::loadView('pdf.payment-receipt', [
+            'payment' => $payment,
+        ])
+            ->setPaper('a4', 'portrait');
+
+        $filename = "receipt-{$payment->receipt_number}-{$payment->payment_date->format('Ymd')}.pdf";
+
+        return $pdf->download($filename);
+    }
+
+    /**
+     * Generate unique receipt number
+     */
+    private function generateReceiptNumber(Payment $payment): string
+    {
+        $year = $payment->payment_date->format('Y');
+        $month = $payment->payment_date->format('m');
+
+        // Format: OR-YYYYMM-####
+        $lastReceipt = Payment::whereYear('payment_date', $year)
+            ->whereMonth('payment_date', $month)
+            ->whereNotNull('receipt_number')
+            ->orderBy('receipt_number', 'desc')
+            ->first();
+
+        if ($lastReceipt && preg_match('/OR-\d{6}-(\d{4})/', $lastReceipt->receipt_number, $matches)) {
+            $nextNumber = intval($matches[1]) + 1;
+        } else {
+            $nextNumber = 1;
+        }
+
+        return sprintf('OR-%s%s-%04d', $year, $month, $nextNumber);
+    }
+}

--- a/database/migrations/2025_10_21_090452_add_receipt_number_to_payments_table.php
+++ b/database/migrations/2025_10_21_090452_add_receipt_number_to_payments_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            $table->string('receipt_number')->nullable()->unique()->after('reference_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('payments', function (Blueprint $table) {
+            $table->dropColumn('receipt_number');
+        });
+    }
+};

--- a/resources/views/pdf/payment-receipt.blade.php
+++ b/resources/views/pdf/payment-receipt.blade.php
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Official Receipt</title>
+    <style>
+        @page { margin: 0.5in; }
+        body {
+            font-family: Arial, sans-serif;
+            font-size: 12px;
+        }
+        .receipt-container {
+            border: 3px double #000;
+            padding: 30px;
+            max-width: 700px;
+            margin: 0 auto;
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 30px;
+            border-bottom: 2px solid #000;
+            padding-bottom: 20px;
+        }
+        .school-name {
+            font-size: 24px;
+            font-weight: bold;
+            margin: 10px 0;
+        }
+        .receipt-title {
+            font-size: 20px;
+            font-weight: bold;
+            margin: 15px 0;
+            text-transform: uppercase;
+        }
+        .receipt-number {
+            font-size: 14px;
+            color: #666;
+        }
+        .details-section {
+            margin: 20px 0;
+        }
+        .detail-row {
+            margin: 10px 0;
+            padding: 8px 0;
+        }
+        .detail-row strong {
+            display: inline-block;
+            width: 180px;
+        }
+        .amount-section {
+            margin: 30px 0;
+            padding: 20px;
+            background-color: #f9f9f9;
+            border: 2px solid #333;
+        }
+        .amount-row {
+            font-size: 18px;
+            font-weight: bold;
+            margin-top: 20px;
+            border-top: 1px solid #333;
+            padding-top: 15px;
+        }
+        .signature-section {
+            margin-top: 50px;
+            display: flex;
+            justify-content: space-between;
+        }
+        .signature-box {
+            width: 45%;
+            text-align: center;
+        }
+        .signature-line {
+            border-top: 2px solid #000;
+            margin-top: 40px;
+            padding-top: 10px;
+            font-weight: bold;
+        }
+        .footer {
+            margin-top: 40px;
+            text-align: center;
+            font-size: 10px;
+            font-style: italic;
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+    <div class="receipt-container">
+        <div class="header">
+            <div class="school-name">Christian Bible Heritage Learning Center</div>
+            <div>{{ config('app.school_address', 'Lantapan, Bukidnon') }}</div>
+            <div>{{ config('app.school_phone', '') }} | {{ config('app.school_email', 'cbhlc@example.com') }}</div>
+            <div class="receipt-title">Official Receipt</div>
+            <div class="receipt-number">Receipt No: {{ $payment->receipt_number }}</div>
+        </div>
+
+        <div class="details-section">
+            <div class="detail-row">
+                <strong>Date Issued:</strong>
+                <span>{{ $payment->payment_date->format('F d, Y') }}</span>
+            </div>
+            <div class="detail-row">
+                <strong>Received From:</strong>
+                <span>{{ $payment->invoice->guardian->first_name ?? '' }} {{ $payment->invoice->guardian->last_name ?? '' }}</span>
+            </div>
+            <div class="detail-row">
+                <strong>Student Name:</strong>
+                <span>{{ $payment->invoice->student->first_name }} {{ $payment->invoice->student->middle_name }} {{ $payment->invoice->student->last_name }}</span>
+            </div>
+            <div class="detail-row">
+                <strong>Student ID:</strong>
+                <span>{{ $payment->invoice->student->student_id }}</span>
+            </div>
+            <div class="detail-row">
+                <strong>Grade Level:</strong>
+                <span>{{ $payment->invoice->grade_level }}</span>
+            </div>
+            <div class="detail-row">
+                <strong>School Year:</strong>
+                <span>{{ $payment->invoice->school_year }}</span>
+            </div>
+            <div class="detail-row">
+                <strong>Enrollment ID:</strong>
+                <span>{{ $payment->invoice->enrollment_id }}</span>
+            </div>
+        </div>
+
+        <div class="amount-section">
+            <div class="detail-row">
+                <strong>Description:</strong>
+                <span>{{ $payment->notes ?? 'Tuition and School Fees Payment' }}</span>
+            </div>
+            <div class="detail-row">
+                <strong>Payment Method:</strong>
+                <span>{{ ucfirst(str_replace('_', ' ', $payment->payment_method)) }}</span>
+            </div>
+            @if($payment->reference_number)
+            <div class="detail-row">
+                <strong>Reference Number:</strong>
+                <span>{{ $payment->reference_number }}</span>
+            </div>
+            @endif
+            <div class="amount-row">
+                AMOUNT PAID: <span style="float: right;">₱{{ number_format($payment->amount, 2) }}</span>
+            </div>
+        </div>
+
+        <div class="signature-section">
+            <div class="signature-box">
+                <div class="signature-line">Received By</div>
+                <div style="margin-top: 5px;">
+                    {{ $payment->processedBy->name ?? 'Cashier' }}
+                </div>
+            </div>
+            <div class="signature-box">
+                <div class="signature-line">Date</div>
+                <div style="margin-top: 5px;">
+                    {{ $payment->payment_date->format('M d, Y') }}
+                </div>
+            </div>
+        </div>
+
+        <div class="footer">
+            This is a computer-generated official receipt.<br>
+            Please keep this for your records.<br>
+            Receipt No: {{ $payment->receipt_number }}
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,6 +92,9 @@ Route::middleware(['auth'])->group(function () {
     // Invoice Routes - Using resource controller (only index and show actions)
     Route::resource('invoices', InvoiceController::class)->only(['index', 'show']);
 
+    // Payment Routes
+    Route::get('/payments/{payment}/receipt', [\App\Http\Controllers\PaymentController::class, 'downloadReceipt'])->name('payments.receipt');
+
     // Tuition Routes
     Route::get('/tuition', [TuitionController::class, 'index'])->name('tuition');
 


### PR DESCRIPTION
## Summary
Adds functionality for guardians and admins to download individual official receipts for each payment transaction.

## Changes
- **Backend:**
  - Created PaymentController with downloadReceipt method
  - Added receipt_number field to payments table (migration)
  - Auto-generates unique receipt numbers: OR-YYYYMM-#### format
  - Authorization for both guardians (own students) and admins

- **PDF Template:**
  - Professional official receipt format
  - Double border design
  - School branding and details
  - Payment information with reference numbers
  - Signature section for received by and date

- **Routes:**
  - Added: GET /payments/{payment}/receipt (shared route)

## Features
- Automatic receipt number generation on first download
- Sequential numbering per month (resets each month)
- Professional receipt format suitable for records
- Includes all payment details and student information
- Cashier/processed by information
- Date and receipt number footer

## Security
- Guardians can only access receipts for their own students
- Admins have full access to all receipts
- Returns 404 for unauthorized access

## Dependencies
- Depends on DomPDF package (installed in ticket 005)

Implements ticket 006