### PR TITLE
feat: Add complete Document management CRUD for Super Admin with navigation

### DIFF
--- a/app/Http/Controllers/SuperAdmin/DocumentController.php
+++ b/app/Http/Controllers/SuperAdmin/DocumentController.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\SuperAdmin\RejectDocumentRequest;
+use App\Models\Document;
+use App\Notifications\DocumentRejectedNotification;
+use App\Notifications\DocumentVerifiedNotification;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+
+class DocumentController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * Display a listing of all documents.
+     */
+    public function index(Request $request)
+    {
+        Gate::authorize('viewAny', Document::class);
+
+        $query = Document::with(['student', 'verifiedBy']);
+
+        // Apply filters
+        if ($request->filled('verification_status')) {
+            $query->where('verification_status', $request->get('verification_status'));
+        }
+
+        if ($request->filled('document_type')) {
+            $query->where('document_type', $request->get('document_type'));
+        }
+
+        if ($request->filled('student_id')) {
+            $query->where('student_id', $request->get('student_id'));
+        }
+
+        if ($request->filled('search')) {
+            $search = $request->get('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('original_filename', 'like', "%{$search}%")
+                    ->orWhereHas('student', function ($studentQuery) use ($search) {
+                        $studentQuery->where('first_name', 'like', "%{$search}%")
+                            ->orWhere('last_name', 'like', "%{$search}%");
+                    });
+            });
+        }
+
+        $documents = $query->latest('upload_date')->paginate(20)->withQueryString();
+
+        return Inertia::render('super-admin/documents/index', [
+            'documents' => $documents,
+            'filters' => $request->only(['verification_status', 'document_type', 'student_id', 'search']),
+        ]);
+    }
+
+    /**
+     * Display the specified document.
+     */
+    public function show(Document $document)
+    {
+        Gate::authorize('view', $document);
+
+        $document->load(['student.guardians', 'verifiedBy']);
+
+        // Generate temporary signed URL for file viewing
+        $url = Storage::disk('private')->temporaryUrl(
+            $document->file_path,
+            now()->addMinutes(5)
+        );
+
+        return Inertia::render('super-admin/documents/show', [
+            'document' => $document,
+            'fileUrl' => $url,
+        ]);
+    }
+
+    /**
+     * View/download the specified document file.
+     */
+    public function view(Document $document)
+    {
+        Gate::authorize('view', $document);
+
+        // Return the file for viewing in browser
+        return Storage::disk('private')->response($document->file_path, $document->original_filename);
+    }
+
+    /**
+     * Verify the specified document.
+     */
+    public function verify(Document $document)
+    {
+        Gate::authorize('verify', $document);
+
+        $document->verify(auth()->user());
+
+        // Log activity
+        activity()
+            ->performedOn($document)
+            ->withProperties([
+                'document_type' => $document->document_type,
+                'student_id' => $document->student_id,
+            ])
+            ->log('Document verified');
+
+        // Notify all guardians of the student
+        $document->student->guardians->each(function ($guardian) use ($document) {
+            $guardian->user?->notify(new DocumentVerifiedNotification($document));
+        });
+
+        return redirect()->route('super-admin.documents.index')
+            ->with('success', 'Document verified successfully.');
+    }
+
+    /**
+     * Reject the specified document.
+     */
+    public function reject(RejectDocumentRequest $request, Document $document)
+    {
+        Gate::authorize('reject', $document);
+
+        $document->reject(auth()->user(), $request->validated()['notes']);
+
+        // Log activity
+        activity()
+            ->performedOn($document)
+            ->withProperties([
+                'document_type' => $document->document_type,
+                'student_id' => $document->student_id,
+                'rejection_reason' => $request->validated()['notes'],
+            ])
+            ->log('Document rejected');
+
+        // Notify all guardians of the student
+        $document->student->guardians->each(function ($guardian) use ($document) {
+            $guardian->user?->notify(new DocumentRejectedNotification($document));
+        });
+
+        return redirect()->route('super-admin.documents.index')
+            ->with('success', 'Document rejected.');
+    }
+
+    /**
+     * Remove the specified document from storage.
+     */
+    public function destroy(Document $document)
+    {
+        Gate::authorize('delete', $document);
+
+        $documentData = $document->toArray();
+        $document->delete();
+
+        activity()
+            ->withProperties($documentData)
+            ->log('Document deleted');
+
+        return redirect()->route('super-admin.documents.index')
+            ->with('success', 'Document deleted successfully.');
+    }
+}

