### PR TITLE
Fix Issue #238: Fix blank users page

### DIFF
--- a/resources/js/pages/super-admin/users/index.tsx
+++ b/resources/js/pages/super-admin/users/index.tsx
@@ -52,7 +52,7 @@ export default function UsersIndex({ users, filters }: Props) {
             <div className="px-4 py-6">
                 <div className="mb-4 flex items-center justify-between">
                     <h1 className="text-2xl font-bold">Users Index</h1>
-                    <Link href={route('super-admin.users.create')}>
+                    <Link href="/super-admin/users/create">
                         <Button>
                             <Plus className="mr-2 h-4 w-4" />
                             Create User


### PR DESCRIPTION
## Summary
Fixes blank screen on Super Admin Users page.

## Issue Fixed
**#238** - Users page displays blank/empty screen

## Root Cause
Undefined route helper `route('super-admin.users.create')` caused page to crash

## Solution
- Changed to direct URL: `/super-admin/users/create`
- Page now renders properly

## Testing
✅ All checks passed