### PR TITLE
fix: Improve text readability on landing page (Issue #180)

### DIFF
--- a/resources/js/components/public-nav.tsx
+++ b/resources/js/components/public-nav.tsx
@@ -56,7 +56,13 @@ export function PublicNav({ currentPage }: PublicNavProps) {
                             <Link href={getDashboardUrl()}>Dashboard</Link>
                         </Button>
                     ) : (
-                        <LoginDialog trigger={<Button variant="outline">Login</Button>} />
+                        <LoginDialog
+                            trigger={
+                                <Button variant="default" className="bg-black text-white hover:bg-black/90">
+                                    Login
+                                </Button>
+                            }
+                        />
                     )}
                 </nav>
             </div>

--- a/resources/js/pages/public/landing.tsx
+++ b/resources/js/pages/public/landing.tsx
@@ -67,7 +67,7 @@ export default function Landing() {
                                 <Button size="lg" className="px-8 py-3" asChild>
                                     <Link href={register()}>Start Enrollment</Link>
                                 </Button>
-                                <Button variant="outline" size="lg" className="px-8 py-3" asChild>
+                                <Button variant="default" size="lg" className="bg-black px-8 py-3 text-white hover:bg-black/90" asChild>
                                     <Link href="/about">Learn More</Link>
                                 </Button>
                             </div>
@@ -185,15 +185,15 @@ export default function Landing() {
                                 <div className="space-y-3">
                                     <div className="flex items-center justify-center space-x-2 md:justify-start">
                                         <Icon iconNode={Phone} className="h-4 w-4 text-blue-400" />
-                                        <span className="text-sm text-slate-400">+63 123 456 7890</span>
+                                        <span className="text-sm text-white">+63 123 456 7890</span>
                                     </div>
                                     <div className="flex items-center justify-center space-x-2 md:justify-start">
                                         <Icon iconNode={Mail} className="h-4 w-4 text-blue-400" />
-                                        <span className="text-sm text-slate-400">christianbibleheritage@gmail.com</span>
+                                        <span className="text-sm text-white">christianbibleheritage@gmail.com</span>
                                     </div>
                                     <div className="flex items-center justify-center space-x-2 md:justify-start">
                                         <Icon iconNode={MapPin} className="h-4 w-4 text-blue-400" />
-                                        <span className="text-sm text-slate-400">Bayabas Ext. NAPICO Manggahan 1611 Pasig, Philippines</span>
+                                        <span className="text-sm text-white">Bayabas Ext. NAPICO Manggahan 1611 Pasig, Philippines</span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
Improves text readability on the landing page by making buttons and contact information more visible.

## Issue
- Closes #180
- Login and Learn More buttons had low contrast with outline style
- Contact section text in footer was too dark (slate-400) and hard to read

## Changes
### Login Button (PublicNav)
- Changed from `variant="outline"` to solid black button
- Added `bg-black text-white hover:bg-black/90` classes

### Learn More Button (Landing Page)
- Changed from `variant="outline"` to solid black button  
- Added `bg-black text-white hover:bg-black/90` classes

### Contact Section (Footer)
- Changed contact information text from `text-slate-400` to `text-white`
- Includes phone, email, and address text

## Testing
✅ All pre-push checks passed  
✅ TypeScript validation passed  
✅ All 752 tests passing  
✅ Code coverage: 62.06%

## Visual Changes
**Before:**
- Login button: outline style with low contrast
- Learn More button: outline style with low contrast
- Contact text: dark gray (slate-400) on dark background

**After:**
- Login button: solid black with white text
- Learn More button: solid black with white text  
- Contact text: white on dark background (much better readability)