--- a/app/Http/Requests/SuperAdmin/RejectDocumentRequest.php
+++ b/app/Http/Requests/SuperAdmin/RejectDocumentRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\SuperAdmin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectDocumentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true; // Authorization is handled via policy in controller
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'notes' => 'required|string|min:10|max:500',
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'notes.required' => 'Please provide a reason for rejection.',
+            'notes.min' => 'Rejection reason must be at least 10 characters.',
+            'notes.max' => 'Rejection reason must not exceed 500 characters.',
+        ];
+    }
+}

--- a/resources/js/components/sidebars/super-admin-sidebar.tsx
+++ b/resources/js/components/sidebars/super-admin-sidebar.tsx
@@ -8,6 +8,7 @@ import {
     Calendar,
     ClipboardList,
     FileCheck,
+    FileText,
     GraduationCap,
     LayoutGrid,
     Receipt,
@@ -53,6 +54,11 @@ const mainNavItems: NavItem[] = [
         title: 'Users',
         href: '/super-admin/users',
         icon: UserCog,
+    },
+    {
+        title: 'Documents',
+        href: '/super-admin/documents',
+        icon: FileText,
     },
     {
         title: 'Invoices',

--- a/resources/js/pages/super-admin/documents/index.tsx
+++ b/resources/js/pages/super-admin/documents/index.tsx
@@ -1,0 +1,191 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { DataTable } from '@/components/ui/data-table';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, router } from '@inertiajs/react';
+import { ColumnDef } from '@tanstack/react-table';
+import { CheckCircle, Eye, Trash2, XCircle } from 'lucide-react';
+
+interface Student {
+    id: number;
+    first_name: string;
+    last_name: string;
+}
+
+interface VerifiedBy {
+    id: number;
+    name: string;
+}
+
+interface Document {
+    id: number;
+    document_type: string;
+    original_filename: string;
+    file_size: number;
+    mime_type: string;
+    upload_date: string;
+    verification_status: string;
+    verified_at: string | null;
+    rejection_reason: string | null;
+    student: Student;
+    verified_by: VerifiedBy | null;
+}
+
+interface PaginatedDocuments {
+    data: Document[];
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+}
+
+interface Props {
+    documents: PaginatedDocuments;
+}
+
+export default function DocumentsIndex({ documents }: Props) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Super Admin', href: '/super-admin/dashboard' },
+        { title: 'Documents', href: '/super-admin/documents' },
+    ];
+
+    const getStatusBadgeVariant = (status: string): 'default' | 'secondary' | 'destructive' => {
+        switch (status) {
+            case 'verified':
+                return 'default';
+            case 'pending':
+                return 'secondary';
+            case 'rejected':
+                return 'destructive';
+            default:
+                return 'secondary';
+        }
+    };
+
+    const getDocumentTypeLabel = (type: string): string => {
+        const labels: Record<string, string> = {
+            birth_certificate: 'Birth Certificate',
+            report_card: 'Report Card',
+            form_138: 'Form 138',
+            good_moral: 'Good Moral Certificate',
+            other: 'Other Document',
+        };
+        return labels[type] || type;
+    };
+
+    const formatFileSize = (bytes: number): string => {
+        const units = ['B', 'KB', 'MB', 'GB'];
+        let size = bytes;
+        let unitIndex = 0;
+
+        while (size >= 1024 && unitIndex < units.length - 1) {
+            size /= 1024;
+            unitIndex++;
+        }
+
+        return `${size.toFixed(2)} ${units[unitIndex]}`;
+    };
+
+    const handleVerify = (id: number) => {
+        if (confirm('Are you sure you want to verify this document?')) {
+            router.post(`/super-admin/documents/${id}/verify`);
+        }
+    };
+
+    const handleReject = (id: number) => {
+        const reason = prompt('Please provide a reason for rejection (minimum 10 characters):');
+        if (reason && reason.length >= 10) {
+            router.post(`/super-admin/documents/${id}/reject`, { notes: reason });
+        } else if (reason) {
+            alert('Rejection reason must be at least 10 characters.');
+        }
+    };
+
+    const handleDelete = (id: number) => {
+        if (confirm('Are you sure you want to delete this document? This action cannot be undone.')) {
+            router.delete(`/super-admin/documents/${id}`);
+        }
+    };
+
+    const columns: ColumnDef<Document>[] = [
+        {
+            accessorKey: 'student',
+            header: 'Student',
+            cell: ({ row }) => (
+                <div>
+                    <div className="font-medium">
+                        {row.original.student.first_name} {row.original.student.last_name}
+                    </div>
+                    <div className="text-xs text-muted-foreground">{getDocumentTypeLabel(row.original.document_type)}</div>
+                </div>
+            ),
+        },
+        {
+            accessorKey: 'original_filename',
+            header: 'File Name',
+            cell: ({ row }) => (
+                <div>
+                    <div className="font-medium">{row.original.original_filename}</div>
+                    <div className="text-xs text-muted-foreground">{formatFileSize(row.original.file_size)}</div>
+                </div>
+            ),
+        },
+        {
+            accessorKey: 'upload_date',
+            header: 'Upload Date',
+            cell: ({ row }) => new Date(row.original.upload_date).toLocaleDateString(),
+        },
+        {
+            accessorKey: 'verification_status',
+            header: 'Status',
+            cell: ({ row }) => (
+                <Badge variant={getStatusBadgeVariant(row.original.verification_status)}>
+                    {row.original.verification_status.charAt(0).toUpperCase() + row.original.verification_status.slice(1)}
+                </Badge>
+            ),
+        },
+        {
+            id: 'actions',
+            header: 'Actions',
+            cell: ({ row }) => (
+                <div className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => router.visit(`/super-admin/documents/${row.original.id}`)}>
+                        <Eye className="mr-1 h-3 w-3" />
+                        View
+                    </Button>
+                    {row.original.verification_status === 'pending' && (
+                        <>
+                            <Button size="sm" variant="outline" onClick={() => handleVerify(row.original.id)}>
+                                <CheckCircle className="mr-1 h-3 w-3" />
+                                Verify
+                            </Button>
+                            <Button size="sm" variant="outline" onClick={() => handleReject(row.original.id)}>
+                                <XCircle className="mr-1 h-3 w-3" />
+                                Reject
+                            </Button>
+                        </>
+                    )}
+                    <Button size="sm" variant="destructive" onClick={() => handleDelete(row.original.id)}>
+                        <Trash2 className="h-3 w-3" />
+                    </Button>
+                </div>
+            ),
+        },
+    ];
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Documents" />
+            <div className="px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold">Documents</h1>
+                        <p className="mt-1 text-sm text-muted-foreground">Manage student documents and verification status</p>
+                    </div>
+                </div>
+                <DataTable columns={columns} data={documents.data} />
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/documents/show.tsx
+++ b/resources/js/pages/super-admin/documents/show.tsx
@@ -1,0 +1,240 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AppLayout from '@/layouts/app-layout';
+import { Head, Link, router } from '@inertiajs/react';
+import { ArrowLeft, Calendar, CheckCircle, Download, FileText, User, XCircle } from 'lucide-react';
+
+interface Guardian {
+    id: number;
+    first_name: string;
+    last_name: string;
+}
+
+interface Student {
+    id: number;
+    first_name: string;
+    last_name: string;
+    guardians: Guardian[];
+}
+
+interface VerifiedBy {
+    id: number;
+    name: string;
+}
+
+interface Document {
+    id: number;
+    document_type: string;
+    original_filename: string;
+    file_size: number;
+    mime_type: string;
+    upload_date: string;
+    verification_status: string;
+    verified_at: string | null;
+    rejection_reason: string | null;
+    student: Student;
+    verified_by: VerifiedBy | null;
+}
+
+interface Props {
+    document: Document;
+    fileUrl: string;
+}
+
+export default function DocumentShow({ document, fileUrl }: Props) {
+    const getStatusBadgeVariant = (status: string): 'default' | 'secondary' | 'destructive' => {
+        switch (status) {
+            case 'verified':
+                return 'default';
+            case 'pending':
+                return 'secondary';
+            case 'rejected':
+                return 'destructive';
+            default:
+                return 'secondary';
+        }
+    };
+
+    const getDocumentTypeLabel = (type: string): string => {
+        const labels: Record<string, string> = {
+            birth_certificate: 'Birth Certificate',
+            report_card: 'Report Card',
+            form_138: 'Form 138',
+            good_moral: 'Good Moral Certificate',
+            other: 'Other Document',
+        };
+        return labels[type] || type;
+    };
+
+    const formatFileSize = (bytes: number): string => {
+        const units = ['B', 'KB', 'MB', 'GB'];
+        let size = bytes;
+        let unitIndex = 0;
+
+        while (size >= 1024 && unitIndex < units.length - 1) {
+            size /= 1024;
+            unitIndex++;
+        }
+
+        return `${size.toFixed(2)} ${units[unitIndex]}`;
+    };
+
+    const handleVerify = () => {
+        if (confirm('Are you sure you want to verify this document?')) {
+            router.post(`/super-admin/documents/${document.id}/verify`);
+        }
+    };
+
+    const handleReject = () => {
+        const reason = prompt('Please provide a reason for rejection (minimum 10 characters):');
+        if (reason && reason.length >= 10) {
+            router.post(`/super-admin/documents/${document.id}/reject`, { notes: reason });
+        } else if (reason) {
+            alert('Rejection reason must be at least 10 characters.');
+        }
+    };
+
+    const handleDelete = () => {
+        if (confirm('Are you sure you want to delete this document? This action cannot be undone.')) {
+            router.delete(`/super-admin/documents/${document.id}`);
+        }
+    };
+
+    return (
+        <AppLayout
+            breadcrumbs={[
+                { title: 'Super Admin', href: '/super-admin/dashboard' },
+                { title: 'Documents', href: '/super-admin/documents' },
+                { title: 'View Document', href: '#' },
+            ]}
+        >
+            <Head title="View Document" />
+            <div className="px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                        <Link href="/super-admin/documents">
+                            <Button variant="outline" size="sm">
+                                <ArrowLeft className="mr-2 h-4 w-4" />
+                                Back to Documents
+                            </Button>
+                        </Link>
+                        <div>
+                            <h1 className="flex items-center gap-2 text-2xl font-bold">
+                                {document.original_filename}
+                                <Badge variant={getStatusBadgeVariant(document.verification_status)}>
+                                    {document.verification_status.charAt(0).toUpperCase() + document.verification_status.slice(1)}
+                                </Badge>
+                            </h1>
+                            <p className="text-sm text-muted-foreground">{getDocumentTypeLabel(document.document_type)}</p>
+                        </div>
+                    </div>
+                    <div className="flex gap-2">
+                        <Button variant="outline" onClick={() => window.open(fileUrl, '_blank')}>
+                            <Download className="mr-2 h-4 w-4" />
+                            Download
+                        </Button>
+                        {document.verification_status === 'pending' && (
+                            <>
+                                <Button variant="outline" onClick={handleVerify}>
+                                    <CheckCircle className="mr-2 h-4 w-4" />
+                                    Verify
+                                </Button>
+                                <Button variant="outline" onClick={handleReject}>
+                                    <XCircle className="mr-2 h-4 w-4" />
+                                    Reject
+                                </Button>
+                            </>
+                        )}
+                        <Button variant="destructive" onClick={handleDelete}>
+                            Delete Document
+                        </Button>
+                    </div>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-3">
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">Student Information</CardTitle>
+                            <User className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">
+                                {document.student.first_name} {document.student.last_name}
+                            </div>
+                            <p className="text-xs text-muted-foreground">{document.student.guardians.length} guardian(s) registered</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">File Details</CardTitle>
+                            <FileText className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">{formatFileSize(document.file_size)}</div>
+                            <p className="text-xs text-muted-foreground">{document.mime_type}</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">Upload Date</CardTitle>
+                            <Calendar className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">{new Date(document.upload_date).toLocaleDateString()}</div>
+                            <p className="text-xs text-muted-foreground">{new Date(document.upload_date).toLocaleTimeString()}</p>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                {document.verified_by && (
+                    <Card className="mt-4">
+                        <CardHeader>
+                            <CardTitle>Verification Information</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-2">
+                            <div>
+                                <span className="font-medium">Verified by:</span> {document.verified_by.name}
+                            </div>
+                            {document.verified_at && (
+                                <div>
+                                    <span className="font-medium">Verified at:</span> {new Date(document.verified_at).toLocaleString()}
+                                </div>
+                            )}
+                            {document.rejection_reason && (
+                                <div>
+                                    <span className="font-medium">Rejection reason:</span>
+                                    <p className="mt-1 rounded-md bg-destructive/10 p-2 text-sm">{document.rejection_reason}</p>
+                                </div>
+                            )}
+                        </CardContent>
+                    </Card>
+                )}
+
+                <Card className="mt-4">
+                    <CardHeader>
+                        <CardTitle>Document Preview</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {document.mime_type.startsWith('image/') ? (
+                            <img src={fileUrl} alt={document.original_filename} className="max-h-[600px] w-full rounded-lg object-contain" />
+                        ) : (
+                            <div className="flex min-h-[400px] items-center justify-center rounded-lg border-2 border-dashed">
+                                <div className="text-center">
+                                    <FileText className="mx-auto h-12 w-12 text-muted-foreground" />
+                                    <p className="mt-2 text-sm text-muted-foreground">Preview not available for this file type</p>
+                                    <Button variant="outline" className="mt-4" onClick={() => window.open(fileUrl, '_blank')}>
+                                        <Download className="mr-2 h-4 w-4" />
+                                        Download to View
+                                    </Button>
+                                </div>
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,7 @@ use App\Http\Controllers\Student\DashboardController as StudentDashboardControll
 use App\Http\Controllers\StudentReportController;
 use App\Http\Controllers\SuperAdmin\AuditLogController as SuperAdminAuditLogController;
 use App\Http\Controllers\SuperAdmin\DashboardController as SuperAdminDashboardController;
+use App\Http\Controllers\SuperAdmin\DocumentController as SuperAdminDocumentController;
 use App\Http\Controllers\SuperAdmin\EnrollmentController as SuperAdminEnrollmentController;
 use App\Http\Controllers\SuperAdmin\EnrollmentPeriodController as SuperAdminEnrollmentPeriodController;
 use App\Http\Controllers\SuperAdmin\GradeLevelFeeController as SuperAdminGradeLevelFeeController;
@@ -158,6 +159,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
         // Payments Management
         Route::resource('payments', SuperAdminPaymentController::class);
         Route::post('/payments/{payment}/refund', [SuperAdminPaymentController::class, 'refund'])->name('payments.refund');
+
+        // Documents Management
+        Route::resource('documents', SuperAdminDocumentController::class)->only(['index', 'show', 'destroy']);
+        Route::get('/documents/{document}/view', [SuperAdminDocumentController::class, 'view'])->name('documents.view');
+        Route::post('/documents/{document}/verify', [SuperAdminDocumentController::class, 'verify'])->name('documents.verify');
+        Route::post('/documents/{document}/reject', [SuperAdminDocumentController::class, 'reject'])->name('documents.reject');
 
         // Grade Level Fees Management
         Route::resource('grade-level-fees', SuperAdminGradeLevelFeeController::class);


### PR DESCRIPTION
## Summary
Implements complete Document management CRUD for Super Admin with focus on viewing, verification, and deletion operations.

## Key Differences from Other CRUDs
Documents are **uploaded by guardians**, not created by admins. Therefore, Super Admin CRUD focuses on:
- Viewing all documents with filtering
- Verifying/rejecting documents
- Deleting documents
- **No create/edit forms** (documents come from guardian uploads)

## Backend Changes
- **DocumentController**: View-focused operations
  - `index()`: List all documents with filters (status, type, student, search)
  - `show()`: View document details with temporary signed URL (5-min expiry)
  - `view()`: Download/view file directly
  - `verify()`: Mark document as verified and notify guardians
  - `reject()`: Mark document as rejected with reason and notify guardians
  - `destroy()`: Delete document (soft delete with automatic file cleanup)
  - Authorization via Gate::authorize() for all actions
  - Activity logging for all operations
  - Guardian notifications on verify/reject

- **RejectDocumentRequest**: Validation for rejection
  - Required notes field (10-500 characters)
  - Custom error messages

- **Authorization**: Uses existing DocumentPolicy
  - viewAny/view: super_admin, administrator, registrar, guardian
  - verify/reject: super_admin, administrator, registrar
  - delete: super_admin, administrator

## Frontend Changes
- **Index Page**: DataTable with all documents
  - Status badges (pending/verified/rejected) with color coding
  - Document type labels (Birth Certificate, Report Card, Form 138, Good Moral, Other)
  - File size in human-readable format
  - Student name and document type display
  - Quick actions: View, Verify, Reject, Delete
  - Inline verification/rejection with confirmation prompts
  - Contextual actions (only show verify/reject for pending documents)

- **Show Page**: Detailed document view
  - Three stat cards: Student info, File details, Upload date
  - Verification information card (verifier, timestamp, rejection reason)
  - Image preview for image files
  - Download prompt for non-image files
  - Quick actions bar with verify/reject/delete
  - Back to list navigation
  - Breadcrumb navigation

- **TypeScript**: All components use proper TypeScript interfaces

## Navigation
- Added "Documents" item to super-admin sidebar
- FileText icon from lucide-react
- Positioned after Users and before Invoices

## Routes
- Resource routes: index, show, destroy only (no create/edit)
- Custom routes: view, verify, reject
- All routes under super-admin prefix with role middleware

## Technical Details
- Laravel 12 controller with Inertia.js
- React 18+ with TypeScript
- shadcn/ui components (Button, Card, Badge, DataTable)
- TanStack Table for data tables
- File storage via Laravel's private disk
- Temporary signed URLs for secure file access (5-minute expiry)
- Activity logging using activity() helper

## Testing
✅ All pre-push checks passed:
- PHP syntax check
- Code style (Laravel Pint)
- Static analysis (PHPStan)
- Security audit (Composer audit)
- Vite build
- TypeScript compilation
- Prettier formatting
- Test coverage (>60%)

## Files Changed
- Backend: 2 new files (Controller, Request)
- Frontend: 2 new pages (index, show)
- Modified: routes/web.php, super-admin-sidebar.tsx

## Related Models
- Document model with student and verifiedBy relationships
- DocumentType enum (5 types)
- VerificationStatus enum (pending, verified, rejected)
- SoftDeletes with automatic file cleanup

## Notes
- No create/edit pages since documents are uploaded by guardians
- Uses existing DocumentPolicy (no new policy needed)
- File viewing uses temporary signed URLs for security
- Guardian notifications sent automatically on verify/reject