### PR TITLE
feat: Add complete Receipt CRUD for Super Admin with navigation

### DIFF
--- a/app/Http/Controllers/SuperAdmin/ReceiptController.php
+++ b/app/Http/Controllers/SuperAdmin/ReceiptController.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\SuperAdmin\StoreReceiptRequest;
+use App\Http\Requests\SuperAdmin\UpdateReceiptRequest;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\Receipt;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+
+class ReceiptController extends Controller
+{
+    /**
+     * Display a listing of receipts.
+     */
+    public function index(Request $request)
+    {
+        Gate::authorize('viewAny', Receipt::class);
+
+        $query = Receipt::with(['payment.invoice.enrollment.student', 'invoice.enrollment.student', 'receivedBy']);
+
+        // Apply filters
+        if ($request->filled('search')) {
+            $search = $request->get('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('receipt_number', 'like', "%{$search}%")
+                    ->orWhere('payment_method', 'like', "%{$search}%")
+                    ->orWhereHas('payment.invoice.enrollment.student', function ($studentQuery) use ($search) {
+                        $studentQuery->where('first_name', 'like', "%{$search}%")
+                            ->orWhere('last_name', 'like', "%{$search}%");
+                    });
+            });
+        }
+
+        if ($request->filled('payment_method')) {
+            $query->where('payment_method', $request->get('payment_method'));
+        }
+
+        if ($request->filled('date_from')) {
+            $query->whereDate('receipt_date', '>=', $request->get('date_from'));
+        }
+
+        if ($request->filled('date_to')) {
+            $query->whereDate('receipt_date', '<=', $request->get('date_to'));
+        }
+
+        $receipts = $query->latest('receipt_date')->paginate(20)->withQueryString();
+
+        return Inertia::render('super-admin/receipts/index', [
+            'receipts' => $receipts,
+            'filters' => $request->only(['search', 'payment_method', 'date_from', 'date_to']),
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new receipt.
+     */
+    public function create()
+    {
+        Gate::authorize('create', Receipt::class);
+
+        $payments = Payment::with('invoice.enrollment.student')->whereDoesntHave('receipt')->get();
+        $invoices = Invoice::with('enrollment.student')->get();
+
+        return Inertia::render('super-admin/receipts/create', [
+            'payments' => $payments,
+            'invoices' => $invoices,
+            'nextReceiptNumber' => Receipt::generateReceiptNumber(),
+        ]);
+    }
+
+    /**
+     * Store a newly created receipt.
+     */
+    public function store(StoreReceiptRequest $request)
+    {
+        Gate::authorize('create', Receipt::class);
+
+        $validated = $request->validated();
+        $validated['received_by'] = auth()->id();
+        $validated['receipt_number'] = Receipt::generateReceiptNumber();
+
+        $receipt = Receipt::create($validated);
+
+        activity()
+            ->performedOn($receipt)
+            ->withProperties($receipt->toArray())
+            ->log('Receipt created');
+
+        return redirect()->route('super-admin.receipts.index')
+            ->with('success', 'Receipt created successfully.');
+    }
+
+    /**
+     * Display the specified receipt.
+     */
+    public function show(Receipt $receipt)
+    {
+        Gate::authorize('view', $receipt);
+
+        $receipt->load(['payment.invoice.enrollment.student', 'invoice.enrollment.student', 'receivedBy']);
+
+        return Inertia::render('super-admin/receipts/show', [
+            'receipt' => $receipt,
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified receipt.
+     */
+    public function edit(Receipt $receipt)
+    {
+        Gate::authorize('update', $receipt);
+
+        $receipt->load(['payment', 'invoice']);
+        $payments = Payment::with('invoice.enrollment.student')->get();
+        $invoices = Invoice::with('enrollment.student')->get();
+
+        return Inertia::render('super-admin/receipts/edit', [
+            'receipt' => $receipt,
+            'payments' => $payments,
+            'invoices' => $invoices,
+        ]);
+    }
+
+    /**
+     * Update the specified receipt.
+     */
+    public function update(UpdateReceiptRequest $request, Receipt $receipt)
+    {
+        Gate::authorize('update', $receipt);
+
+        $validated = $request->validated();
+        $oldData = $receipt->toArray();
+        $receipt->update($validated);
+
+        activity()
+            ->performedOn($receipt)
+            ->withProperties(['old' => $oldData, 'new' => $receipt->fresh()->toArray()])
+            ->log('Receipt updated');
+
+        return redirect()->route('super-admin.receipts.index')
+            ->with('success', 'Receipt updated successfully.');
+    }
+
+    /**
+     * Remove the specified receipt.
+     */
+    public function destroy(Receipt $receipt)
+    {
+        Gate::authorize('delete', $receipt);
+
+        $receiptData = $receipt->toArray();
+        $receipt->delete();
+
+        activity()
+            ->withProperties($receiptData)
+            ->log('Receipt deleted');
+
+        return redirect()->route('super-admin.receipts.index')
+            ->with('success', 'Receipt deleted successfully.');
+    }
+}

--- a/app/Http/Requests/SuperAdmin/StoreReceiptRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreReceiptRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\SuperAdmin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreReceiptRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()->hasRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'payment_id' => ['nullable', 'exists:payments,id'],
+            'invoice_id' => ['nullable', 'exists:invoices,id'],
+            'receipt_date' => ['required', 'date'],
+            'amount' => ['required', 'numeric', 'min:0.01'],
+            'payment_method' => ['required', 'string', 'max:50'],
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     */
+    public function messages(): array
+    {
+        return [
+            'payment_id.exists' => 'The selected payment does not exist.',
+            'invoice_id.exists' => 'The selected invoice does not exist.',
+            'receipt_date.required' => 'Receipt date is required.',
+            'amount.required' => 'Amount is required.',
+            'amount.min' => 'Amount must be greater than zero.',
+            'payment_method.required' => 'Payment method is required.',
+        ];
+    }
+}

--- a/app/Http/Requests/SuperAdmin/UpdateReceiptRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateReceiptRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\SuperAdmin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateReceiptRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()->hasRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'payment_id' => ['nullable', 'exists:payments,id'],
+            'invoice_id' => ['nullable', 'exists:invoices,id'],
+            'receipt_date' => ['required', 'date'],
+            'amount' => ['required', 'numeric', 'min:0.01'],
+            'payment_method' => ['required', 'string', 'max:50'],
+            'notes' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     */
+    public function messages(): array
+    {
+        return [
+            'payment_id.exists' => 'The selected payment does not exist.',
+            'invoice_id.exists' => 'The selected invoice does not exist.',
+            'receipt_date.required' => 'Receipt date is required.',
+            'amount.required' => 'Amount is required.',
+            'amount.min' => 'Amount must be greater than zero.',
+            'payment_method.required' => 'Payment method is required.',
+        ];
+    }
+}

--- a/app/Policies/ReceiptPolicy.php
+++ b/app/Policies/ReceiptPolicy.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Receipt;
+use App\Models\User;
+
+class ReceiptPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator', 'registrar']);
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Receipt $receipt): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator', 'registrar']);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Receipt $receipt): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Receipt $receipt): bool
+    {
+        return $user->hasRole('super_admin');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Receipt $receipt): bool
+    {
+        return $user->hasRole('super_admin');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Receipt $receipt): bool
+    {
+        return $user->hasRole('super_admin');
+    }
+}

--- a/resources/js/components/sidebars/super-admin-sidebar.tsx
+++ b/resources/js/components/sidebars/super-admin-sidebar.tsx
@@ -11,6 +11,7 @@ import {
     GraduationCap,
     LayoutGrid,
     Receipt,
+    ReceiptText,
     Settings,
     ShieldCheck,
     UserCog,
@@ -63,6 +64,11 @@ const mainNavItems: NavItem[] = [
         title: 'Payments',
         href: '/super-admin/payments',
         icon: Receipt,
+    },
+    {
+        title: 'Receipts',
+        href: '/super-admin/receipts',
+        icon: ReceiptText,
     },
     {
         title: 'School Information',

--- a/resources/js/pages/super-admin/receipts/create.tsx
+++ b/resources/js/pages/super-admin/receipts/create.tsx
@@ -1,0 +1,188 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import AppLayout from '@/layouts/app-layout';
+import { Head, useForm } from '@inertiajs/react';
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+interface Student {
+    id: number;
+    first_name: string;
+    last_name: string;
+}
+
+interface Enrollment {
+    id: number;
+    student: Student;
+}
+
+interface Invoice {
+    id: number;
+    invoice_number: string;
+    enrollment: Enrollment;
+}
+
+interface Payment {
+    id: number;
+    invoice: Invoice;
+    amount: number;
+}
+
+interface Props {
+    payments: Payment[];
+    invoices: Invoice[];
+    nextReceiptNumber: string;
+}
+
+export default function ReceiptCreate({ payments, invoices, nextReceiptNumber }: Props) {
+    const { data, setData, post, processing, errors, wasSuccessful } = useForm({
+        payment_id: '',
+        invoice_id: '',
+        receipt_date: new Date().toISOString().split('T')[0],
+        amount: '',
+        payment_method: '',
+        notes: '',
+    });
+
+    useEffect(() => {
+        if (wasSuccessful) toast.success('Receipt created successfully.');
+    }, [wasSuccessful]);
+
+    return (
+        <AppLayout
+            breadcrumbs={[
+                { title: 'Super Admin', href: '/super-admin/dashboard' },
+                { title: 'Receipts', href: '/super-admin/receipts' },
+                { title: 'Create', href: '#' },
+            ]}
+        >
+            <Head title="Create Receipt" />
+            <div className="px-4 py-6">
+                <h1 className="mb-4 text-2xl font-bold">Create Receipt</h1>
+                <Card className="mx-auto max-w-2xl">
+                    <CardHeader>
+                        <CardTitle>Receipt Information</CardTitle>
+                        <p className="text-sm text-muted-foreground">
+                            Receipt Number: <span className="font-medium">{nextReceiptNumber}</span>
+                        </p>
+                    </CardHeader>
+                    <CardContent>
+                        <form
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                post(route('super-admin.receipts.store'));
+                            }}
+                            className="space-y-4"
+                        >
+                            <div>
+                                <Label>Payment (Optional)</Label>
+                                <Select value={data.payment_id} onValueChange={(value) => setData('payment_id', value)}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select a payment" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="">None</SelectItem>
+                                        {payments.map((payment) => {
+                                            const student = payment.invoice?.enrollment?.student;
+                                            return (
+                                                <SelectItem key={payment.id} value={payment.id.toString()}>
+                                                    {student ? `${student.first_name} ${student.last_name}` : 'Unknown Student'} - ₱
+                                                    {payment.amount.toLocaleString()}
+                                                </SelectItem>
+                                            );
+                                        })}
+                                    </SelectContent>
+                                </Select>
+                                {errors.payment_id && <p className="text-sm text-red-500">{errors.payment_id}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Invoice (Optional)</Label>
+                                <Select value={data.invoice_id} onValueChange={(value) => setData('invoice_id', value)}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select an invoice" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="">None</SelectItem>
+                                        {invoices.map((invoice) => {
+                                            const student = invoice.enrollment?.student;
+                                            return (
+                                                <SelectItem key={invoice.id} value={invoice.id.toString()}>
+                                                    {invoice.invoice_number} -{' '}
+                                                    {student ? `${student.first_name} ${student.last_name}` : 'Unknown Student'}
+                                                </SelectItem>
+                                            );
+                                        })}
+                                    </SelectContent>
+                                </Select>
+                                {errors.invoice_id && <p className="text-sm text-red-500">{errors.invoice_id}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Receipt Date</Label>
+                                <Input
+                                    type="date"
+                                    value={data.receipt_date}
+                                    onChange={(e) => setData('receipt_date', e.target.value)}
+                                    className={errors.receipt_date ? 'border-red-500' : ''}
+                                />
+                                {errors.receipt_date && <p className="text-sm text-red-500">{errors.receipt_date}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Amount</Label>
+                                <Input
+                                    type="number"
+                                    step="0.01"
+                                    min="0.01"
+                                    value={data.amount}
+                                    onChange={(e) => setData('amount', e.target.value)}
+                                    className={errors.amount ? 'border-red-500' : ''}
+                                    placeholder="0.00"
+                                />
+                                {errors.amount && <p className="text-sm text-red-500">{errors.amount}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Payment Method</Label>
+                                <Select value={data.payment_method} onValueChange={(value) => setData('payment_method', value)}>
+                                    <SelectTrigger className={errors.payment_method ? 'border-red-500' : ''}>
+                                        <SelectValue placeholder="Select payment method" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="Cash">Cash</SelectItem>
+                                        <SelectItem value="Check">Check</SelectItem>
+                                        <SelectItem value="Bank Transfer">Bank Transfer</SelectItem>
+                                        <SelectItem value="Credit Card">Credit Card</SelectItem>
+                                        <SelectItem value="Debit Card">Debit Card</SelectItem>
+                                        <SelectItem value="GCash">GCash</SelectItem>
+                                        <SelectItem value="PayMaya">PayMaya</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                {errors.payment_method && <p className="text-sm text-red-500">{errors.payment_method}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Notes (Optional)</Label>
+                                <Input value={data.notes} onChange={(e) => setData('notes', e.target.value)} placeholder="Additional notes" />
+                                {errors.notes && <p className="text-sm text-red-500">{errors.notes}</p>}
+                            </div>
+
+                            <div className="flex gap-4">
+                                <Button type="submit" disabled={processing}>
+                                    Create Receipt
+                                </Button>
+                                <Button type="button" variant="outline" onClick={() => window.history.back()}>
+                                    Cancel
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/receipts/edit.tsx
+++ b/resources/js/pages/super-admin/receipts/edit.tsx
@@ -1,0 +1,199 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import AppLayout from '@/layouts/app-layout';
+import { Head, useForm } from '@inertiajs/react';
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+interface Student {
+    id: number;
+    first_name: string;
+    last_name: string;
+}
+
+interface Enrollment {
+    id: number;
+    student: Student;
+}
+
+interface Invoice {
+    id: number;
+    invoice_number: string;
+    enrollment: Enrollment;
+}
+
+interface Payment {
+    id: number;
+    invoice: Invoice;
+    amount: number;
+}
+
+interface Receipt {
+    id: number;
+    receipt_number: string;
+    payment_id: number | null;
+    invoice_id: number | null;
+    receipt_date: string;
+    amount: number;
+    payment_method: string;
+    notes: string | null;
+}
+
+interface Props {
+    receipt: Receipt;
+    payments: Payment[];
+    invoices: Invoice[];
+}
+
+export default function ReceiptEdit({ receipt, payments, invoices }: Props) {
+    const { data, setData, put, processing, errors, wasSuccessful } = useForm({
+        payment_id: receipt.payment_id?.toString() || '',
+        invoice_id: receipt.invoice_id?.toString() || '',
+        receipt_date: receipt.receipt_date || '',
+        amount: receipt.amount.toString() || '',
+        payment_method: receipt.payment_method || '',
+        notes: receipt.notes || '',
+    });
+
+    useEffect(() => {
+        if (wasSuccessful) toast.success('Receipt updated successfully.');
+    }, [wasSuccessful]);
+
+    return (
+        <AppLayout
+            breadcrumbs={[
+                { title: 'Super Admin', href: '/super-admin/dashboard' },
+                { title: 'Receipts', href: '/super-admin/receipts' },
+                { title: 'Edit', href: '#' },
+            ]}
+        >
+            <Head title="Edit Receipt" />
+            <div className="px-4 py-6">
+                <h1 className="mb-4 text-2xl font-bold">Edit Receipt</h1>
+                <Card className="mx-auto max-w-2xl">
+                    <CardHeader>
+                        <CardTitle>Receipt Information</CardTitle>
+                        <p className="text-sm text-muted-foreground">
+                            Receipt Number: <span className="font-medium">{receipt.receipt_number}</span>
+                        </p>
+                    </CardHeader>
+                    <CardContent>
+                        <form
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                put(route('super-admin.receipts.update', { receipt: receipt.id }));
+                            }}
+                            className="space-y-4"
+                        >
+                            <div>
+                                <Label>Payment (Optional)</Label>
+                                <Select value={data.payment_id} onValueChange={(value) => setData('payment_id', value)}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select a payment" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="">None</SelectItem>
+                                        {payments.map((payment) => {
+                                            const student = payment.invoice?.enrollment?.student;
+                                            return (
+                                                <SelectItem key={payment.id} value={payment.id.toString()}>
+                                                    {student ? `${student.first_name} ${student.last_name}` : 'Unknown Student'} - ₱
+                                                    {payment.amount.toLocaleString()}
+                                                </SelectItem>
+                                            );
+                                        })}
+                                    </SelectContent>
+                                </Select>
+                                {errors.payment_id && <p className="text-sm text-red-500">{errors.payment_id}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Invoice (Optional)</Label>
+                                <Select value={data.invoice_id} onValueChange={(value) => setData('invoice_id', value)}>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select an invoice" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="">None</SelectItem>
+                                        {invoices.map((invoice) => {
+                                            const student = invoice.enrollment?.student;
+                                            return (
+                                                <SelectItem key={invoice.id} value={invoice.id.toString()}>
+                                                    {invoice.invoice_number} -{' '}
+                                                    {student ? `${student.first_name} ${student.last_name}` : 'Unknown Student'}
+                                                </SelectItem>
+                                            );
+                                        })}
+                                    </SelectContent>
+                                </Select>
+                                {errors.invoice_id && <p className="text-sm text-red-500">{errors.invoice_id}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Receipt Date</Label>
+                                <Input
+                                    type="date"
+                                    value={data.receipt_date}
+                                    onChange={(e) => setData('receipt_date', e.target.value)}
+                                    className={errors.receipt_date ? 'border-red-500' : ''}
+                                />
+                                {errors.receipt_date && <p className="text-sm text-red-500">{errors.receipt_date}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Amount</Label>
+                                <Input
+                                    type="number"
+                                    step="0.01"
+                                    min="0.01"
+                                    value={data.amount}
+                                    onChange={(e) => setData('amount', e.target.value)}
+                                    className={errors.amount ? 'border-red-500' : ''}
+                                    placeholder="0.00"
+                                />
+                                {errors.amount && <p className="text-sm text-red-500">{errors.amount}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Payment Method</Label>
+                                <Select value={data.payment_method} onValueChange={(value) => setData('payment_method', value)}>
+                                    <SelectTrigger className={errors.payment_method ? 'border-red-500' : ''}>
+                                        <SelectValue placeholder="Select payment method" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value="Cash">Cash</SelectItem>
+                                        <SelectItem value="Check">Check</SelectItem>
+                                        <SelectItem value="Bank Transfer">Bank Transfer</SelectItem>
+                                        <SelectItem value="Credit Card">Credit Card</SelectItem>
+                                        <SelectItem value="Debit Card">Debit Card</SelectItem>
+                                        <SelectItem value="GCash">GCash</SelectItem>
+                                        <SelectItem value="PayMaya">PayMaya</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                {errors.payment_method && <p className="text-sm text-red-500">{errors.payment_method}</p>}
+                            </div>
+
+                            <div>
+                                <Label>Notes (Optional)</Label>
+                                <Input value={data.notes} onChange={(e) => setData('notes', e.target.value)} placeholder="Additional notes" />
+                                {errors.notes && <p className="text-sm text-red-500">{errors.notes}</p>}
+                            </div>
+
+                            <div className="flex gap-4">
+                                <Button type="submit" disabled={processing}>
+                                    Update Receipt
+                                </Button>
+                                <Button type="button" variant="outline" onClick={() => window.history.back()}>
+                                    Cancel
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/receipts/index.tsx
+++ b/resources/js/pages/super-admin/receipts/index.tsx
@@ -1,0 +1,149 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { DataTable } from '@/components/ui/data-table';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link, router } from '@inertiajs/react';
+import { ColumnDef } from '@tanstack/react-table';
+import { Eye, Plus } from 'lucide-react';
+
+interface Student {
+    id: number;
+    first_name: string;
+    last_name: string;
+}
+
+interface Enrollment {
+    id: number;
+    student: Student;
+}
+
+interface Invoice {
+    id: number;
+    invoice_number: string;
+    enrollment: Enrollment;
+}
+
+interface Payment {
+    id: number;
+    invoice: Invoice;
+}
+
+interface ReceivedBy {
+    id: number;
+    name: string;
+}
+
+interface Receipt {
+    id: number;
+    receipt_number: string;
+    payment_id: number | null;
+    invoice_id: number | null;
+    receipt_date: string;
+    amount: number;
+    payment_method: string;
+    notes: string | null;
+    payment: Payment | null;
+    invoice: Invoice | null;
+    received_by: ReceivedBy;
+}
+
+interface PaginatedReceipts {
+    data: Receipt[];
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+}
+
+interface Props {
+    receipts: PaginatedReceipts;
+}
+
+export default function ReceiptsIndex({ receipts }: Props) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Super Admin', href: '/super-admin/dashboard' },
+        { title: 'Receipts', href: '/super-admin/receipts' },
+    ];
+
+    const formatAmount = (amount: number): string => {
+        return `₱${amount.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    };
+
+    const columns: ColumnDef<Receipt>[] = [
+        {
+            accessorKey: 'receipt_number',
+            header: 'Receipt Number',
+            cell: ({ row }) => <span className="font-medium">{row.original.receipt_number}</span>,
+        },
+        {
+            accessorKey: 'payment',
+            header: 'Student',
+            cell: ({ row }) => {
+                const student = row.original.payment?.invoice?.enrollment?.student;
+                return (
+                    <div>
+                        {student ? (
+                            <span>
+                                {student.first_name} {student.last_name}
+                            </span>
+                        ) : (
+                            <span className="text-muted-foreground">N/A</span>
+                        )}
+                    </div>
+                );
+            },
+        },
+        {
+            accessorKey: 'receipt_date',
+            header: 'Receipt Date',
+            cell: ({ row }) => new Date(row.original.receipt_date).toLocaleDateString(),
+        },
+        {
+            accessorKey: 'amount',
+            header: 'Amount',
+            cell: ({ row }) => <span className="font-medium">{formatAmount(row.original.amount)}</span>,
+        },
+        {
+            accessorKey: 'payment_method',
+            header: 'Payment Method',
+            cell: ({ row }) => <Badge variant="outline">{row.original.payment_method}</Badge>,
+        },
+        {
+            id: 'actions',
+            header: 'Actions',
+            cell: ({ row }) => (
+                <div className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => router.visit(`/super-admin/receipts/${row.original.id}`)}>
+                        <Eye className="mr-1 h-3 w-3" />
+                        View
+                    </Button>
+                    <Button size="sm" variant="outline" onClick={() => router.visit(`/super-admin/receipts/${row.original.id}/edit`)}>
+                        Edit
+                    </Button>
+                </div>
+            ),
+        },
+    ];
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Receipts" />
+            <div className="px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold">Receipts</h1>
+                        <p className="mt-1 text-sm text-muted-foreground">Manage payment receipts and records</p>
+                    </div>
+                    <Link href="/super-admin/receipts/create">
+                        <Button>
+                            <Plus className="mr-2 h-4 w-4" />
+                            Create Receipt
+                        </Button>
+                    </Link>
+                </div>
+                <DataTable columns={columns} data={receipts.data} />
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/receipts/show.tsx
+++ b/resources/js/pages/super-admin/receipts/show.tsx
@@ -1,0 +1,209 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AppLayout from '@/layouts/app-layout';
+import { Head, Link, router } from '@inertiajs/react';
+import { ArrowLeft, Calendar, DollarSign, FileText, User } from 'lucide-react';
+
+interface Student {
+    id: number;
+    first_name: string;
+    last_name: string;
+}
+
+interface Enrollment {
+    id: number;
+    student: Student;
+}
+
+interface Invoice {
+    id: number;
+    invoice_number: string;
+    enrollment: Enrollment;
+}
+
+interface Payment {
+    id: number;
+    invoice: Invoice;
+    amount: number;
+}
+
+interface ReceivedBy {
+    id: number;
+    name: string;
+}
+
+interface Receipt {
+    id: number;
+    receipt_number: string;
+    payment_id: number | null;
+    invoice_id: number | null;
+    receipt_date: string;
+    amount: number;
+    payment_method: string;
+    notes: string | null;
+    payment: Payment | null;
+    invoice: Invoice | null;
+    received_by: ReceivedBy;
+}
+
+interface Props {
+    receipt: Receipt;
+}
+
+export default function ReceiptShow({ receipt }: Props) {
+    const formatAmount = (amount: number): string => {
+        return `₱${amount.toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    };
+
+    const handleDelete = () => {
+        if (confirm('Are you sure you want to delete this receipt? This action cannot be undone.')) {
+            router.delete(`/super-admin/receipts/${receipt.id}`);
+        }
+    };
+
+    return (
+        <AppLayout
+            breadcrumbs={[
+                { title: 'Super Admin', href: '/super-admin/dashboard' },
+                { title: 'Receipts', href: '/super-admin/receipts' },
+                { title: receipt.receipt_number, href: '#' },
+            ]}
+        >
+            <Head title={receipt.receipt_number} />
+            <div className="px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                        <Link href="/super-admin/receipts">
+                            <Button variant="outline" size="sm">
+                                <ArrowLeft className="mr-2 h-4 w-4" />
+                                Back to Receipts
+                            </Button>
+                        </Link>
+                        <div>
+                            <h1 className="text-2xl font-bold">{receipt.receipt_number}</h1>
+                            <p className="text-sm text-muted-foreground">
+                                <Badge variant="outline">{receipt.payment_method}</Badge>
+                            </p>
+                        </div>
+                    </div>
+                    <div className="flex gap-2">
+                        <Link href={`/super-admin/receipts/${receipt.id}/edit`}>
+                            <Button variant="outline">Edit Receipt</Button>
+                        </Link>
+                        <Button variant="destructive" onClick={handleDelete}>
+                            Delete Receipt
+                        </Button>
+                    </div>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-4">
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">Amount</CardTitle>
+                            <DollarSign className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">{formatAmount(receipt.amount)}</div>
+                            <p className="text-xs text-muted-foreground">Payment amount</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">Receipt Date</CardTitle>
+                            <Calendar className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">{new Date(receipt.receipt_date).toLocaleDateString()}</div>
+                            <p className="text-xs text-muted-foreground">Date issued</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">Received By</CardTitle>
+                            <User className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">{receipt.received_by.name}</div>
+                            <p className="text-xs text-muted-foreground">Receiving staff</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">Payment Method</CardTitle>
+                            <FileText className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">{receipt.payment_method}</div>
+                            <p className="text-xs text-muted-foreground">Payment type</p>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    {receipt.payment && (
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Related Payment</CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-2">
+                                {receipt.payment.invoice?.enrollment?.student && (
+                                    <div>
+                                        <span className="font-medium">Student:</span> {receipt.payment.invoice.enrollment.student.first_name}{' '}
+                                        {receipt.payment.invoice.enrollment.student.last_name}
+                                    </div>
+                                )}
+                                <div>
+                                    <span className="font-medium">Payment Amount:</span> {formatAmount(receipt.payment.amount)}
+                                </div>
+                                <Link href={`/super-admin/payments/${receipt.payment.id}`}>
+                                    <Button variant="outline" size="sm" className="mt-2">
+                                        View Payment
+                                    </Button>
+                                </Link>
+                            </CardContent>
+                        </Card>
+                    )}
+
+                    {receipt.invoice && (
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Related Invoice</CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-2">
+                                <div>
+                                    <span className="font-medium">Invoice Number:</span> {receipt.invoice.invoice_number}
+                                </div>
+                                {receipt.invoice.enrollment?.student && (
+                                    <div>
+                                        <span className="font-medium">Student:</span> {receipt.invoice.enrollment.student.first_name}{' '}
+                                        {receipt.invoice.enrollment.student.last_name}
+                                    </div>
+                                )}
+                                <Link href={`/super-admin/invoices/${receipt.invoice.id}`}>
+                                    <Button variant="outline" size="sm" className="mt-2">
+                                        View Invoice
+                                    </Button>
+                                </Link>
+                            </CardContent>
+                        </Card>
+                    )}
+                </div>
+
+                {receipt.notes && (
+                    <Card className="mt-4">
+                        <CardHeader>
+                            <CardTitle>Notes</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-sm">{receipt.notes}</p>
+                        </CardContent>
+                    </Card>
+                )}
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,6 +37,7 @@ use App\Http\Controllers\SuperAdmin\GradeLevelFeeController as SuperAdminGradeLe
 use App\Http\Controllers\SuperAdmin\GuardianController as SuperAdminGuardianController;
 use App\Http\Controllers\SuperAdmin\InvoiceController as SuperAdminInvoiceController;
 use App\Http\Controllers\SuperAdmin\PaymentController as SuperAdminPaymentController;
+use App\Http\Controllers\SuperAdmin\ReceiptController as SuperAdminReceiptController;
 use App\Http\Controllers\SuperAdmin\SchoolInformationController as SuperAdminSchoolInformationController;
 use App\Http\Controllers\SuperAdmin\StudentController as SuperAdminStudentController;
 use App\Http\Controllers\SuperAdmin\UserController as SuperAdminUserController;
@@ -158,6 +159,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         // Payments Management
         Route::resource('payments', SuperAdminPaymentController::class);
         Route::post('/payments/{payment}/refund', [SuperAdminPaymentController::class, 'refund'])->name('payments.refund');
+
+        // Receipts Management
+        Route::resource('receipts', SuperAdminReceiptController::class);
 
         // Grade Level Fees Management
         Route::resource('grade-level-fees', SuperAdminGradeLevelFeeController::class);

--- a/tests/Feature/Models/InvoiceItemTest.php
+++ b/tests/Feature/Models/InvoiceItemTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Models\Enrollment;
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\SchoolYear;
+use App\Models\Student;
+use Database\Seeders\RolesAndPermissionsSeeder;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+it('can create an invoice item with all attributes', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+    $invoice = Invoice::factory()->create([
+        'enrollment_id' => $enrollment->id,
+    ]);
+
+    $invoiceItem = InvoiceItem::create([
+        'invoice_id' => $invoice->id,
+        'description' => 'Tuition Fee',
+        'quantity' => 1,
+        'unit_price' => 15000.00,
+        'amount' => 15000.00,
+    ]);
+
+    expect($invoiceItem)->toBeInstanceOf(InvoiceItem::class)
+        ->and($invoiceItem->description)->toBe('Tuition Fee')
+        ->and($invoiceItem->quantity)->toBe(1)
+        ->and($invoiceItem->unit_price)->toBe('15000.00')
+        ->and($invoiceItem->amount)->toBe('15000.00');
+});
+
+it('belongs to an invoice', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+    $invoice = Invoice::factory()->create([
+        'enrollment_id' => $enrollment->id,
+    ]);
+
+    $invoiceItem = InvoiceItem::create([
+        'invoice_id' => $invoice->id,
+        'description' => 'Miscellaneous Fee',
+        'quantity' => 1,
+        'unit_price' => 2500.00,
+        'amount' => 2500.00,
+    ]);
+
+    expect($invoiceItem->invoice)->toBeInstanceOf(Invoice::class)
+        ->and($invoiceItem->invoice->id)->toBe($invoice->id);
+});
+
+it('casts quantity as integer', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+    $invoice = Invoice::factory()->create([
+        'enrollment_id' => $enrollment->id,
+    ]);
+
+    $invoiceItem = InvoiceItem::create([
+        'invoice_id' => $invoice->id,
+        'description' => 'Books',
+        'quantity' => '5',
+        'unit_price' => 500.00,
+        'amount' => 2500.00,
+    ]);
+
+    expect($invoiceItem->quantity)->toBeInt()
+        ->and($invoiceItem->quantity)->toBe(5);
+});
+
+it('casts unit_price and amount as decimal with 2 places', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+    $invoice = Invoice::factory()->create([
+        'enrollment_id' => $enrollment->id,
+    ]);
+
+    $invoiceItem = InvoiceItem::create([
+        'invoice_id' => $invoice->id,
+        'description' => 'Lab Fee',
+        'quantity' => 1,
+        'unit_price' => 1234.567,
+        'amount' => 1234.567,
+    ]);
+
+    expect($invoiceItem->unit_price)->toBe('1234.57')
+        ->and($invoiceItem->amount)->toBe('1234.57');
+});

--- a/tests/Feature/Models/PaymentReminderTest.php
+++ b/tests/Feature/Models/PaymentReminderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Models\Enrollment;
+use App\Models\PaymentReminder;
+use App\Models\SchoolYear;
+use App\Models\Student;
+use Database\Seeders\RolesAndPermissionsSeeder;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+it('can create a payment reminder', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+
+    $reminder = PaymentReminder::create([
+        'enrollment_id' => $enrollment->id,
+        'reminder_type' => 'upcoming_7days',
+        'sent_at' => now(),
+    ]);
+
+    expect($reminder)->toBeInstanceOf(PaymentReminder::class)
+        ->and($reminder->enrollment_id)->toBe($enrollment->id)
+        ->and($reminder->reminder_type)->toBe('upcoming_7days')
+        ->and($reminder->sent_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+});
+
+it('belongs to an enrollment', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+
+    $reminder = PaymentReminder::create([
+        'enrollment_id' => $enrollment->id,
+        'reminder_type' => 'upcoming_3days',
+        'sent_at' => now(),
+    ]);
+
+    expect($reminder->enrollment)->toBeInstanceOf(Enrollment::class)
+        ->and($reminder->enrollment->id)->toBe($enrollment->id);
+});
+
+it('casts sent_at as datetime', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+
+    $sentAt = now();
+    $reminder = PaymentReminder::create([
+        'enrollment_id' => $enrollment->id,
+        'reminder_type' => 'overdue',
+        'sent_at' => $sentAt,
+    ]);
+
+    expect($reminder->sent_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class)
+        ->and($reminder->sent_at->format('Y-m-d H:i:s'))->toBe($sentAt->format('Y-m-d H:i:s'));
+});
+
+it('casts email_opened_at as datetime when set', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+
+    $openedAt = now();
+    $reminder = PaymentReminder::create([
+        'enrollment_id' => $enrollment->id,
+        'reminder_type' => 'overdue_7days',
+        'sent_at' => now()->subHours(2),
+        'email_opened_at' => $openedAt,
+    ]);
+
+    expect($reminder->email_opened_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class)
+        ->and($reminder->email_opened_at->format('Y-m-d H:i:s'))->toBe($openedAt->format('Y-m-d H:i:s'));
+});
+
+it('has timestamps disabled', function () {
+    $reminder = new PaymentReminder;
+
+    expect($reminder->timestamps)->toBeFalse();
+});

--- a/tests/Feature/Notifications/EnrollmentApprovedNotificationTest.php
+++ b/tests/Feature/Notifications/EnrollmentApprovedNotificationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use App\Enums\EnrollmentStatus;
+use App\Models\Enrollment;
+use App\Models\SchoolYear;
+use App\Models\Student;
+use App\Models\User;
+use App\Notifications\EnrollmentApprovedNotification;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Notifications\Messages\MailMessage;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+it('can be instantiated with an enrollment', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+        'status' => EnrollmentStatus::APPROVED,
+        'approved_at' => now(),
+    ]);
+
+    $notification = new EnrollmentApprovedNotification($enrollment);
+
+    expect($notification)->toBeInstanceOf(EnrollmentApprovedNotification::class)
+        ->and($notification->enrollment)->toBe($enrollment)
+        ->and($notification->remarks)->toBeNull();
+});
+
+it('can be instantiated with remarks', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+        'status' => EnrollmentStatus::APPROVED,
+        'approved_at' => now(),
+    ]);
+
+    $notification = new EnrollmentApprovedNotification($enrollment, 'Welcome to our school!');
+
+    expect($notification->remarks)->toBe('Welcome to our school!');
+});
+
+it('specifies mail and database as delivery channels', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+        'status' => EnrollmentStatus::APPROVED,
+        'approved_at' => now(),
+    ]);
+    $user = User::factory()->create();
+
+    $notification = new EnrollmentApprovedNotification($enrollment);
+    $channels = $notification->via($user);
+
+    expect($channels)->toBe(['mail', 'database']);
+});
+
+it('generates correct mail message without remarks', function () {
+    $student = Student::factory()->create(['first_name' => 'John', 'last_name' => 'Doe']);
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+        'status' => EnrollmentStatus::APPROVED,
+        'approved_at' => now(),
+    ]);
+    $user = User::factory()->create();
+
+    $notification = new EnrollmentApprovedNotification($enrollment);
+    $mail = $notification->toMail($user);
+
+    expect($mail)->toBeInstanceOf(MailMessage::class)
+        ->and($mail->subject)->toContain('Enrollment Application Approved');
+});
+
+it('generates correct mail message with remarks', function () {
+    $student = Student::factory()->create(['first_name' => 'John', 'last_name' => 'Doe']);
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+        'status' => EnrollmentStatus::APPROVED,
+        'approved_at' => now(),
+    ]);
+    $user = User::factory()->create();
+
+    $notification = new EnrollmentApprovedNotification($enrollment, 'Great application!');
+    $mail = $notification->toMail($user);
+
+    expect($mail)->toBeInstanceOf(MailMessage::class);
+});
+
+it('generates correct array representation', function () {
+    $student = Student::factory()->create(['first_name' => 'Jane', 'last_name' => 'Smith']);
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+        'status' => EnrollmentStatus::APPROVED,
+        'approved_at' => now(),
+    ]);
+    $user = User::factory()->create();
+
+    $notification = new EnrollmentApprovedNotification($enrollment, 'Test remarks');
+    $array = $notification->toArray($user);
+
+    expect($array)->toHaveKey('enrollment_id')
+        ->and($array['enrollment_id'])->toBe($enrollment->id)
+        ->and($array)->toHaveKey('status')
+        ->and($array['status'])->toBe('approved')
+        ->and($array)->toHaveKey('remarks')
+        ->and($array['remarks'])->toBe('Test remarks')
+        ->and($array)->toHaveKey('student_name')
+        ->and($array['student_name'])->toContain('Jane');
+});

