### PR TITLE
Ticket 007: Automated Payment Reminder System

### DIFF
--- a/app/Console/Commands/SendPaymentReminders.php
+++ b/app/Console/Commands/SendPaymentReminders.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\EnrollmentStatus;
+use App\Mail\PaymentOverdueNotice;
+use App\Mail\PaymentReminder;
+use App\Models\Enrollment;
+use App\Models\PaymentReminder as PaymentReminderModel;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+
+class SendPaymentReminders extends Command
+{
+    protected $signature = 'enrollment:send-payment-reminders {--dry-run : Run without sending emails}';
+
+    protected $description = 'Send payment reminder emails for upcoming and overdue payments';
+
+    public function handle()
+    {
+        $dryRun = $this->option('dry-run');
+
+        if (! $this->isReminderEnabled()) {
+            $this->info('Payment reminders are disabled in settings.');
+
+            return 0;
+        }
+
+        $today = now()->startOfDay();
+
+        // Find enrollments with outstanding balance
+        $enrollments = Enrollment::with(['student', 'guardian.user'])
+            ->where('status', EnrollmentStatus::ENROLLED)
+            ->where('balance_cents', '>', 0)
+            ->whereNotNull('payment_due_date')
+            ->get();
+
+        $this->info("Found {$enrollments->count()} enrollments with outstanding balance.");
+
+        $sent = 0;
+
+        foreach ($enrollments as $enrollment) {
+            $dueDate = $enrollment->payment_due_date;
+            $daysUntilDue = $today->diffInDays($dueDate, false);
+
+            $reminderType = $this->determineReminderType($daysUntilDue);
+
+            if (! $reminderType) {
+                continue; // No reminder needed for this enrollment today
+            }
+
+            // Check if reminder already sent
+            if ($this->reminderAlreadySent($enrollment->id, $reminderType)) {
+                continue;
+            }
+
+            if ($dryRun) {
+                $this->line("Would send {$reminderType} reminder for enrollment {$enrollment->enrollment_id}");
+                $sent++;
+                continue;
+            }
+
+            // Send reminder
+            $this->sendReminder($enrollment, $reminderType, $daysUntilDue);
+            $sent++;
+        }
+
+        $this->info("Sent {$sent} payment reminders.");
+
+        return 0;
+    }
+
+    private function isReminderEnabled(): bool
+    {
+        return DB::table('settings')
+            ->where('key', 'payment_reminders_enabled')
+            ->value('value') !== '0';
+    }
+
+    private function determineReminderType(int $daysUntilDue): ?string
+    {
+        return match (true) {
+            $daysUntilDue === 7 => 'upcoming_7days',
+            $daysUntilDue === 3 => 'upcoming_3days',
+            $daysUntilDue === 1 => 'upcoming_1day',
+            $daysUntilDue === 0 => 'overdue',
+            $daysUntilDue === -7 => 'overdue_7days',
+            $daysUntilDue === -30 => 'overdue_30days',
+            default => null,
+        };
+    }
+
+    private function reminderAlreadySent(int $enrollmentId, string $reminderType): bool
+    {
+        return PaymentReminderModel::where('enrollment_id', $enrollmentId)
+            ->where('reminder_type', $reminderType)
+            ->whereDate('sent_at', today())
+            ->exists();
+    }
+
+    private function sendReminder(Enrollment $enrollment, string $reminderType, int $daysUntilDue): void
+    {
+        $guardianEmail = $enrollment->guardian?->user?->email;
+
+        if (! $guardianEmail) {
+            $this->warn("No email for enrollment {$enrollment->enrollment_id}");
+
+            return;
+        }
+
+        if (str_contains($reminderType, 'overdue')) {
+            Mail::to($guardianEmail)->queue(new PaymentOverdueNotice($enrollment, abs($daysUntilDue)));
+        } else {
+            Mail::to($guardianEmail)->queue(new PaymentReminder($enrollment, $daysUntilDue));
+        }
+
+        // Record reminder sent
+        PaymentReminderModel::create([
+            'enrollment_id' => $enrollment->id,
+            'reminder_type' => $reminderType,
+            'sent_at' => now(),
+        ]);
+
+        $this->line("Sent {$reminderType} reminder to {$guardianEmail}");
+    }
+}

