### PR TITLE
Fix CI/CD: Remove duplicate workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - develop
   push:
     branches:
+      - main
       - develop
-      - feature/*
 
 # Cancel in-progress runs when a new workflow with the same group name is triggered
 concurrency:


### PR DESCRIPTION
## Summary
Fixes duplicate CI/CD workflow runs when pushing to PR branches.

## Issue
Currently, CI/CD runs twice for every PR commit:
1. Once for the `push` event (triggered by `feature/*` pattern)
2. Once for the `pull_request` event

This wastes GitHub Actions minutes and clutters the checks UI.

## Solution
Changed `push` trigger from:
```yaml
push:
  branches:
    - develop
    - feature/*
```

To:
```yaml
push:
  branches:
    - main
    - develop
```

## How It Works Now
- **PR commits**: Only `pull_request` event runs ✅
- **Direct commits to main/develop**: Only `push` event runs ✅
- **No duplicates** ✅

## Benefits
- 50% reduction in CI/CD runs for PRs
- Cleaner checks UI
- Saves GitHub Actions minutes
- Faster feedback (no waiting for duplicate runs)