--- a/tests/Feature/Notifications/NewEnrollmentForReviewNotificationTest.php
+++ b/tests/Feature/Notifications/NewEnrollmentForReviewNotificationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\Enrollment;
+use App\Models\SchoolYear;
+use App\Models\Student;
+use App\Models\User;
+use App\Notifications\NewEnrollmentForReviewNotification;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Notifications\Messages\MailMessage;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+it('can be instantiated with an enrollment', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+
+    $notification = new NewEnrollmentForReviewNotification($enrollment);
+
+    expect($notification)->toBeInstanceOf(NewEnrollmentForReviewNotification::class)
+        ->and($notification->enrollment)->toBe($enrollment);
+});
+
+it('specifies mail and database as delivery channels', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+    $user = User::factory()->create();
+
+    $notification = new NewEnrollmentForReviewNotification($enrollment);
+    $channels = $notification->via($user);
+
+    expect($channels)->toBe(['mail', 'database']);
+});
+
+it('generates correct mail message', function () {
+    $student = Student::factory()->create();
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+    $user = User::factory()->create(['name' => 'John Registrar']);
+
+    $notification = new NewEnrollmentForReviewNotification($enrollment);
+    $mail = $notification->toMail($user);
+
+    expect($mail)->toBeInstanceOf(MailMessage::class)
+        ->and($mail->subject)->toBe('New Enrollment Application Requires Review')
+        ->and($mail->greeting)->toContain('Hello John Registrar');
+});
+
+it('generates correct array representation', function () {
+    $student = Student::factory()->create(['first_name' => 'Jane', 'last_name' => 'Student']);
+    $schoolYear = SchoolYear::factory()->create();
+    $enrollment = Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'school_year_id' => $schoolYear->id,
+    ]);
+    $user = User::factory()->create();
+
+    $notification = new NewEnrollmentForReviewNotification($enrollment);
+    $array = $notification->toArray($user);
+
+    expect($array)->toHaveKey('enrollment_id')
+        ->and($array['enrollment_id'])->toBe($enrollment->id)
+        ->and($array)->toHaveKey('student_name')
+        ->and($array['student_name'])->toContain('Jane')
+        ->and($array)->toHaveKey('status')
+        ->and($array['status'])->toBe('pending_review');
+});

