### PR TITLE
Add GradeLevelFeeSeeder to DatabaseSeeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -27,6 +27,9 @@ class DatabaseSeeder extends Seeder
         // Seed enrollment periods
         $this->call(EnrollmentPeriodSeeder::class);
 
+        // Seed grade level fees
+        $this->call(GradeLevelFeeSeeder::class);
+
         // Seed enrollments (includes students and guardians if needed)
         $this->call(EnrollmentSeeder::class);
 


### PR DESCRIPTION
## Summary
Adds GradeLevelFeeSeeder to the main DatabaseSeeder so it runs automatically.

## Issue
GradeLevelFeeSeeder was created but not included in DatabaseSeeder, so it wouldn't run with `migrate:fresh --seed`.

## Solution
Added `GradeLevelFeeSeeder` to DatabaseSeeder call stack:
- Runs after EnrollmentPeriodSeeder
- Runs before EnrollmentSeeder
- Ensures fee structures are available before creating enrollments

## Now Works
```bash
php artisan migrate:fresh --seed
```

Will automatically seed:
- 21 grade level fee structures
- All payment terms (ANNUAL, SEMESTRAL, MONTHLY)
- All grade levels (Kinder, Grades 1-6)

## Testing
✅ All checks passed