--- a/app/Console/Commands/SendPaymentReminders.php
+++ b/app/Console/Commands/SendPaymentReminders.php
@@ -42,7 +42,7 @@ class SendPaymentReminders extends Command
 
         foreach ($enrollments as $enrollment) {
             $dueDate = $enrollment->payment_due_date;
-            $daysUntilDue = $today->diffInDays($dueDate, false);
+            $daysUntilDue = (int) $today->diffInDays($dueDate, false);
 
             $reminderType = $this->determineReminderType($daysUntilDue);
 

--- a/app/Mail/PaymentOverdueNotice.php
+++ b/app/Mail/PaymentOverdueNotice.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Enrollment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PaymentOverdueNotice extends Mailable implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public Enrollment $enrollment,
+        public int $daysOverdue
+    ) {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Payment Overdue Notice - Christian Bible Heritage Learning Center',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.payment-overdue',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Mail/PaymentReminder.php
+++ b/app/Mail/PaymentReminder.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Enrollment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class PaymentReminder extends Mailable implements ShouldQueue
+{
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new message instance.
+     */
+    public function __construct(
+        public Enrollment $enrollment,
+        public int $daysUntilDue
+    ) {
+        //
+    }
+
+    /**
+     * Get the message envelope.
+     */
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Payment Reminder - Christian Bible Heritage Learning Center',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     */
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.payment-reminder',
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/PaymentReminder.php
+++ b/app/Models/PaymentReminder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PaymentReminder extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'enrollment_id',
+        'reminder_type',
+        'sent_at',
+        'email_opened_at',
+    ];
+
+    protected $casts = [
+        'sent_at' => 'datetime',
+        'email_opened_at' => 'datetime',
+    ];
+
+    public function enrollment(): BelongsTo
+    {
+        return $this->belongsTo(Enrollment::class);
+    }
+}

--- a/database/migrations/2025_10_21_094118_create_payment_reminders_table.php
+++ b/database/migrations/2025_10_21_094118_create_payment_reminders_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('payment_reminders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('enrollment_id')->constrained()->onDelete('cascade');
+            $table->enum('reminder_type', [
+                'upcoming_7days',
+                'upcoming_3days',
+                'upcoming_1day',
+                'overdue',
+                'overdue_7days',
+                'overdue_30days',
+            ]);
+            $table->timestamp('sent_at');
+            $table->timestamp('email_opened_at')->nullable();
+            $table->index(['enrollment_id', 'reminder_type']);
+            $table->index('sent_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_reminders');
+    }
+};