--- a/tests/Feature/Policies/ReceiptPolicyTest.php
+++ b/tests/Feature/Policies/ReceiptPolicyTest.php
@@ -3,13 +3,13 @@
 use App\Models\Receipt;
 use App\Models\User;
 use App\Policies\ReceiptPolicy;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Database\Seeders\RolesAndPermissionsSeeder;
 
-uses(RefreshDatabase::class);
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
 
 beforeEach(function () {
     $this->policy = new ReceiptPolicy;
-    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+    $this->seed(RolesAndPermissionsSeeder::class);
 });
 
 it('allows super_admin to view any receipts', function () {
@@ -107,4 +107,36 @@ it('denies administrator from deleting a receipt', function () {
     $receipt = Receipt::factory()->create();
 
     expect($this->policy->delete($user, $receipt))->toBeFalse();
+});
+
+it('allows only super_admin to restore a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->restore($user, $receipt))->toBeTrue();
+});
+
+it('denies administrator from restoring a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->restore($user, $receipt))->toBeFalse();
+});
+
+it('allows only super_admin to force delete a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->forceDelete($user, $receipt))->toBeTrue();
+});
+
+it('denies administrator from force deleting a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->forceDelete($user, $receipt))->toBeFalse();
 });

--- a/tests/Unit/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequestTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit\Http\Requests\SuperAdmin;
+
+use App\Http\Requests\SuperAdmin\StoreGradeLevelFeeRequest;
+use App\Models\SchoolYear;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreGradeLevelFeeRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_authorize_returns_true_for_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $request = new StoreGradeLevelFeeRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    public function test_validation_rules(): void
+    {
+        $request = new StoreGradeLevelFeeRequest;
+        $rules = $request->rules();
+
+        $this->assertArrayHasKey('grade_level', $rules);
+        $this->assertArrayHasKey('school_year_id', $rules);
+        $this->assertArrayHasKey('tuition_fee', $rules);
+    }
+
+    public function test_validation_passes_with_valid_data(): void
+    {
+        $schoolYear = SchoolYear::factory()->create();
+
+        $data = [
+            'grade_level' => 'Grade 1',
+            'school_year_id' => $schoolYear->id,
+            'tuition_fee' => 15000.00,
+            'miscellaneous_fee' => 2500.00,
+            'payment_terms' => 'ANNUAL',
+            'is_active' => true,
+        ];
+
+        $request = new StoreGradeLevelFeeRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function test_validation_fails_with_invalid_school_year_id(): void
+    {
+        $data = [
+            'grade_level' => 'Grade 1',
+            'school_year_id' => 99999,
+            'tuition_fee' => 15000.00,
+            'miscellaneous_fee' => 2500.00,
+            'payment_terms' => 'ANNUAL',
+        ];
+
+        $request = new StoreGradeLevelFeeRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function test_custom_messages(): void
+    {
+        $request = new StoreGradeLevelFeeRequest;
+        $messages = $request->messages();
+
+        $this->assertArrayHasKey('grade_level.unique', $messages);
+    }
+}

--- a/tests/Unit/Http/Requests/SuperAdmin/StoreGuardianRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/StoreGuardianRequestTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\Http\Requests\SuperAdmin;
+
+use App\Http\Requests\SuperAdmin\StoreGuardianRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreGuardianRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_authorize_returns_true_for_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $request = new StoreGuardianRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    public function test_authorize_returns_false_for_non_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('administrator');
+
+        $request = new StoreGuardianRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertFalse($request->authorize());
+    }
+
+    public function test_validation_rules(): void
+    {
+        $request = new StoreGuardianRequest;
+        $rules = $request->rules();
+
+        $this->assertArrayHasKey('email', $rules);
+        $this->assertArrayHasKey('password', $rules);
+        $this->assertArrayHasKey('first_name', $rules);
+    }
+
+    public function test_validation_passes_with_valid_data(): void
+    {
+        $data = [
+            'email' => 'guardian@example.com',
+            'password' => 'SecurePassword123!',
+            'password_confirmation' => 'SecurePassword123!',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'phone' => '09171234567',
+            'address' => '123 Main St',
+        ];
+
+        $request = new StoreGuardianRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function test_validation_fails_with_invalid_email(): void
+    {
+        $data = [
+            'email' => 'not-an-email',
+            'password' => 'SecurePassword123!',
+            'password_confirmation' => 'SecurePassword123!',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'phone' => '09171234567',
+            'address' => '123 Main St',
+        ];
+
+        $request = new StoreGuardianRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function test_validation_fails_with_password_mismatch(): void
+    {
+        $data = [
+            'email' => 'guardian@example.com',
+            'password' => 'SecurePassword123!',
+            'password_confirmation' => 'DifferentPassword!',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'phone' => '09171234567',
+            'address' => '123 Main St',
+        ];
+
+        $request = new StoreGuardianRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+    }
+}

--- a/tests/Unit/Http/Requests/SuperAdmin/StoreInvoiceRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/StoreInvoiceRequestTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Unit\Http\Requests\SuperAdmin;
+
+use App\Http\Requests\SuperAdmin\StoreInvoiceRequest;
+use App\Models\Enrollment;
+use App\Models\SchoolYear;
+use App\Models\Student;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreInvoiceRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_authorize_returns_true_for_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $request = new StoreInvoiceRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    public function test_authorize_returns_false_for_non_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('administrator');
+
+        $request = new StoreInvoiceRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertFalse($request->authorize());
+    }
+
+    public function test_validation_rules(): void
+    {
+        $request = new StoreInvoiceRequest;
+        $rules = $request->rules();
+
+        $this->assertArrayHasKey('enrollment_id', $rules);
+        $this->assertArrayHasKey('invoice_date', $rules);
+        $this->assertArrayHasKey('items', $rules);
+    }
+
+    public function test_validation_passes_with_valid_data(): void
+    {
+        $student = Student::factory()->create();
+        $schoolYear = SchoolYear::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'school_year_id' => $schoolYear->id,
+        ]);
+
+        $data = [
+            'enrollment_id' => $enrollment->id,
+            'invoice_date' => '2025-01-15',
+            'due_date' => '2025-02-15',
+            'items' => [
+                [
+                    'description' => 'Tuition Fee',
+                    'quantity' => 1,
+                    'unit_price' => 15000.00,
+                    'amount' => 15000.00,
+                ],
+            ],
+        ];
+
+        $request = new StoreInvoiceRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function test_validation_fails_with_due_date_before_invoice_date(): void
+    {
+        $student = Student::factory()->create();
+        $schoolYear = SchoolYear::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'school_year_id' => $schoolYear->id,
+        ]);
+
+        $data = [
+            'enrollment_id' => $enrollment->id,
+            'invoice_date' => '2025-02-15',
+            'due_date' => '2025-01-15',
+            'items' => [
+                [
+                    'description' => 'Tuition Fee',
+                    'quantity' => 1,
+                    'unit_price' => 15000.00,
+                    'amount' => 15000.00,
+                ],
+            ],
+        ];
+
+        $request = new StoreInvoiceRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function test_custom_messages(): void
+    {
+        $request = new StoreInvoiceRequest;
+        $messages = $request->messages();
+
+        $this->assertArrayHasKey('items.required', $messages);
+        $this->assertArrayHasKey('due_date.after', $messages);
+    }
+}

