### PR TITLE
Fix: Allow multiple fee structures per grade/year with different payment terms

### DIFF
--- a/app/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequest.php
@@ -27,7 +27,8 @@ class StoreGradeLevelFeeRequest extends FormRequest
                 'string',
                 'max:50',
                 \Illuminate\Validation\Rule::unique('grade_level_fees')->where(function ($query) {
-                    return $query->where('school_year', $this->school_year);
+                    return $query->where('school_year', $this->school_year)
+                        ->where('payment_terms', $this->payment_terms);
                 }),
             ],
             'school_year' => ['required', 'string', 'regex:/^\d{4}-\d{4}$/'],
@@ -48,7 +49,7 @@ class StoreGradeLevelFeeRequest extends FormRequest
     {
         return [
             'school_year.regex' => 'School year must be in the format YYYY-YYYY (e.g., 2024-2025).',
-            'grade_level.unique' => 'A fee structure for this grade level and school year already exists.',
+            'grade_level.unique' => 'A fee structure for this grade level, school year, and payment term already exists.',
         ];
     }
 }

--- a/app/Http/Requests/SuperAdmin/UpdateGradeLevelFeeRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateGradeLevelFeeRequest.php
@@ -31,7 +31,8 @@ class UpdateGradeLevelFeeRequest extends FormRequest
                 \Illuminate\Validation\Rule::unique('grade_level_fees')
                     ->ignore($gradeLevelFeeId)
                     ->where(function ($query) {
-                        return $query->where('school_year', $this->school_year);
+                        return $query->where('school_year', $this->school_year)
+                            ->where('payment_terms', $this->payment_terms);
                     }),
             ],
             'school_year' => ['required', 'string', 'regex:/^\d{4}-\d{4}$/'],
@@ -52,7 +53,7 @@ class UpdateGradeLevelFeeRequest extends FormRequest
     {
         return [
             'school_year.regex' => 'School year must be in the format YYYY-YYYY (e.g., 2024-2025).',
-            'grade_level.unique' => 'A fee structure for this grade level and school year already exists.',
+            'grade_level.unique' => 'A fee structure for this grade level, school year, and payment term already exists.',
         ];
     }
 }


### PR DESCRIPTION
## Summary
Fixes validation to allow multiple fee structures for the same grade level and school year with different payment terms.

## Issue
Frontend validation blocks creating multiple fee structures for the same grade level and school year, even with different payment terms (ANNUAL, QUARTERLY, MONTHLY, etc.)

Error: "A fee structure for this grade level and school year already exists."

## Root Cause
Unique validation only checked  + , but didn't include 

## Solution
✅ Updated  validation to include 
✅ Updated  validation to include   
✅ Updated error message to reflect new constraint
✅ Database migration already exists and was run

## Now Allows
- Grade 1, 2025-2026, ANNUAL
- Grade 1, 2025-2026, QUARTERLY
- Grade 1, 2025-2026, MONTHLY
- etc.

## Testing
✅ All checks passed
✅ Validation now checks all three fields
✅ Matches database unique constraint