### PR TITLE
Fix: Registrar tables search filter

### DIFF
--- a/resources/js/pages/registrar/enrollments/enrollments-table.tsx
+++ b/resources/js/pages/registrar/enrollments/enrollments-table.tsx
@@ -125,14 +125,20 @@ export const createColumns = ({ onApproveClick, onRejectClick, onUpdatePaymentSt
     {
         accessorKey: 'student',
         header: 'Student',
+        accessorFn: (row) => `${row.student.first_name} ${row.student.last_name}`,
         cell: ({ row }) => {
-            const student = row.getValue('student') as { first_name: string; last_name: string; student_id: string };
+            const student = row.original.student;
             return (
                 <div>
                     <div>{`${student.first_name} ${student.last_name}`}</div>
                     <div className="text-xs text-muted-foreground">{student.student_id}</div>
                 </div>
             );
+        },
+        filterFn: (row, id, value) => {
+            const student = row.original.student;
+            const fullName = `${student.first_name} ${student.last_name}`.toLowerCase();
+            return fullName.includes(value.toLowerCase());
         },
     },
     {

--- a/resources/js/pages/registrar/students/students-table.tsx
+++ b/resources/js/pages/registrar/students/students-table.tsx
@@ -120,6 +120,7 @@ export const columns: ColumnDef<Student>[] = [
     {
         accessorKey: 'name',
         header: 'Name',
+        accessorFn: (row) => `${row.first_name} ${row.middle_name.charAt(0)}. ${row.last_name}`,
         cell: ({ row }) => {
             const student = row.original;
             return (
@@ -128,6 +129,11 @@ export const columns: ColumnDef<Student>[] = [
                     <div className="text-xs text-muted-foreground">{student.address}</div>
                 </div>
             );
+        },
+        filterFn: (row, id, value) => {
+            const student = row.original;
+            const fullName = `${student.first_name} ${student.middle_name.charAt(0)}. ${student.last_name}`.toLowerCase();
+            return fullName.includes(value.toLowerCase());
         },
     },
     {


### PR DESCRIPTION
Addresses issues where searching in the enrollments and students tables would cause data to disappear due to incorrect filtering logic. Implemented custom accessorFn and filterFn for student/name columns to correctly filter by full name.