### PR TITLE
fix: Registrar grade level fee form validation and authorization

### DIFF
--- a/app/Http/Controllers/Registrar/GradeLevelFeeController.php
+++ b/app/Http/Controllers/Registrar/GradeLevelFeeController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Registrar;
 
 use App\Enums\GradeLevel;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\SuperAdmin\StoreGradeLevelFeeRequest;
+use App\Http\Requests\SuperAdmin\UpdateGradeLevelFeeRequest;
 use App\Models\GradeLevelFee;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -75,28 +77,18 @@ class GradeLevelFeeController extends Controller
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(StoreGradeLevelFeeRequest $request)
     {
         // Check if user has permission to manage fees
         if (! auth()->user()->can('grade_level_fees.manage')) {
             abort(403, 'Unauthorized to manage grade level fees');
         }
 
-        $validated = $request->validate([
-            'grade_level' => ['required', 'string'],
-            'school_year' => ['required', 'regex:/^\d{4}-\d{4}$/'],
-            'enrollment_fee' => ['required', 'numeric', 'min:0'],
-            'tuition_fee' => ['required', 'numeric', 'min:0'],
-            'miscellaneous_fee' => ['required', 'numeric', 'min:0'],
-            'computer_fee' => ['nullable', 'numeric', 'min:0'],
-            'library_fee' => ['nullable', 'numeric', 'min:0'],
-            'laboratory_fee' => ['nullable', 'numeric', 'min:0'],
-            'pe_uniform_fee' => ['nullable', 'numeric', 'min:0'],
-            'school_uniform_fee' => ['nullable', 'numeric', 'min:0'],
-            'books_fee' => ['nullable', 'numeric', 'min:0'],
-            'description' => ['nullable', 'string', 'max:500'],
-            'is_active' => ['boolean'],
-        ]);
+        $validated = $request->validated();
+
+        // Get the school year to populate the school_year string field
+        $schoolYear = \App\Models\SchoolYear::findOrFail($validated['school_year_id']);
+        $validated['school_year'] = $schoolYear->name;
 
         // Set created_by to track who created the fee
         $validated['created_by'] = auth()->id();
@@ -147,28 +139,18 @@ class GradeLevelFeeController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, GradeLevelFee $gradeLevelFee)
+    public function update(UpdateGradeLevelFeeRequest $request, GradeLevelFee $gradeLevelFee)
     {
         // Check if user has permission to manage fees
         if (! auth()->user()->can('grade_level_fees.manage')) {
             abort(403, 'Unauthorized to manage grade level fees');
         }
 
-        $validated = $request->validate([
-            'grade_level' => ['required', 'string'],
-            'school_year' => ['required', 'regex:/^\d{4}-\d{4}$/'],
-            'enrollment_fee' => ['required', 'numeric', 'min:0'],
-            'tuition_fee' => ['required', 'numeric', 'min:0'],
-            'miscellaneous_fee' => ['required', 'numeric', 'min:0'],
-            'computer_fee' => ['nullable', 'numeric', 'min:0'],
-            'library_fee' => ['nullable', 'numeric', 'min:0'],
-            'laboratory_fee' => ['nullable', 'numeric', 'min:0'],
-            'pe_uniform_fee' => ['nullable', 'numeric', 'min:0'],
-            'school_uniform_fee' => ['nullable', 'numeric', 'min:0'],
-            'books_fee' => ['nullable', 'numeric', 'min:0'],
-            'description' => ['nullable', 'string', 'max:500'],
-            'is_active' => ['boolean'],
-        ]);
+        $validated = $request->validated();
+
+        // Get the school year to populate the school_year string field
+        $schoolYear = \App\Models\SchoolYear::findOrFail($validated['school_year_id']);
+        $validated['school_year'] = $schoolYear->name;
 
         // Set updated_by to track who updated the fee
         $validated['updated_by'] = auth()->id();

--- a/app/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequest.php
@@ -11,7 +11,7 @@ class StoreGradeLevelFeeRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return $this->user()->hasRole('super_admin');
+        return $this->user()->can('grade_level_fees.manage');
     }
 
     /**

--- a/app/Http/Requests/SuperAdmin/UpdateGradeLevelFeeRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateGradeLevelFeeRequest.php
@@ -11,7 +11,7 @@ class UpdateGradeLevelFeeRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return $this->user()->hasRole('super_admin');
+        return $this->user()->can('grade_level_fees.manage');
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes issues with the Registrar grade level fee create and edit forms that were preventing form submission.

## Issues Fixed
1. **Form validation error**: Registrar controller was using inline validation with old rules expecting `school_year` string, but forms were sending `school_year_id`
2. **403 Forbidden error**: Form requests were checking for `super_admin` role instead of `grade_level_fees.manage` permission

## Changes Made

### 1. Updated Registrar Controller
- Import and use `StoreGradeLevelFeeRequest` and `UpdateGradeLevelFeeRequest` from SuperAdmin namespace
- Both `store()` and `update()` methods now:
  - Use form request validation
  - Handle `school_year_id` properly
  - Populate `school_year` string field from SchoolYear model

### 2. Fixed Form Request Authorization
- Changed authorization check in both form requests:
  - **Before**: `hasRole('super_admin')`
  - **After**: `can('grade_level_fees.manage')`
- This allows Registrars (and anyone with the permission) to use the forms

## Testing
- ✅ All 754 tests passing
- ✅ Pre-push checks passed
- ✅ Manually tested create and edit forms work for Registrar role

## Related
- Follows up on merged PR #273 (Grade Level Fee Forms - School Year Integration)