### PR TITLE
Fix: Add year selector to DatePicker for easier birthdate selection

### DIFF
--- a/resources/js/components/ui/date-picker.tsx
+++ b/resources/js/components/ui/date-picker.tsx
@@ -92,7 +92,7 @@ export function DatePicker({
                     initialFocus
                     disabled={getDisabledDates}
                     defaultMonth={minAge ? new Date(new Date().setFullYear(new Date().getFullYear() - minAge)) : undefined}
-                    captionLayout="dropdown-months"
+                    captionLayout="dropdown"
                     fromYear={1900}
                     toYear={new Date().getFullYear()}
                 />


### PR DESCRIPTION
## Summary
Adds year dropdown selector to DatePicker component for easier birthdate selection when creating/editing students.

## Issue
DatePicker only showed month dropdown selector, making it tedious to select birthdates (especially for students born many years ago). Users had to click through many months to reach the correct year.

## Solution
Changed `captionLayout` from `"dropdown-months"` to `"dropdown"` in the Calendar component.

## Now Includes
✅ **Year dropdown** (1900 - current year)
✅ **Month dropdown**
✅ Much faster birthdate selection

## Affected Areas
- Student creation forms (Guardian, Registrar)
- Student edit forms
- All other date pickers in the app

## Testing
✅ All 751 tests passed
✅ Date picker functionality verified
✅ Year range: 1900 to current year
✅ Disabled dates logic still works