--- a/tests/Unit/Http/Requests/SuperAdmin/StorePaymentRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/StorePaymentRequestTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Unit\Http\Requests\SuperAdmin;
+
+use App\Http\Requests\SuperAdmin\StorePaymentRequest;
+use App\Models\Enrollment;
+use App\Models\Invoice;
+use App\Models\SchoolYear;
+use App\Models\Student;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StorePaymentRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_authorize_returns_true_for_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $request = new StorePaymentRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    public function test_validation_rules(): void
+    {
+        $request = new StorePaymentRequest;
+        $rules = $request->rules();
+
+        $this->assertArrayHasKey('invoice_id', $rules);
+        $this->assertArrayHasKey('payment_date', $rules);
+        $this->assertArrayHasKey('amount', $rules);
+        $this->assertArrayHasKey('payment_method', $rules);
+    }
+
+    public function test_validation_passes_with_valid_data(): void
+    {
+        $student = Student::factory()->create();
+        $schoolYear = SchoolYear::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'school_year_id' => $schoolYear->id,
+        ]);
+        $invoice = Invoice::factory()->create([
+            'enrollment_id' => $enrollment->id,
+        ]);
+
+        $data = [
+            'invoice_id' => $invoice->id,
+            'payment_date' => '2025-01-15',
+            'amount' => 5000.00,
+            'payment_method' => 'cash',
+        ];
+
+        $request = new StorePaymentRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function test_validation_fails_with_invalid_invoice_id(): void
+    {
+        $data = [
+            'invoice_id' => 99999,
+            'payment_date' => '2025-01-15',
+            'amount' => 5000.00,
+            'payment_method' => 'cash',
+        ];
+
+        $request = new StorePaymentRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+    }
+
+    public function test_validation_fails_with_invalid_payment_method(): void
+    {
+        $student = Student::factory()->create();
+        $schoolYear = SchoolYear::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'school_year_id' => $schoolYear->id,
+        ]);
+        $invoice = Invoice::factory()->create([
+            'enrollment_id' => $enrollment->id,
+        ]);
+
+        $data = [
+            'invoice_id' => $invoice->id,
+            'payment_date' => '2025-01-15',
+            'amount' => 5000.00,
+            'payment_method' => 'invalid_method',
+        ];
+
+        $request = new StorePaymentRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+    }
+}

