### PR TITLE
fix: PaymentSeeder faker issue and invoice payment display

### DIFF
--- a/database/seeders/PaymentSeeder.php
+++ b/database/seeders/PaymentSeeder.php
@@ -83,12 +83,13 @@ class PaymentSeeder extends Seeder
                 }
 
                 // Create payment
+                $faker = \Faker\Factory::create();
                 $payment = Payment::create([
                     'invoice_id' => $invoice->id,
                     'amount' => $paymentAmountCents / 100, // Convert cents to decimal
-                    'payment_method' => fake()->randomElement($paymentMethods),
+                    'payment_method' => $paymentMethods[array_rand($paymentMethods)],
                     'payment_date' => now()->subDays(rand(1, 60)),
-                    'reference_number' => 'REF-'.strtoupper(fake()->bothify('???###???')),
+                    'reference_number' => 'REF-'.strtoupper($faker->bothify('???###???')),
                     'receipt_number' => 'RCP-'.now()->format('Ym').'-'.str_pad((string) ($paymentCount + 1), 6, '0', STR_PAD_LEFT),
                     'notes' => $i === 0 ? 'Initial payment' : 'Installment payment '.($i + 1),
                     'processed_by' => $enrollment->approved_by,

--- a/resources/js/pages/super-admin/invoices/show.tsx
+++ b/resources/js/pages/super-admin/invoices/show.tsx
@@ -49,7 +49,7 @@ interface InvoiceItem {
 
 interface Payment {
     id: number;
-    payment_number: string;
+    receipt_number?: string;
     amount: number;
     payment_method: string;
     payment_date: string;
@@ -323,7 +323,7 @@ export default function SuperAdminInvoicesShow({ invoice }: Props) {
                                     <TableBody>
                                         {invoice.payments.map((payment) => (
                                             <TableRow key={payment.id}>
-                                                <TableCell className="font-medium">{payment.payment_number}</TableCell>
+                                                <TableCell className="font-medium">{payment.receipt_number || `#${payment.id}`}</TableCell>
                                                 <TableCell>{formatDate(payment.payment_date)}</TableCell>
                                                 <TableCell className="capitalize">{payment.payment_method.replace('_', ' ')}</TableCell>
                                                 <TableCell>{payment.reference_number || 'N/A'}</TableCell>


### PR DESCRIPTION
## Description

This PR fixes two issues:
1. PaymentSeeder using `fake()` helper that doesn't exist in production
2. Invoice payment history not displaying payment numbers

## Issues Fixed

### 1. PaymentSeeder Faker Error
**Problem**: Seeder was using `fake()` helper which caused error:
```
Call to undefined function Database\Seeders\fake()
```

**Solution**: 
- Use `\Faker\Factory::create()` instead of `fake()` helper
- Use `array_rand()` instead of `randomElement()`

### 2. Missing Payment Numbers in Invoice View
**Problem**: Invoice payment history table showed empty payment numbers

**Solution**:
- Changed Payment interface from `payment_number` to `receipt_number`
- Updated display to show `receipt_number` with fallback to payment ID
- Matches actual database schema (payments table has `receipt_number` column)

## Changes Made

### Backend
- `database/seeders/PaymentSeeder.php` - Fixed Faker usage

### Frontend  
- `resources/js/pages/super-admin/invoices/show.tsx` - Fixed payment number display

## Testing

✅ All pre-push checks passed
✅ TypeScript compilation successful
✅ Code style and static analysis passed

## Related

- Follows up on PR #253 (PaymentSeeder)