### PR TITLE
fix: Add missing Admin controller routes to resolve 404 regression (TICKET-033)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
+use App\Http\Controllers\Admin\AuditLogController as AdminAuditLogController;
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
+use App\Http\Controllers\Admin\DocumentController as AdminDocumentController;
 use App\Http\Controllers\Admin\EnrollmentController as AdminEnrollmentController;
+use App\Http\Controllers\Admin\EnrollmentPeriodController as AdminEnrollmentPeriodController;
+use App\Http\Controllers\Admin\GradeLevelFeeController as AdminGradeLevelFeeController;
+use App\Http\Controllers\Admin\PaymentController as AdminPaymentController;
+use App\Http\Controllers\Admin\ReportController as AdminReportController;
+use App\Http\Controllers\Admin\SchoolInformationController as AdminSchoolInformationController;
 use App\Http\Controllers\Admin\StudentController as AdminStudentController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Guardian\BillingController as GuardianBillingController;
@@ -187,6 +194,41 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
         // Users Management (limited compared to super-admin)
         Route::resource('users', AdminUserController::class);
+
+        // Payments Management
+        Route::resource('payments', AdminPaymentController::class);
+
+        // Grade Level Fees Management
+        Route::resource('grade-level-fees', AdminGradeLevelFeeController::class);
+        Route::post('/grade-level-fees/{gradeLevelFee}/duplicate', [AdminGradeLevelFeeController::class, 'duplicate'])->name('grade-level-fees.duplicate');
+
+        // Enrollment Periods Management
+        Route::resource('enrollment-periods', AdminEnrollmentPeriodController::class);
+        Route::post('/enrollment-periods/{enrollmentPeriod}/activate', [AdminEnrollmentPeriodController::class, 'activate'])->name('enrollment-periods.activate');
+        Route::post('/enrollment-periods/{enrollmentPeriod}/close', [AdminEnrollmentPeriodController::class, 'close'])->name('enrollment-periods.close');
+
+        // Document Management
+        Route::get('/documents/pending', [AdminDocumentController::class, 'pending'])->name('documents.pending');
+        Route::get('/documents/{document}', [AdminDocumentController::class, 'show'])->name('documents.show');
+        Route::get('/documents/{document}/view', [AdminDocumentController::class, 'view'])->name('documents.view');
+        Route::post('/documents/{document}/verify', [AdminDocumentController::class, 'verify'])->name('documents.verify');
+        Route::post('/documents/{document}/reject', [AdminDocumentController::class, 'reject'])->name('documents.reject');
+
+        // Reports Management
+        Route::get('/reports', [AdminReportController::class, 'index'])->name('reports.index');
+
+        // Audit Logs Management
+        Route::prefix('audit-logs')->name('audit-logs.')->group(function () {
+            Route::get('/', [AdminAuditLogController::class, 'index'])->name('index');
+            Route::get('/{activity}', [AdminAuditLogController::class, 'show'])->name('show');
+            Route::post('/export', [AdminAuditLogController::class, 'export'])->name('export');
+        });
+
+        // School Information Management
+        Route::prefix('school-information')->name('school-information.')->group(function () {
+            Route::get('/', [AdminSchoolInformationController::class, 'index'])->name('index');
+            Route::put('/', [AdminSchoolInformationController::class, 'update'])->name('update');
+        });
     });
 
     // Registrar Routes


### PR DESCRIPTION
## Summary

Fixes 404 errors occurring when administrators click sidebar navigation links for Payments, Grade Level Fees, Enrollment Periods, Documents, Reports, Audit Logs, and School Information.

**Closes:** TICKET-033

## Problem

After the `feat/remove-school-year-column` refactor was merged, administrators started getting 404 errors when accessing the following routes:

- `/admin/payments`
- `/admin/grade-level-fees`
- `/admin/enrollment-periods`
- `/admin/documents/pending`
- `/admin/reports`
- `/admin/audit-logs`
- `/admin/school-information`

**Root Cause:** Route definitions for these admin features were missing from `routes/web.php`. The admin sidebar correctly pointed to `/admin/*` URLs, but no corresponding routes existed under the admin route group.

## Solution

Added complete admin route definitions to `routes/web.php`:

### Added Controller Use Statements (alphabetically sorted)
- `AdminAuditLogController`
- `AdminDocumentController`
- `AdminEnrollmentPeriodController`
- `AdminGradeLevelFeeController`
- `AdminPaymentController`
- `AdminReportController`
- `AdminSchoolInformationController`

### Added Route Groups
1. **Payments Management** - RESTful resource routes
2. **Grade Level Fees Management** - Resource routes + duplicate action
3. **Enrollment Periods Management** - Resource routes + activate/close actions
4. **Document Management** - pending, show, view, verify, reject routes
5. **Reports Management** - index route
6. **Audit Logs Management** - index, show, export routes (nested group)
7. **School Information Management** - index, update routes (nested group)

All routes use:
- Prefix: `/admin`
- Named route prefix: `admin.`
- Middleware: `role:administrator`
- Admin controllers from `App\Http\Controllers\Admin\` namespace

## Testing

✅ All existing tests pass
✅ Pre-push checks passed (PHP syntax, Pint, PHPStan, security audit, TypeScript, Prettier)
✅ Code coverage maintained above 60% threshold

### Manual Testing Checklist

- [x] Administrator can access `/admin/payments`
- [x] Administrator can access `/admin/grade-level-fees`
- [x] Administrator can access `/admin/enrollment-periods`
- [x] Administrator can access `/admin/documents/pending`
- [x] Administrator can access `/admin/reports`
- [x] Administrator can access `/admin/audit-logs`
- [x] Administrator can access `/admin/school-information`
- [x] Super admin retains existing access
- [x] No 404 errors on admin navigation

## Files Changed

- `routes/web.php` - Added 7 missing admin controller use statements and complete admin route definitions (42 new lines)

## Impact

- **Users Affected:** Administrators
- **Severity:** High (blocking access to critical features)
- **Risk:** Low (route additions only, no logic changes)
- **Breaking Changes:** None

## Related

- Introduced by: `feat/remove-school-year-column` refactor
- Related Branch: `feat/remove-school-year-column`
- Priority: High