--- a/tests/Unit/Http/Requests/SuperAdmin/StoreReceiptRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/StoreReceiptRequestTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Tests\Unit\Http\Requests\SuperAdmin;
+
+use App\Http\Requests\SuperAdmin\StoreReceiptRequest;
+use App\Models\Enrollment;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Models\SchoolYear;
+use App\Models\Student;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreReceiptRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_authorize_returns_true_for_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $request = new StoreReceiptRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    public function test_authorize_returns_true_for_administrator(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('administrator');
+
+        $request = new StoreReceiptRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    public function test_authorize_returns_false_for_non_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('registrar');
+
+        $request = new StoreReceiptRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertFalse($request->authorize());
+    }
+
+    public function test_validation_rules(): void
+    {
+        $request = new StoreReceiptRequest;
+        $rules = $request->rules();
+
+        $this->assertArrayHasKey('payment_id', $rules);
+        $this->assertArrayHasKey('invoice_id', $rules);
+        $this->assertArrayHasKey('receipt_date', $rules);
+        $this->assertArrayHasKey('amount', $rules);
+        $this->assertArrayHasKey('payment_method', $rules);
+    }
+
+    public function test_validation_passes_with_valid_data(): void
+    {
+        $student = Student::factory()->create();
+        $schoolYear = SchoolYear::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'school_year_id' => $schoolYear->id,
+        ]);
+        $invoice = Invoice::factory()->create([
+            'enrollment_id' => $enrollment->id,
+        ]);
+        $payment = Payment::factory()->create([
+            'invoice_id' => $invoice->id,
+        ]);
+
+        $data = [
+            'payment_id' => $payment->id,
+            'invoice_id' => $invoice->id,
+            'receipt_date' => '2025-01-15',
+            'amount' => 5000.00,
+            'payment_method' => 'cash',
+            'notes' => 'Payment received in full',
+        ];
+
+        $request = new StoreReceiptRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function test_validation_fails_with_invalid_payment_id(): void
+    {
+        $data = [
+            'payment_id' => 99999,
+            'receipt_date' => '2025-01-15',
+            'amount' => 5000.00,
+            'payment_method' => 'cash',
+        ];
+
+        $request = new StoreReceiptRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('payment_id', $validator->errors()->toArray());
+    }
+
+    public function test_validation_fails_with_negative_amount(): void
+    {
+        $data = [
+            'receipt_date' => '2025-01-15',
+            'amount' => -100.00,
+            'payment_method' => 'cash',
+        ];
+
+        $request = new StoreReceiptRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('amount', $validator->errors()->toArray());
+    }
+
+    public function test_validation_fails_with_missing_required_fields(): void
+    {
+        $data = [];
+
+        $request = new StoreReceiptRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('receipt_date', $validator->errors()->toArray());
+        $this->assertArrayHasKey('amount', $validator->errors()->toArray());
+        $this->assertArrayHasKey('payment_method', $validator->errors()->toArray());
+    }
+
+    public function test_custom_messages(): void
+    {
+        $request = new StoreReceiptRequest;
+        $messages = $request->messages();
+
+        $this->assertArrayHasKey('payment_id.exists', $messages);
+        $this->assertArrayHasKey('invoice_id.exists', $messages);
+        $this->assertArrayHasKey('receipt_date.required', $messages);
+        $this->assertArrayHasKey('amount.required', $messages);
+        $this->assertArrayHasKey('amount.min', $messages);
+        $this->assertArrayHasKey('payment_method.required', $messages);
+    }
+}

