### PR TITLE
Fix Super Admin forms: Guardian and Invoice management (#202, #203, #204)

### DIFF
--- a/app/Http/Controllers/SuperAdmin/InvoiceController.php
+++ b/app/Http/Controllers/SuperAdmin/InvoiceController.php
@@ -71,7 +71,7 @@ class InvoiceController extends Controller
         Gate::authorize('create', Invoice::class);
 
         $enrollments = Enrollment::with(['student', 'guardian.user'])
-            ->where('status', 'approved')
+            ->whereIn('status', [\App\Enums\EnrollmentStatus::APPROVED, \App\Enums\EnrollmentStatus::READY_FOR_PAYMENT, \App\Enums\EnrollmentStatus::ENROLLED])
             ->get();
 
         return Inertia::render('super-admin/invoices/create', [

--- a/app/Http/Requests/SuperAdmin/StoreGuardianRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreGuardianRequest.php
@@ -31,7 +31,6 @@ class StoreGuardianRequest extends FormRequest
             'first_name' => ['required', 'string', 'max:100'],
             'middle_name' => ['nullable', 'string', 'max:100'],
             'last_name' => ['required', 'string', 'max:100'],
-            'relationship_type' => ['required', 'string', 'in:father,mother,guardian,other'],
             'phone' => ['required', 'string', 'max:20'],
             'occupation' => ['nullable', 'string', 'max:100'],
             'employer' => ['nullable', 'string', 'max:255'],

--- a/app/Http/Requests/SuperAdmin/UpdateGuardianRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateGuardianRequest.php
@@ -33,7 +33,6 @@ class UpdateGuardianRequest extends FormRequest
             'first_name' => ['required', 'string', 'max:100'],
             'middle_name' => ['nullable', 'string', 'max:100'],
             'last_name' => ['required', 'string', 'max:100'],
-            'relationship_type' => ['required', 'string', 'in:father,mother,guardian,other'],
             'phone' => ['required', 'string', 'max:20'],
             'occupation' => ['nullable', 'string', 'max:100'],
             'employer' => ['nullable', 'string', 'max:255'],

--- a/resources/js/pages/super-admin/guardians/create.tsx
+++ b/resources/js/pages/super-admin/guardians/create.tsx
@@ -3,7 +3,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, useForm } from '@inertiajs/react';
@@ -18,7 +17,6 @@ interface FormData {
     password_confirmation: string;
     phone: string;
     address: string;
-    relationship_type: string;
     occupation: string;
     employer: string;
     emergency_contact: boolean;
@@ -34,7 +32,6 @@ export default function SuperAdminGuardiansCreate() {
         password_confirmation: '',
         phone: '',
         address: '',
-        relationship_type: '',
         occupation: '',
         employer: '',
         emergency_contact: false,
@@ -111,24 +108,6 @@ export default function SuperAdminGuardiansCreate() {
                                         />
                                         {errors.last_name && <p className="text-sm text-red-600">{errors.last_name}</p>}
                                     </div>
-                                </div>
-
-                                <div className="space-y-2">
-                                    <Label htmlFor="relationship_type">
-                                        Relationship <span className="text-red-600">*</span>
-                                    </Label>
-                                    <Select value={data.relationship_type} onValueChange={(value) => setData('relationship_type', value)}>
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Select relationship" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="father">Father</SelectItem>
-                                            <SelectItem value="mother">Mother</SelectItem>
-                                            <SelectItem value="guardian">Guardian</SelectItem>
-                                            <SelectItem value="other">Other</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                    {errors.relationship_type && <p className="text-sm text-red-600">{errors.relationship_type}</p>}
                                 </div>
                             </CardContent>
                         </Card>

--- a/resources/js/pages/super-admin/guardians/create.tsx
+++ b/resources/js/pages/super-admin/guardians/create.tsx
@@ -14,9 +14,11 @@ interface FormData {
     middle_name: string;
     last_name: string;
     email: string;
+    password: string;
+    password_confirmation: string;
     phone: string;
     address: string;
-    relationship: string;
+    relationship_type: string;
     occupation: string;
     employer: string;
     emergency_contact: boolean;
@@ -28,9 +30,11 @@ export default function SuperAdminGuardiansCreate() {
         middle_name: '',
         last_name: '',
         email: '',
+        password: '',
+        password_confirmation: '',
         phone: '',
         address: '',
-        relationship: '',
+        relationship_type: '',
         occupation: '',
         employer: '',
         emergency_contact: false,
@@ -110,22 +114,21 @@ export default function SuperAdminGuardiansCreate() {
                                 </div>
 
                                 <div className="space-y-2">
-                                    <Label htmlFor="relationship">
+                                    <Label htmlFor="relationship_type">
                                         Relationship <span className="text-red-600">*</span>
                                     </Label>
-                                    <Select value={data.relationship} onValueChange={(value) => setData('relationship', value)}>
+                                    <Select value={data.relationship_type} onValueChange={(value) => setData('relationship_type', value)}>
                                         <SelectTrigger>
                                             <SelectValue placeholder="Select relationship" />
                                         </SelectTrigger>
                                         <SelectContent>
                                             <SelectItem value="father">Father</SelectItem>
                                             <SelectItem value="mother">Mother</SelectItem>
-                                            <SelectItem value="legal_guardian">Legal Guardian</SelectItem>
-                                            <SelectItem value="grandparent">Grandparent</SelectItem>
+                                            <SelectItem value="guardian">Guardian</SelectItem>
                                             <SelectItem value="other">Other</SelectItem>
                                         </SelectContent>
                                     </Select>
-                                    {errors.relationship && <p className="text-sm text-red-600">{errors.relationship}</p>}
+                                    {errors.relationship_type && <p className="text-sm text-red-600">{errors.relationship_type}</p>}
                                 </div>
                             </CardContent>
                         </Card>
@@ -146,6 +149,34 @@ export default function SuperAdminGuardiansCreate() {
                                         {errors.email && <p className="text-sm text-red-600">{errors.email}</p>}
                                     </div>
 
+                                    <div className="space-y-2">
+                                        <Label htmlFor="password">
+                                            Password <span className="text-red-600">*</span>
+                                        </Label>
+                                        <Input
+                                            id="password"
+                                            type="password"
+                                            value={data.password}
+                                            onChange={(e) => setData('password', e.target.value)}
+                                        />
+                                        {errors.password && <p className="text-sm text-red-600">{errors.password}</p>}
+                                    </div>
+                                </div>
+
+                                <div className="space-y-2">
+                                    <Label htmlFor="password_confirmation">
+                                        Confirm Password <span className="text-red-600">*</span>
+                                    </Label>
+                                    <Input
+                                        id="password_confirmation"
+                                        type="password"
+                                        value={data.password_confirmation}
+                                        onChange={(e) => setData('password_confirmation', e.target.value)}
+                                    />
+                                    {errors.password_confirmation && <p className="text-sm text-red-600">{errors.password_confirmation}</p>}
+                                </div>
+
+                                <div className="grid gap-4 md:grid-cols-2">
                                     <div className="space-y-2">
                                         <Label htmlFor="phone">
                                             Phone <span className="text-red-600">*</span>

--- a/tests/Unit/Http/Requests/SuperAdmin/UpdateGuardianRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/UpdateGuardianRequestTest.php
@@ -59,7 +59,6 @@ class UpdateGuardianRequestTest extends TestCase
         $this->assertArrayHasKey('password', $rules);
         $this->assertArrayHasKey('first_name', $rules);
         $this->assertArrayHasKey('last_name', $rules);
-        $this->assertArrayHasKey('relationship_type', $rules);
         $this->assertArrayHasKey('phone', $rules);
         $this->assertArrayHasKey('address', $rules);
 
@@ -77,7 +76,6 @@ class UpdateGuardianRequestTest extends TestCase
             'first_name' => 'Updated',
             'middle_name' => 'Middle',
             'last_name' => 'Guardian',
-            'relationship_type' => 'father',
             'phone' => '09123456789',
             'occupation' => 'Engineer',
             'employer' => 'Tech Company',
@@ -118,7 +116,6 @@ class UpdateGuardianRequestTest extends TestCase
             'email' => 'test@example.com', // Same email
             'first_name' => 'Updated',
             'last_name' => 'Guardian',
-            'relationship_type' => 'mother',
             'phone' => '09123456789',
             'address' => '123 Updated Street',
             'emergency_contact' => false,
@@ -156,7 +153,6 @@ class UpdateGuardianRequestTest extends TestCase
             'email' => 'updated@example.com',
             'first_name' => 'Updated',
             'last_name' => 'Guardian',
-            'relationship_type' => 'guardian',
             'phone' => '09123456789',
             'address' => '123 Updated Street',
             'emergency_contact' => false,
@@ -185,44 +181,5 @@ class UpdateGuardianRequestTest extends TestCase
         $validator = Validator::make($data, $request->rules());
 
         $this->assertTrue($validator->passes());
-    }
-
-    public function test_validation_fails_with_invalid_relationship_type(): void
-    {
-        $existingGuardian = Guardian::factory()->create();
-
-        $data = [
-            'email' => 'updated@example.com',
-            'first_name' => 'Updated',
-            'last_name' => 'Guardian',
-            'relationship_type' => 'invalid_type',
-            'phone' => '09123456789',
-            'address' => '123 Updated Street',
-            'emergency_contact' => false,
-        ];
-
-        $request = new class($existingGuardian) extends UpdateGuardianRequest
-        {
-            private $guardian;
-
-            public function __construct($guardian)
-            {
-                $this->guardian = $guardian;
-            }
-
-            public function route($param = null, $default = null)
-            {
-                if ($param === 'guardian') {
-                    return $this->guardian;
-                }
-
-                return parent::route($param, $default);
-            }
-        };
-
-        $validator = Validator::make($data, $request->rules());
-
-        $this->assertFalse($validator->passes());
-        $this->assertArrayHasKey('relationship_type', $validator->errors()->toArray());
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes the remaining critical Super Admin form issues that were preventing Guardian and Invoice management.

## Issues Fixed

### ✅ Issue #202: Invoice Enrollment Dropdown Empty
**Problem**: The enrollment dropdown on the Create Invoice page was empty
**Solution**:
- Updated enrollment status filter to include `APPROVED`, `READY_FOR_PAYMENT`, and `ENROLLED` statuses
- Previous filter only checked for string 'approved' which didn't match enum values
- Dropdown now properly populated with available enrollments for invoicing

### ✅ Issue #203: Create Guardian Button Unresponsive
**Problem**: Create Guardian form was not submitting data
**Solution**:
- Added missing `password` and `password_confirmation` fields to the form
- Removed `relationship_type` field which doesn't exist on Guardian model
- Fixed form data structure to match backend validation requirements
- Form now properly creates guardian accounts with user credentials

### ✅ Issue #204: Update Guardian Button Not Submitting
**Problem**: Update Guardian form was not saving changes
**Solution**:
- Removed `relationship_type` validation from both Store and Update requests
- Guardian model doesn't have `relationship_type` field (it's stored in pivot table `guardian_student`)
- Updated tests to reflect the corrected validation rules
- Both create and update guardian forms now work properly

## Technical Changes

### Backend
- **InvoiceController**: Fixed enrollment status filter in `create()` method
  - Changed from `where('status', 'approved')` to `whereIn('status', [APPROVED, READY_FOR_PAYMENT, ENROLLED])`
  
- **StoreGuardianRequest**: Removed `relationship_type` validation
  - Field doesn't exist on Guardian model
  - Relationship type is stored in pivot table when linking guardian to student
  
- **UpdateGuardianRequest**: Removed `relationship_type` validation
  - Same reason as Store request

### Frontend
- **super-admin/guardians/create.tsx**:
  - Added `password` and `password_confirmation` fields
  - Removed `relationship_type` field and related Select component
  - Cleaned up unused imports
  
### Tests
- **UpdateGuardianRequestTest**: 
  - Removed `relationship_type` assertions
  - Removed invalid relationship type test
  - Updated test data to match new validation rules

## Root Cause Analysis
The Guardian forms were failing because:
1. **Missing password fields**: Create form didn't include required password fields for user account creation
2. **Invalid field validation**: Backend was validating `relationship_type` which doesn't exist on Guardian model
3. **Enum mismatch**: Invoice dropdown filter used string comparison instead of enum values

## Testing
- ✅ All tests passing
- ✅ Code coverage maintained above 60%
- ✅ TypeScript compilation successful
- ✅ PHP static analysis passed
- ✅ Code style checks passed

## User Impact
- **Super Admins** can now create and update guardian accounts successfully
- **Super Admins** can now create invoices with proper enrollment selection
- Forms provide proper validation feedback
- All Super Admin CRUD operations for guardians now functional

## Breaking Changes
None - these are bug fixes for non-functional features

## Migration Required
No

## Related PRs
- PR #217: Fixed issues #205-#214
- PR #218: Fixed issues #211-#216
