### PR TITLE
Fix Issue #232: Prevent 502 error in registrar enrollment view

### DIFF
--- a/resources/js/pages/registrar/enrollments/show.tsx
+++ b/resources/js/pages/registrar/enrollments/show.tsx
@@ -104,7 +104,7 @@ export default function RegistrarEnrollmentsShow({ enrollment }: Props) {
                             </div>
                             <div className="flex items-center justify-between">
                                 <p className="text-sm font-medium text-muted-foreground">Guardian Name</p>
-                                <p className="text-lg font-semibold">{enrollment.guardian.name}</p>
+                                <p className="text-lg font-semibold">{enrollment.guardian?.name || 'N/A'}</p>
                             </div>
                         </CardContent>
                     </Card>


### PR DESCRIPTION
## Summary
Fixes 502 Bad Gateway error when viewing enrollment details.

## Issue Fixed
**#232** - 502 error when registrar clicks View on enrollments

## Root Cause
Frontend tried to access `enrollment.guardian.name` but guardian could be null, causing server crash.

## Solution
- Added optional chaining: `enrollment.guardian?.name`
- Shows 'N/A' if guardian not assigned
- Prevents server crash

## Testing
✅ All checks passed