--- a/tests/Unit/Http/Requests/SuperAdmin/StoreSchoolYearRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/StoreSchoolYearRequestTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Tests\Unit\Http\Requests\SuperAdmin;
+
+use App\Http\Requests\SuperAdmin\StoreSchoolYearRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreSchoolYearRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+    }
+
+    public function test_authorize_returns_true_for_super_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('super_admin');
+
+        $request = new StoreSchoolYearRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    public function test_authorize_returns_true_for_administrator(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('administrator');
+
+        $request = new StoreSchoolYearRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    public function test_authorize_returns_false_for_non_admin(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('registrar');
+
+        $request = new StoreSchoolYearRequest;
+        $request->setUserResolver(fn () => $user);
+
+        $this->assertFalse($request->authorize());
+    }
+
+    public function test_validation_rules(): void
+    {
+        $request = new StoreSchoolYearRequest;
+        $rules = $request->rules();
+
+        $this->assertArrayHasKey('name', $rules);
+        $this->assertArrayHasKey('start_year', $rules);
+        $this->assertArrayHasKey('end_year', $rules);
+        $this->assertArrayHasKey('start_date', $rules);
+        $this->assertArrayHasKey('end_date', $rules);
+        $this->assertArrayHasKey('status', $rules);
+        $this->assertArrayHasKey('is_active', $rules);
+    }
+
+    public function test_validation_passes_with_valid_data(): void
+    {
+        $data = [
+            'name' => '2025-2026',
+            'start_year' => 2025,
+            'end_year' => 2026,
+            'start_date' => '2025-06-01',
+            'end_date' => '2026-03-31',
+            'status' => 'upcoming',
+            'is_active' => false,
+        ];
+
+        $request = new StoreSchoolYearRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertFalse($validator->fails());
+    }
+
+    public function test_validation_fails_with_end_year_not_greater_than_start_year(): void
+    {
+        $data = [
+            'name' => '2025-2025',
+            'start_year' => 2025,
+            'end_year' => 2025,
+            'start_date' => '2025-06-01',
+            'end_date' => '2025-03-31',
+            'status' => 'upcoming',
+            'is_active' => false,
+        ];
+
+        $request = new StoreSchoolYearRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('end_year', $validator->errors()->toArray());
+    }
+
+    public function test_validation_fails_with_end_date_before_start_date(): void
+    {
+        $data = [
+            'name' => '2025-2026',
+            'start_year' => 2025,
+            'end_year' => 2026,
+            'start_date' => '2025-06-01',
+            'end_date' => '2025-03-31',
+            'status' => 'upcoming',
+            'is_active' => false,
+        ];
+
+        $request = new StoreSchoolYearRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('end_date', $validator->errors()->toArray());
+    }
+
+    public function test_validation_fails_with_invalid_status(): void
+    {
+        $data = [
+            'name' => '2025-2026',
+            'start_year' => 2025,
+            'end_year' => 2026,
+            'start_date' => '2025-06-01',
+            'end_date' => '2026-03-31',
+            'status' => 'invalid_status',
+            'is_active' => false,
+        ];
+
+        $request = new StoreSchoolYearRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('status', $validator->errors()->toArray());
+    }
+
+    public function test_validation_fails_with_missing_required_fields(): void
+    {
+        $data = [];
+
+        $request = new StoreSchoolYearRequest;
+        $validator = validator($data, $request->rules());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('name', $validator->errors()->toArray());
+        $this->assertArrayHasKey('start_year', $validator->errors()->toArray());
+        $this->assertArrayHasKey('end_year', $validator->errors()->toArray());
+        $this->assertArrayHasKey('start_date', $validator->errors()->toArray());
+        $this->assertArrayHasKey('end_date', $validator->errors()->toArray());
+        $this->assertArrayHasKey('status', $validator->errors()->toArray());
+        $this->assertArrayHasKey('is_active', $validator->errors()->toArray());
+    }
+
+    public function test_custom_messages(): void
+    {
+        $request = new StoreSchoolYearRequest;
+        $messages = $request->messages();
+
+        $this->assertArrayHasKey('name.required', $messages);
+        $this->assertArrayHasKey('name.unique', $messages);
+        $this->assertArrayHasKey('start_year.required', $messages);
+        $this->assertArrayHasKey('end_year.required', $messages);
+        $this->assertArrayHasKey('end_year.gt', $messages);
+        $this->assertArrayHasKey('start_date.required', $messages);
+        $this->assertArrayHasKey('end_date.required', $messages);
+        $this->assertArrayHasKey('end_date.after', $messages);
+        $this->assertArrayHasKey('status.required', $messages);
+        $this->assertArrayHasKey('status.in', $messages);
+    }
+}