--- a/resources/views/emails/payment-overdue.blade.php
+++ b/resources/views/emails/payment-overdue.blade.php
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            background-color: #DC2626;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .content {
+            padding: 30px 20px;
+            background-color: #f9f9f9;
+        }
+        .alert {
+            background-color: #FEE2E2;
+            border-left: 4px solid #DC2626;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .details {
+            background-color: white;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 5px;
+        }
+        .details table {
+            width: 100%;
+        }
+        .details td {
+            padding: 8px 0;
+        }
+        .details td:first-child {
+            font-weight: bold;
+            width: 40%;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 30px;
+            background-color: #DC2626;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
+        .footer {
+            text-align: center;
+            padding: 20px;
+            color: #666;
+            font-size: 12px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Payment Overdue Notice</h1>
+        </div>
+
+        <div class="content">
+            <p>Dear {{ $enrollment->guardian->first_name ?? 'Guardian' }},</p>
+
+            <div class="alert">
+                <strong>URGENT: Payment {{ $daysOverdue }} {{ Str::plural('day', $daysOverdue) }} Overdue</strong>
+            </div>
+
+            <p>This is an important notice regarding an overdue payment for your child's enrollment at Christian Bible Heritage Learning Center.</p>
+
+            <div class="details">
+                <h3>Enrollment Details</h3>
+                <table>
+                    <tr>
+                        <td>Student Name:</td>
+                        <td>{{ $enrollment->student->first_name }} {{ $enrollment->student->last_name }}</td>
+                    </tr>
+                    <tr>
+                        <td>Grade Level:</td>
+                        <td>{{ $enrollment->grade_level }}</td>
+                    </tr>
+                    <tr>
+                        <td>School Year:</td>
+                        <td>{{ $enrollment->school_year }}</td>
+                    </tr>
+                    <tr>
+                        <td>Original Due Date:</td>
+                        <td>{{ $enrollment->payment_due_date->format('F d, Y') }}</td>
+                    </tr>
+                    <tr>
+                        <td>Days Overdue:</td>
+                        <td><strong style="color: #DC2626;">{{ $daysOverdue }} {{ Str::plural('day', $daysOverdue) }}</strong></td>
+                    </tr>
+                    <tr>
+                        <td>Outstanding Amount:</td>
+                        <td><strong style="color: #DC2626;">₱{{ number_format($enrollment->balance, 2) }}</strong></td>
+                    </tr>
+                </table>
+            </div>
+
+            <p><strong>Please settle this payment as soon as possible to avoid any disruption to your child's enrollment.</strong></p>
+
+            <center>
+                <a href="{{ url('/guardian/enrollments/' . $enrollment->id) }}" class="button">Pay Now</a>
+            </center>
+
+            <p>If you have already made this payment, please disregard this notice. If you need to discuss payment arrangements, please contact our office immediately.</p>
+
+            <p><strong>Contact Information:</strong></p>
+            <ul>
+                <li>Phone: {{ config('app.school_phone', 'Contact school office') }}</li>
+                <li>Email: {{ config('app.school_email', 'Contact school office') }}</li>
+                <li>Office Hours: Monday - Friday, 8:00 AM - 5:00 PM</li>
+            </ul>
+
+            <p>Thank you for your immediate attention to this matter.</p>
+
+            <p>
+                Sincerely,<br>
+                <strong>Christian Bible Heritage Learning Center</strong><br>
+                Cashier's Office
+            </p>
+        </div>
+
+        <div class="footer">
+            <p>This is an automated message. Please do not reply to this email.</p>
+            <p>Christian Bible Heritage Learning Center</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/emails/payment-reminder.blade.php
+++ b/resources/views/emails/payment-reminder.blade.php
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+        }
+        .container {
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .header {
+            background-color: #4F46E5;
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }
+        .content {
+            padding: 30px 20px;
+            background-color: #f9f9f9;
+        }
+        .highlight {
+            background-color: #FEF3C7;
+            border-left: 4px solid #F59E0B;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .details {
+            background-color: white;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 5px;
+        }
+        .details table {
+            width: 100%;
+        }
+        .details td {
+            padding: 8px 0;
+        }
+        .details td:first-child {
+            font-weight: bold;
+            width: 40%;
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 30px;
+            background-color: #4F46E5;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
+        .footer {
+            text-align: center;
+            padding: 20px;
+            color: #666;
+            font-size: 12px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Payment Reminder</h1>
+        </div>
+
+        <div class="content">
+            <p>Dear {{ $enrollment->guardian->first_name ?? 'Guardian' }},</p>
+
+            <div class="highlight">
+                <strong>Payment Due in {{ $daysUntilDue }} {{ Str::plural('day', $daysUntilDue) }}</strong>
+            </div>
+
+            <p>This is a friendly reminder that a payment for your child's enrollment is due soon.</p>
+
+            <div class="details">
+                <h3>Enrollment Details</h3>
+                <table>
+                    <tr>
+                        <td>Student Name:</td>
+                        <td>{{ $enrollment->student->first_name }} {{ $enrollment->student->last_name }}</td>
+                    </tr>
+                    <tr>
+                        <td>Grade Level:</td>
+                        <td>{{ $enrollment->grade_level }}</td>
+                    </tr>
+                    <tr>
+                        <td>School Year:</td>
+                        <td>{{ $enrollment->school_year }}</td>
+                    </tr>
+                    <tr>
+                        <td>Payment Due Date:</td>
+                        <td>{{ $enrollment->payment_due_date->format('F d, Y') }}</td>
+                    </tr>
+                    <tr>
+                        <td>Amount Due:</td>
+                        <td><strong>₱{{ number_format($enrollment->balance, 2) }}</strong></td>
+                    </tr>
+                </table>
+            </div>
+
+            <p>Please ensure your payment is made on or before the due date to avoid any inconvenience.</p>
+
+            <center>
+                <a href="{{ url('/guardian/enrollments/' . $enrollment->id) }}" class="button">View Enrollment Details</a>
+            </center>
+
+            <p>If you have any questions or concerns, please don't hesitate to contact our office.</p>
+
+            <p>Thank you for your cooperation.</p>
+
+            <p>
+                Best regards,<br>
+                <strong>Christian Bible Heritage Learning Center</strong>
+            </p>
+        </div>
+
+        <div class="footer">
+            <p>This is an automated message. Please do not reply to this email.</p>
+            <p>Christian Bible Heritage Learning Center</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/console.php
+++ b/routes/console.php
@@ -13,3 +13,10 @@ Schedule::command('enrollment-periods:update-status --notify')
     ->daily()
     ->at('00:00')
     ->timezone('Asia/Manila');
+
+// Payment reminder scheduler - runs daily at 8 AM
+Schedule::command('enrollment:send-payment-reminders')
+    ->dailyAt('08:00')
+    ->timezone('Asia/Manila')
+    ->withoutOverlapping()
+    ->onOneServer();


### PR DESCRIPTION
## Summary
Implements automated payment reminder emails for guardians with outstanding balances to help keep them on track with payment schedules.

## Changes
- **Database:**
  - Created payment_reminders table to track sent reminders
  - Supports reminder types: 7d/3d/1d before due, overdue, 7d/30d overdue

- **Backend:**
  - Created PaymentReminder model with enrollment relationship
  - Created SendPaymentReminders scheduled command
  - Added PaymentReminder and PaymentOverdueNotice mailable classes
  - Scheduled to run daily at 8 AM (Asia/Manila timezone)

- **Email Templates:**
  - Professional reminder email for upcoming payments
  - Urgent overdue notice email with red alert styling
  - Both templates include enrollment details and payment information

## Features
- Multiple reminder types based on days until/after due date
- Dry-run mode for testing: `php artisan enrollment:send-payment-reminders --dry-run`
- Prevents duplicate reminders (checks if already sent today)
- System setting for enabling/disabling reminders
- Queued emails for performance (implements ShouldQueue)
- One server lock to prevent duplicate execution
- Timezone aware (Asia/Manila)

## Command Usage
```bash
# Run manually
php artisan enrollment:send-payment-reminders

# Test mode (no emails sent)
php artisan enrollment:send-payment-reminders --dry-run
```

## Scheduled Execution
Runs automatically daily at 8:00 AM via Laravel scheduler

## Requirements
- Enrollments must have payment_due_date set
- Queue worker must be running for queued emails
- System setting 'payment_reminders_enabled' must not be '0'

Implements ticket 007