### PR TITLE
Fix guardian enrollment submit button validation

### DIFF
--- a/app/Http/Requests/Guardian/StoreEnrollmentRequest.php
+++ b/app/Http/Requests/Guardian/StoreEnrollmentRequest.php
@@ -33,6 +33,8 @@ class StoreEnrollmentRequest extends FormRequest
     {
         return [
             'enrollment_period' => [
+                'nullable',
+                'string',
                 function ($attribute, $value, $fail) {
                     // Validate active enrollment period exists
                     $activePeriod = EnrollmentPeriod::active()->first();


### PR DESCRIPTION
## Description
Fixes the submit button not working on the guardian enrollment create page by adding proper base validation rules to the `enrollment_period` field.

## Root Cause
The `enrollment_period` field in `StoreEnrollmentRequest` only had a closure-based custom validator without any base validation rules (like `nullable`, `required`, or `string`). This could cause Laravel's validation to fail silently or behave unexpectedly.

## Changes
- Added `'nullable'` and `'string'` base rules to the `enrollment_period` validation array
- The field is optional (nullable) since it's only used as a trigger for validation logic
- The custom closure validator remains unchanged and continues to validate enrollment period eligibility

## Technical Details
In Laravel, when you define validation rules as an array with only a closure, the validator may not process it correctly. Adding base rules ensures proper validation flow:

```php
'enrollment_period' => [
    'nullable',  // ← Added
    'string',    // ← Added
    function (, , ) {
        // Custom validation logic...
    },
],
```

## Testing
1. Navigate to `/guardian/enrollments/create`
2. Select a student
3. Fill in all required fields (grade level, quarter)
4. Click "Submit Enrollment" button
5. Verify the form submits successfully and redirects to enrollment list
6. Verify validation errors display correctly for invalid inputs

## Fixes
Closes #191