### PR TITLE
Add EnrollmentPeriod seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -24,6 +24,9 @@ class DatabaseSeeder extends Seeder
         // Seed school information
         $this->call(SchoolInformationSeeder::class);
 
+        // Seed enrollment periods
+        $this->call(EnrollmentPeriodSeeder::class);
+
         // Seed enrollments (includes students and guardians if needed)
         $this->call(EnrollmentSeeder::class);
 

--- a/database/seeders/EnrollmentPeriodSeeder.php
+++ b/database/seeders/EnrollmentPeriodSeeder.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\EnrollmentPeriod;
+use Illuminate\Database\Seeder;
+
+class EnrollmentPeriodSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Current/Active Period: 2025-2026
+        EnrollmentPeriod::create([
+            'school_year' => '2025-2026',
+            'start_date' => '2025-06-01',
+            'end_date' => '2026-03-31',
+            'early_registration_deadline' => '2025-05-31',
+            'regular_registration_deadline' => '2025-07-31',
+            'late_registration_deadline' => '2025-08-31',
+            'status' => 'active',
+            'description' => 'School Year 2025-2026 Enrollment Period',
+            'allow_new_students' => true,
+            'allow_returning_students' => true,
+        ]);
+
+        // Upcoming Period: 2026-2027
+        EnrollmentPeriod::create([
+            'school_year' => '2026-2027',
+            'start_date' => '2026-06-01',
+            'end_date' => '2027-03-31',
+            'early_registration_deadline' => '2026-05-31',
+            'regular_registration_deadline' => '2026-07-31',
+            'late_registration_deadline' => '2026-08-31',
+            'status' => 'upcoming',
+            'description' => 'School Year 2026-2027 Enrollment Period',
+            'allow_new_students' => true,
+            'allow_returning_students' => true,
+        ]);
+
+        // Past Period: 2024-2025
+        EnrollmentPeriod::create([
+            'school_year' => '2024-2025',
+            'start_date' => '2024-06-01',
+            'end_date' => '2025-03-31',
+            'early_registration_deadline' => '2024-05-31',
+            'regular_registration_deadline' => '2024-07-31',
+            'late_registration_deadline' => '2024-08-31',
+            'status' => 'closed',
+            'description' => 'School Year 2024-2025 Enrollment Period',
+            'allow_new_students' => true,
+            'allow_returning_students' => true,
+        ]);
+
+        // Past Period: 2023-2024
+        EnrollmentPeriod::create([
+            'school_year' => '2023-2024',
+            'start_date' => '2023-06-01',
+            'end_date' => '2024-03-31',
+            'early_registration_deadline' => '2023-05-31',
+            'regular_registration_deadline' => '2023-07-31',
+            'late_registration_deadline' => '2023-08-31',
+            'status' => 'closed',
+            'description' => 'School Year 2023-2024 Enrollment Period',
+            'allow_new_students' => true,
+            'allow_returning_students' => true,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
Adds seeder for enrollment periods with sample data.

## What's Included
**4 Enrollment Periods:**
- ✅ **Active**: 2025-2026 (June 2025 - March 2026)
- ⏰ **Upcoming**: 2026-2027 (June 2026 - March 2027)
- 📁 **Closed**: 2024-2025 (June 2024 - March 2025)
- 📁 **Closed**: 2023-2024 (June 2023 - March 2024)

## Fields Seeded
- School year
- Start/end dates
- Early/regular/late registration deadlines
- Status (active/upcoming/closed)
- Description
- Allow new/returning students flags

## Usage
```bash
php artisan db:seed --class=EnrollmentPeriodSeeder
# or
php artisan migrate:fresh --seed
```

## Testing
✅ All checks passed
✅ Integrated into DatabaseSeeder