### PR TITLE
Fix Issue #199: Add Upload New tab to student documents page

### DIFF
--- a/resources/js/pages/guardian/students/show.tsx
+++ b/resources/js/pages/guardian/students/show.tsx
@@ -2,10 +2,14 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link } from '@inertiajs/react';
+import { Head, Link, router } from '@inertiajs/react';
 import axios from 'axios';
 import {
     Calendar,
@@ -87,6 +91,11 @@ export default function GuardianStudentsShow({ student }: Props) {
     const [downloadingId, setDownloadingId] = useState<number | null>(null);
     const [imageUrls, setImageUrls] = useState<Record<number, string>>({});
     const [viewingImageId, setViewingImageId] = useState<number | null>(null);
+    const [uploadingDocument, setUploadingDocument] = useState(false);
+    const [uploadForm, setUploadForm] = useState({
+        document_type: '',
+        file: null as File | null,
+    });
 
     const breadcrumbs: BreadcrumbItem[] = [
         { title: 'Guardian', href: '/guardian/dashboard' },
@@ -144,6 +153,40 @@ export default function GuardianStudentsShow({ student }: Props) {
             alert('Failed to download document. Please try again.');
         } finally {
             setDownloadingId(null);
+        }
+    };
+
+    const handleUploadDocument = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (!uploadForm.document_type || !uploadForm.file) {
+            alert('Please select document type and file');
+            return;
+        }
+
+        setUploadingDocument(true);
+
+        const formData = new FormData();
+        formData.append('document_type', uploadForm.document_type);
+        formData.append('file', uploadForm.file);
+
+        try {
+            await router.post(`/guardian/students/${student.id}/documents`, formData, {
+                onSuccess: () => {
+                    setUploadForm({ document_type: '', file: null });
+                    alert('Document uploaded successfully!');
+                },
+                onError: (errors) => {
+                    console.error('Upload failed:', errors);
+                    alert('Failed to upload document. Please try again.');
+                },
+                onFinish: () => {
+                    setUploadingDocument(false);
+                },
+            });
+        } catch (error) {
+            console.error('Upload error:', error);
+            setUploadingDocument(false);
         }
     };
 
@@ -383,130 +426,192 @@ export default function GuardianStudentsShow({ student }: Props) {
                         <CardDescription>Uploaded documents for {student.first_name}</CardDescription>
                     </CardHeader>
                     <CardContent>
-                        {/* Document Statistics */}
-                        <div className="mb-6 grid gap-4 md:grid-cols-4">
-                            <Card>
-                                <CardHeader className="pb-2">
-                                    <CardDescription>Total Documents</CardDescription>
-                                </CardHeader>
-                                <CardContent>
-                                    <div className="text-2xl font-bold">{stats.total}</div>
-                                </CardContent>
-                            </Card>
-                            <Card>
-                                <CardHeader className="pb-2">
-                                    <CardDescription>Verified</CardDescription>
-                                </CardHeader>
-                                <CardContent>
-                                    <div className="text-2xl font-bold text-green-600">{stats.verified}</div>
-                                </CardContent>
-                            </Card>
-                            <Card>
-                                <CardHeader className="pb-2">
-                                    <CardDescription>Pending</CardDescription>
-                                </CardHeader>
-                                <CardContent>
-                                    <div className="text-2xl font-bold text-yellow-600">{stats.pending}</div>
-                                </CardContent>
-                            </Card>
-                            <Card>
-                                <CardHeader className="pb-2">
-                                    <CardDescription>Rejected</CardDescription>
-                                </CardHeader>
-                                <CardContent>
-                                    <div className="text-2xl font-bold text-red-600">{stats.rejected}</div>
-                                </CardContent>
-                            </Card>
-                        </div>
+                        <Tabs defaultValue="view" className="w-full">
+                            <TabsList className="grid w-full grid-cols-2">
+                                <TabsTrigger value="view">View Documents</TabsTrigger>
+                                <TabsTrigger value="upload">Upload New</TabsTrigger>
+                            </TabsList>
 
-                        {student.documents && student.documents.length > 0 ? (
-                            <div className="space-y-6">
-                                {student.documents.map((document) => (
-                                    <div key={document.id} className="space-y-3 rounded-lg border p-4">
-                                        <div className="flex items-start justify-between">
-                                            <div className="flex items-center gap-3">
-                                                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
-                                                    <FileText className="h-5 w-5 text-primary" />
-                                                </div>
-                                                <div>
-                                                    <p className="font-medium">{document.document_type_label}</p>
-                                                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                                        <span>{document.original_filename}</span>
-                                                        <span>•</span>
-                                                        <span>{(document.file_size / 1024 / 1024).toFixed(2)} MB</span>
-                                                        <span>•</span>
-                                                        <span>
-                                                            Uploaded{' '}
-                                                            {new Date(document.upload_date).toLocaleDateString('en-US', {
-                                                                year: 'numeric',
-                                                                month: 'short',
-                                                                day: 'numeric',
-                                                            })}
-                                                        </span>
+                            <TabsContent value="view" className="space-y-6">
+                                {/* Document Statistics */}
+                                <div className="grid gap-4 md:grid-cols-4">
+                                    <Card>
+                                        <CardHeader className="pb-2">
+                                            <CardDescription>Total Documents</CardDescription>
+                                        </CardHeader>
+                                        <CardContent>
+                                            <div className="text-2xl font-bold">{stats.total}</div>
+                                        </CardContent>
+                                    </Card>
+                                    <Card>
+                                        <CardHeader className="pb-2">
+                                            <CardDescription>Verified</CardDescription>
+                                        </CardHeader>
+                                        <CardContent>
+                                            <div className="text-2xl font-bold text-green-600">{stats.verified}</div>
+                                        </CardContent>
+                                    </Card>
+                                    <Card>
+                                        <CardHeader className="pb-2">
+                                            <CardDescription>Pending</CardDescription>
+                                        </CardHeader>
+                                        <CardContent>
+                                            <div className="text-2xl font-bold text-yellow-600">{stats.pending}</div>
+                                        </CardContent>
+                                    </Card>
+                                    <Card>
+                                        <CardHeader className="pb-2">
+                                            <CardDescription>Rejected</CardDescription>
+                                        </CardHeader>
+                                        <CardContent>
+                                            <div className="text-2xl font-bold text-red-600">{stats.rejected}</div>
+                                        </CardContent>
+                                    </Card>
+                                </div>
+
+                                {student.documents && student.documents.length > 0 ? (
+                                    <div className="space-y-6">
+                                        {student.documents.map((document) => (
+                                            <div key={document.id} className="space-y-3 rounded-lg border p-4">
+                                                <div className="flex items-start justify-between">
+                                                    <div className="flex items-center gap-3">
+                                                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
+                                                            <FileText className="h-5 w-5 text-primary" />
+                                                        </div>
+                                                        <div>
+                                                            <p className="font-medium">{document.document_type_label}</p>
+                                                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                                                <span>{document.original_filename}</span>
+                                                                <span>•</span>
+                                                                <span>{(document.file_size / 1024 / 1024).toFixed(2)} MB</span>
+                                                                <span>•</span>
+                                                                <span>
+                                                                    Uploaded{' '}
+                                                                    {new Date(document.upload_date).toLocaleDateString('en-US', {
+                                                                        year: 'numeric',
+                                                                        month: 'short',
+                                                                        day: 'numeric',
+                                                                    })}
+                                                                </span>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div className="flex items-center gap-2">
+                                                        {document.verification_status === 'pending' && (
+                                                            <Badge variant="secondary" className="flex items-center gap-1">
+                                                                <Clock className="h-3 w-3" />
+                                                                Pending Review
+                                                            </Badge>
+                                                        )}
+                                                        {document.verification_status === 'verified' && (
+                                                            <Badge variant="default" className="flex items-center gap-1">
+                                                                <CheckCircle2 className="h-3 w-3" />
+                                                                Verified
+                                                            </Badge>
+                                                        )}
+                                                        {document.verification_status === 'rejected' && (
+                                                            <Badge variant="destructive" className="flex items-center gap-1">
+                                                                <XCircle className="h-3 w-3" />
+                                                                Rejected
+                                                            </Badge>
+                                                        )}
                                                     </div>
                                                 </div>
-                                            </div>
-                                            <div className="flex items-center gap-2">
-                                                {document.verification_status === 'pending' && (
-                                                    <Badge variant="secondary" className="flex items-center gap-1">
-                                                        <Clock className="h-3 w-3" />
-                                                        Pending Review
-                                                    </Badge>
-                                                )}
-                                                {document.verification_status === 'verified' && (
-                                                    <Badge variant="default" className="flex items-center gap-1">
-                                                        <CheckCircle2 className="h-3 w-3" />
-                                                        Verified
-                                                    </Badge>
-                                                )}
-                                                {document.verification_status === 'rejected' && (
-                                                    <Badge variant="destructive" className="flex items-center gap-1">
-                                                        <XCircle className="h-3 w-3" />
-                                                        Rejected
-                                                    </Badge>
-                                                )}
-                                            </div>
-                                        </div>
 
-                                        {/* Image Preview */}
-                                        {imageUrls[document.id] ? (
-                                            <div className="space-y-2">
-                                                <img
-                                                    src={imageUrls[document.id]}
-                                                    alt={document.document_type_label}
-                                                    className="h-auto w-full max-w-2xl rounded-lg border object-contain"
-                                                />
-                                                <div className="flex gap-2">
-                                                    <Button variant="outline" size="sm" onClick={() => setViewingImageId(document.id)}>
-                                                        <Eye className="mr-2 h-4 w-4" />
-                                                        View Full Size
-                                                    </Button>
-                                                    <Button
-                                                        variant="outline"
-                                                        size="sm"
-                                                        onClick={() => handleDownload(document.id)}
-                                                        disabled={downloadingId === document.id}
-                                                    >
-                                                        <Download className="mr-2 h-4 w-4" />
-                                                        {downloadingId === document.id ? 'Downloading...' : 'Download'}
-                                                    </Button>
+                                                {/* Image Preview */}
+                                                {imageUrls[document.id] ? (
+                                                    <div className="space-y-2">
+                                                        <img
+                                                            src={imageUrls[document.id]}
+                                                            alt={document.document_type_label}
+                                                            className="h-auto w-full max-w-2xl rounded-lg border object-contain"
+                                                        />
+                                                        <div className="flex gap-2">
+                                                            <Button variant="outline" size="sm" onClick={() => setViewingImageId(document.id)}>
+                                                                <Eye className="mr-2 h-4 w-4" />
+                                                                View Full Size
+                                                            </Button>
+                                                            <Button
+                                                                variant="outline"
+                                                                size="sm"
+                                                                onClick={() => handleDownload(document.id)}
+                                                                disabled={downloadingId === document.id}
+                                                            >
+                                                                <Download className="mr-2 h-4 w-4" />
+                                                                {downloadingId === document.id ? 'Downloading...' : 'Download'}
+                                                            </Button>
+                                                        </div>
+                                                    </div>
+                                                ) : (
+                                                    <div className="flex h-32 items-center justify-center rounded-lg bg-muted">
+                                                        <p className="text-sm text-muted-foreground">Loading image...</p>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        ))}
+                                    </div>
+                                ) : (
+                                    <div className="flex flex-col items-center justify-center py-12 text-center">
+                                        <Upload className="mb-4 h-12 w-12 text-muted-foreground" />
+                                        <p className="mb-2 text-lg font-semibold">No Documents Uploaded</p>
+                                        <p className="text-sm text-muted-foreground">Documents are required for enrollment processing</p>
+                                    </div>
+                                )}
+                            </TabsContent>
+
+                            <TabsContent value="upload" className="space-y-6">
+                                <form onSubmit={handleUploadDocument} className="space-y-4">
+                                    <div className="space-y-2">
+                                        <Label htmlFor="document_type">Document Type</Label>
+                                        <Select
+                                            value={uploadForm.document_type}
+                                            onValueChange={(value) => setUploadForm({ ...uploadForm, document_type: value })}
+                                        >
+                                            <SelectTrigger>
+                                                <SelectValue placeholder="Select document type" />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="birth_certificate">Birth Certificate</SelectItem>
+                                                <SelectItem value="report_card">Report Card</SelectItem>
+                                                <SelectItem value="form_138">Form 138</SelectItem>
+                                                <SelectItem value="good_moral">Good Moral Certificate</SelectItem>
+                                                <SelectItem value="other">Other</SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                    </div>
+
+                                    <div className="space-y-2">
+                                        <Label htmlFor="file">Document File</Label>
+                                        <Input
+                                            id="file"
+                                            type="file"
+                                            accept=".jpg,.jpeg,.png,.pdf"
+                                            onChange={(e) => setUploadForm({ ...uploadForm, file: e.target.files?.[0] || null })}
+                                        />
+                                        <p className="text-sm text-muted-foreground">Accepted formats: JPG, PNG, PDF (Max 50MB)</p>
+                                    </div>
+
+                                    {uploadForm.file && (
+                                        <div className="rounded-lg border p-4">
+                                            <div className="flex items-center gap-3">
+                                                <FileText className="h-8 w-8 text-primary" />
+                                                <div>
+                                                    <p className="font-medium">{uploadForm.file.name}</p>
+                                                    <p className="text-sm text-muted-foreground">
+                                                        {(uploadForm.file.size / 1024 / 1024).toFixed(2)} MB
+                                                    </p>
                                                 </div>
                                             </div>
-                                        ) : (
-                                            <div className="flex h-32 items-center justify-center rounded-lg bg-muted">
-                                                <p className="text-sm text-muted-foreground">Loading image...</p>
-                                            </div>
-                                        )}
-                                    </div>
-                                ))}
-                            </div>
-                        ) : (
-                            <div className="flex flex-col items-center justify-center py-12 text-center">
-                                <Upload className="mb-4 h-12 w-12 text-muted-foreground" />
-                                <p className="mb-2 text-lg font-semibold">No Documents Uploaded</p>
-                                <p className="text-sm text-muted-foreground">Documents are required for enrollment processing</p>
-                            </div>
-                        )}
+                                        </div>
+                                    )}
+
+                                    <Button type="submit" disabled={uploadingDocument || !uploadForm.document_type || !uploadForm.file}>
+                                        <Upload className="mr-2 h-4 w-4" />
+                                        {uploadingDocument ? 'Uploading...' : 'Upload Document'}
+                                    </Button>
+                                </form>
+                            </TabsContent>
+                        </Tabs>
                     </CardContent>
                 </Card>
             </div>


### PR DESCRIPTION
## Summary
Adds 'Upload New' tab to student documents page allowing guardians to upload additional documents.

## Issue Fixed
**#199** - Documents page missing Upload New tab

## Solution
- **Tabs UI**: Added tabs with 'View Documents' and 'Upload New'
- **Upload Form**: Document type selector + file input
- **File Preview**: Shows selected file details before upload
- **Validation**: Proper form validation and disabled states
- **Feedback**: Loading states and success/error messages

## Features
- Document types: Birth Certificate, Report Card, Form 138, Good Moral, Other
- Accepts: JPG, PNG, PDF (Max 50MB)
- Clean, intuitive UI
- Real-time file preview

## User Impact
- **Guardians** can now upload additional documents anytime
- **Better workflow** - upload documents separately from student creation
- **Flexibility** - add missing documents later

## Testing
✅ All checks passed