### PR TITLE
Fix 502 error: Make Guardian name accessor null-safe

### DIFF
--- a/app/Models/Guardian.php
+++ b/app/Models/Guardian.php
@@ -40,7 +40,10 @@ class Guardian extends Model
      */
     public function getNameAttribute(): string
     {
-        return trim("{$this->first_name} {$this->last_name}");
+        $firstName = $this->first_name ?? '';
+        $lastName = $this->last_name ?? '';
+
+        return trim("{$firstName} {$lastName}") ?: 'Unknown';
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes 502 error on registrar enrollment show page when guardian has incomplete data.

## Issue
Production URL  returns 502 error

## Root Cause
Guardian model's `name` accessor crashes when `first_name` or `last_name` is NULL

## Solution
- Made name accessor null-safe
- Handle NULL first_name and last_name gracefully  
- Return 'Unknown' if both names are empty
- Prevents crashes when guardian data is incomplete

## Code Change
```php
public function getNameAttribute(): string
{
    $firstName = $this->first_name ?? '';
    $lastName = $this->last_name ?? '';
    
    return trim("$firstName $lastName") ?: 'Unknown';
}
```

## Testing
✅ All checks passed
✅ Handles NULL values gracefully
✅ Returns 'Unknown' for empty names