--- a/tests/Unit/Policies/ReceiptPolicyTest.php
+++ b/tests/Unit/Policies/ReceiptPolicyTest.php
@@ -1,0 +1,110 @@
+<?php
+
+use App\Models\Receipt;
+use App\Models\User;
+use App\Policies\ReceiptPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->policy = new ReceiptPolicy;
+    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+});
+
+it('allows super_admin to view any receipts', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+
+    expect($this->policy->viewAny($user))->toBeTrue();
+});
+
+it('allows administrator to view any receipts', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+
+    expect($this->policy->viewAny($user))->toBeTrue();
+});
+
+it('allows registrar to view any receipts', function () {
+    $user = User::factory()->create();
+    $user->assignRole('registrar');
+
+    expect($this->policy->viewAny($user))->toBeTrue();
+});
+
+it('denies other roles from viewing any receipts', function () {
+    $user = User::factory()->create();
+    $user->assignRole('guardian');
+
+    expect($this->policy->viewAny($user))->toBeFalse();
+});
+
+it('allows super_admin to view a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->view($user, $receipt))->toBeTrue();
+});
+
+it('allows administrator to view a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->view($user, $receipt))->toBeTrue();
+});
+
+it('allows super_admin to create receipts', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+
+    expect($this->policy->create($user))->toBeTrue();
+});
+
+it('allows administrator to create receipts', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+
+    expect($this->policy->create($user))->toBeTrue();
+});
+
+it('denies registrar from creating receipts', function () {
+    $user = User::factory()->create();
+    $user->assignRole('registrar');
+
+    expect($this->policy->create($user))->toBeFalse();
+});
+
+it('allows super_admin to update a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->update($user, $receipt))->toBeTrue();
+});
+
+it('allows administrator to update a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->update($user, $receipt))->toBeTrue();
+});
+
+it('allows only super_admin to delete a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->delete($user, $receipt))->toBeTrue();
+});
+
+it('denies administrator from deleting a receipt', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+    $receipt = Receipt::factory()->create();
+
+    expect($this->policy->delete($user, $receipt))->toBeFalse();
+});

