### PR TITLE
fix: exclude students with existing enrollments from create enrollment dropdown

### DIFF
--- a/app/Http/Controllers/SuperAdmin/EnrollmentController.php
+++ b/app/Http/Controllers/SuperAdmin/EnrollmentController.php
@@ -79,7 +79,17 @@ class EnrollmentController extends Controller
     {
         Gate::authorize('create', Enrollment::class);
 
-        $students = Student::with('guardians')->get();
+        $currentYear = date('Y');
+        $nextYear = $currentYear + 1;
+        $currentSchoolYear = "{$currentYear}-{$nextYear}";
+
+        // Exclude students who already have enrollments for current school year
+        $students = Student::with('guardians')
+            ->whereDoesntHave('enrollments', function ($query) use ($currentSchoolYear) {
+                $query->where('school_year', $currentSchoolYear);
+            })
+            ->get();
+
         $guardians = Guardian::with('user')->get();
 
         return Inertia::render('super-admin/enrollments/create', [


### PR DESCRIPTION
## Problem

When creating a new enrollment at `/super-admin/enrollments/create`, the student dropdown showed ALL students, including those who already have enrollments for the current school year. This caused the error:

> "Student already has a pending enrollment for this school year."

## Solution

Modified the `create()` method in `EnrollmentController` to **filter out students who already have enrollments** for the current school year.

## Changes

**EnrollmentController.php**:
- Calculate current school year automatically (e.g., "2025-2026")
- Use `whereDoesntHave('enrollments')` to exclude students with existing enrollments
- Only show students who can actually enroll for the current school year

```php
$students = Student::with('guardians')
    ->whereDoesntHave('enrollments', function ($query) use ($currentSchoolYear) {
        $query->where('school_year', $currentSchoolYear);
    })
    ->get();
```

## Impact

**Before**:
- Dropdown showed all students
- User could select a student with existing enrollment
- Error appeared after form submission: "Student already has a pending enrollment"

**After**:
- Dropdown only shows students who can enroll
- No error possible - form validation happens at UI level
- Better UX - prevents user from selecting invalid options

## Test Results

```
Tests:    751 passed (3160 assertions)
Duration: 20.8s
Coverage: 62.00% ✅
```

## Notes

- Students with enrollments for **other** school years are still shown (as expected)
- Only filters by **current** school year (calculated dynamically)
- Existing enrollment validation in `store()` method remains as a safety net