### PR TITLE
fix: Remove schoolYear relationship from enrollment edit

### DIFF
--- a/app/Http/Controllers/SuperAdmin/EnrollmentController.php
+++ b/app/Http/Controllers/SuperAdmin/EnrollmentController.php
@@ -191,7 +191,7 @@ class EnrollmentController extends Controller
     {
         Gate::authorize('update', $enrollment);
 
-        $enrollment->load(['student', 'guardian', 'schoolYear']);
+        $enrollment->load(['student', 'guardian']);
         $students = Student::with('guardians')->get();
         $guardians = Guardian::with('user')->get();
 

--- a/resources/js/pages/super-admin/enrollments/edit.tsx
+++ b/resources/js/pages/super-admin/enrollments/edit.tsx
@@ -41,7 +41,6 @@ interface Enrollment {
     payment_plan: string;
     student: Student;
     guardian: Guardian;
-    schoolYear?: SchoolYear;
 }
 
 interface GradeLevel {


### PR DESCRIPTION
## Problem

When editing an enrollment at `/super-admin/enrollments/{id}/edit`, React threw an error:

```
Uncaught Error: Objects are not valid as a React child 
(found: object with keys {id, name, start_year, end_year, ...})
```

## Root Cause

The controller was loading the `schoolYear` relationship:
```php
$enrollment->load(['student', 'guardian', 'schoolYear']);
```

This caused Inertia to serialize the full SchoolYear object and pass it to the frontend. Somewhere in the component, React was trying to render this object directly.

## Solution

Removed the `schoolYear` relationship from the load since we don't actually need it:

**Backend:**
- Removed `'schoolYear'` from `$enrollment->load()`
- We only need `school_year_id` (for the form) and `school_year` string (for display)
- Both are already on the enrollment model

**Frontend:**
- Removed `schoolYear?: SchoolYear` from the Enrollment interface
- Form still works correctly with the existing fields

## Testing

✅ Edit enrollment page loads without errors
✅ School year dropdown shows correct values
✅ Current school year displays correctly
✅ Form submission works

## Related

- Part of Issue #262 - Enrollment forms
- Follow-up to PR #270