--- a/tests/Unit/Policies/SchoolYearPolicyTest.php
+++ b/tests/Unit/Policies/SchoolYearPolicyTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Models\SchoolYear;
+use App\Models\User;
+use App\Policies\SchoolYearPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->policy = new SchoolYearPolicy;
+    $this->artisan('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+});
+
+it('allows super_admin to view any school years', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+
+    expect($this->policy->viewAny($user))->toBeTrue();
+});
+
+it('allows administrator to view any school years', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+
+    expect($this->policy->viewAny($user))->toBeTrue();
+});
+
+it('denies other roles from viewing any school years', function () {
+    $user = User::factory()->create();
+    $user->assignRole('registrar');
+
+    expect($this->policy->viewAny($user))->toBeFalse();
+});
+
+it('allows super_admin to view a school year', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+    $schoolYear = SchoolYear::factory()->create();
+
+    expect($this->policy->view($user, $schoolYear))->toBeTrue();
+});
+
+it('allows administrator to view a school year', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+    $schoolYear = SchoolYear::factory()->create();
+
+    expect($this->policy->view($user, $schoolYear))->toBeTrue();
+});
+
+it('allows super_admin to create school years', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+
+    expect($this->policy->create($user))->toBeTrue();
+});
+
+it('allows administrator to create school years', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+
+    expect($this->policy->create($user))->toBeTrue();
+});
+
+it('allows super_admin to update a school year', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+    $schoolYear = SchoolYear::factory()->create();
+
+    expect($this->policy->update($user, $schoolYear))->toBeTrue();
+});
+
+it('allows administrator to update a school year', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+    $schoolYear = SchoolYear::factory()->create();
+
+    expect($this->policy->update($user, $schoolYear))->toBeTrue();
+});
+
+it('allows only super_admin to delete a school year', function () {
+    $user = User::factory()->create();
+    $user->assignRole('super_admin');
+    $schoolYear = SchoolYear::factory()->create();
+
+    expect($this->policy->delete($user, $schoolYear))->toBeTrue();
+});
+
+it('denies administrator from deleting a school year', function () {
+    $user = User::factory()->create();
+    $user->assignRole('administrator');
+    $schoolYear = SchoolYear::factory()->create();
+
+    expect($this->policy->delete($user, $schoolYear))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Implements complete CRUD operations for Receipt management in the Super Admin section, including navigation integration.

### Backend Implementation
- Created `ReceiptController` with full CRUD methods (index, create, store, show, edit, update, destroy)
- Added `StoreReceiptRequest` and `UpdateReceiptRequest` for validation
- Created `ReceiptPolicy` for authorization (super_admin, administrator, registrar roles)
- Properly handles nested relationships: Payment → Invoice → Enrollment → Student
- Includes activity logging for all mutations
- Supports search by receipt number, payment method, and student name
- Date range filtering for receipt queries

### Frontend Implementation
- Created index page with DataTable showing receipts with student information
- Created create form for new receipts with payment/invoice selection
- Created edit form for updating existing receipts
- Created show page displaying receipt details with related payment and invoice information
- All forms use shadcn/ui components (Card, Input, Select, Label, Badge)
- Proper TypeScript interfaces matching nested relationship structure
- Real-time form validation with error handling
- Philippine Peso (₱) currency formatting

### Navigation & Routes
- Added "Receipts" menu item to super-admin sidebar with ReceiptText icon
- Registered resourceful routes in web.php under super-admin namespace

### Key Features
- Receipt number auto-generation (OR-YYYY-NNNN format)
- Optional payment and invoice linking
- Multiple payment methods supported (Cash, Check, Bank Transfer, Credit Card, Debit Card, GCash, PayMaya)
- Notes field for additional information
- Tracks who received the payment (received_by relationship)

## Test Plan
- [x] All pre-push checks passed (PHPStan, Pint, ESLint, Prettier, tests)
- [x] Build successful with no TypeScript errors
- [ ] Manual testing: Navigate to /super-admin/receipts
- [ ] Manual testing: Create a new receipt
- [ ] Manual testing: Edit an existing receipt
- [ ] Manual testing: View receipt details
- [ ] Manual testing: Delete a receipt
- [ ] Manual testing: Search and filter receipts
- [ ] Verify sidebar navigation works correctly
- [ ] Check authorization for different roles

## Related
- Part of series adding complete CRUD for all models
- Previous PRs: SchoolYear CRUD (#311), Document CRUD (#312)
- Next PR: Setting CRUD