### PR TITLE
feat: Add complete Setting CRUD for Super Admin with navigation

### DIFF
--- a/app/Http/Controllers/SuperAdmin/SettingController.php
+++ b/app/Http/Controllers/SuperAdmin/SettingController.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\SuperAdmin\StoreSettingRequest;
+use App\Http\Requests\SuperAdmin\UpdateSettingRequest;
+use App\Models\Setting;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+
+class SettingController extends Controller
+{
+    /**
+     * Display a listing of settings.
+     */
+    public function index(Request $request)
+    {
+        Gate::authorize('viewAny', Setting::class);
+
+        $query = Setting::query();
+
+        // Apply search filter
+        if ($request->filled('search')) {
+            $search = $request->get('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('key', 'like', "%{$search}%")
+                    ->orWhere('value', 'like', "%{$search}%");
+            });
+        }
+
+        $settings = $query->latest()->paginate(20)->withQueryString();
+
+        return Inertia::render('super-admin/settings/index', [
+            'settings' => $settings,
+            'filters' => $request->only(['search']),
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new setting.
+     */
+    public function create()
+    {
+        Gate::authorize('create', Setting::class);
+
+        return Inertia::render('super-admin/settings/create');
+    }
+
+    /**
+     * Store a newly created setting.
+     */
+    public function store(StoreSettingRequest $request)
+    {
+        Gate::authorize('create', Setting::class);
+
+        $validated = $request->validated();
+        $setting = Setting::create($validated);
+
+        activity()
+            ->performedOn($setting)
+            ->withProperties($setting->toArray())
+            ->log('Setting created');
+
+        return redirect()->route('super-admin.settings.index')
+            ->with('success', 'Setting created successfully.');
+    }
+
+    /**
+     * Display the specified setting.
+     */
+    public function show(Setting $setting)
+    {
+        Gate::authorize('view', $setting);
+
+        return Inertia::render('super-admin/settings/show', [
+            'setting' => $setting,
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified setting.
+     */
+    public function edit(Setting $setting)
+    {
+        Gate::authorize('update', $setting);
+
+        return Inertia::render('super-admin/settings/edit', [
+            'setting' => $setting,
+        ]);
+    }
+
+    /**
+     * Update the specified setting.
+     */
+    public function update(UpdateSettingRequest $request, Setting $setting)
+    {
+        Gate::authorize('update', $setting);
+
+        $validated = $request->validated();
+        $oldData = $setting->toArray();
+        $setting->update($validated);
+
+        activity()
+            ->performedOn($setting)
+            ->withProperties(['old' => $oldData, 'new' => $setting->fresh()->toArray()])
+            ->log('Setting updated');
+
+        return redirect()->route('super-admin.settings.index')
+            ->with('success', 'Setting updated successfully.');
+    }
+
+    /**
+     * Remove the specified setting.
+     */
+    public function destroy(Setting $setting)
+    {
+        Gate::authorize('delete', $setting);
+
+        $settingData = $setting->toArray();
+        $setting->delete();
+
+        activity()
+            ->withProperties($settingData)
+            ->log('Setting deleted');
+
+        return redirect()->route('super-admin.settings.index')
+            ->with('success', 'Setting deleted successfully.');
+    }
+}

--- a/app/Http/Requests/SuperAdmin/StoreSettingRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreSettingRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\SuperAdmin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreSettingRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()->hasRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'key' => ['required', 'string', 'max:255', 'unique:settings,key'],
+            'value' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * Get custom attribute names for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'key' => 'setting key',
+            'value' => 'setting value',
+        ];
+    }
+}

--- a/app/Http/Requests/SuperAdmin/UpdateSettingRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateSettingRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\SuperAdmin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateSettingRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()->hasRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'key' => ['required', 'string', 'max:255', Rule::unique('settings', 'key')->ignore($this->setting)],
+            'value' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * Get custom attribute names for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function attributes(): array
+    {
+        return [
+            'key' => 'setting key',
+            'value' => 'setting value',
+        ];
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -6,5 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class Setting extends Model
 {
-    //
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'key',
+        'value',
+    ];
 }

--- a/app/Policies/SettingPolicy.php
+++ b/app/Policies/SettingPolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Setting;
+use App\Models\User;
+
+class SettingPolicy
+{
+    /**
+     * Determine whether the user can view any settings.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can view the setting.
+     */
+    public function view(User $user, Setting $setting): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can create settings.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can update the setting.
+     */
+    public function update(User $user, Setting $setting): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can delete the setting.
+     */
+    public function delete(User $user, Setting $setting): bool
+    {
+        return $user->hasRole('super_admin');
+    }
+}

--- a/resources/js/components/sidebars/super-admin-sidebar.tsx
+++ b/resources/js/components/sidebars/super-admin-sidebar.tsx
@@ -13,6 +13,7 @@ import {
     LayoutGrid,
     Receipt,
     Settings,
+    Settings2,
     ShieldCheck,
     UserCog,
     Users,
@@ -79,6 +80,11 @@ const mainNavItems: NavItem[] = [
         title: 'Audit Logs',
         href: '/super-admin/audit-logs',
         icon: ClipboardList,
+    },
+    {
+        title: 'System Settings',
+        href: '/super-admin/settings',
+        icon: Settings2,
     },
     {
         title: 'Profile Settings',

--- a/resources/js/pages/super-admin/settings/create.tsx
+++ b/resources/js/pages/super-admin/settings/create.tsx
@@ -1,0 +1,85 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import AppLayout from '@/layouts/app-layout';
+import { Head, useForm } from '@inertiajs/react';
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+export default function SettingCreate() {
+    const { data, setData, post, processing, errors, wasSuccessful } = useForm({
+        key: '',
+        value: '',
+    });
+
+    useEffect(() => {
+        if (wasSuccessful) toast.success('Setting created successfully.');
+    }, [wasSuccessful]);
+
+    return (
+        <AppLayout
+            breadcrumbs={[
+                { title: 'Super Admin', href: '/super-admin/dashboard' },
+                { title: 'Settings', href: '/super-admin/settings' },
+                { title: 'Create', href: '#' },
+            ]}
+        >
+            <Head title="Create Setting" />
+            <div className="px-4 py-6">
+                <h1 className="mb-4 text-2xl font-bold">Create Setting</h1>
+                <Card className="mx-auto max-w-2xl">
+                    <CardHeader>
+                        <CardTitle>Setting Information</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <form
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                post(route('super-admin.settings.store'));
+                            }}
+                            className="space-y-4"
+                        >
+                            <div>
+                                <Label htmlFor="key">Setting Key</Label>
+                                <Input
+                                    id="key"
+                                    type="text"
+                                    value={data.key}
+                                    onChange={(e) => setData('key', e.target.value)}
+                                    className={errors.key ? 'border-red-500' : ''}
+                                    placeholder="e.g., school_name, payment_location"
+                                />
+                                {errors.key && <p className="text-sm text-red-500">{errors.key}</p>}
+                                <p className="mt-1 text-xs text-muted-foreground">Use lowercase with underscores (e.g., payment_hours)</p>
+                            </div>
+
+                            <div>
+                                <Label htmlFor="value">Setting Value</Label>
+                                <Textarea
+                                    id="value"
+                                    value={data.value}
+                                    onChange={(e) => setData('value', e.target.value)}
+                                    className={errors.value ? 'border-red-500' : ''}
+                                    placeholder="Enter the setting value..."
+                                    rows={5}
+                                />
+                                {errors.value && <p className="text-sm text-red-500">{errors.value}</p>}
+                            </div>
+
+                            <div className="flex gap-4">
+                                <Button type="submit" disabled={processing}>
+                                    Create Setting
+                                </Button>
+                                <Button type="button" variant="outline" onClick={() => window.history.back()}>
+                                    Cancel
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/settings/edit.tsx
+++ b/resources/js/pages/super-admin/settings/edit.tsx
@@ -1,0 +1,95 @@
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import AppLayout from '@/layouts/app-layout';
+import { Head, useForm } from '@inertiajs/react';
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+interface Setting {
+    id: number;
+    key: string;
+    value: string | null;
+}
+
+interface Props {
+    setting: Setting;
+}
+
+export default function SettingEdit({ setting }: Props) {
+    const { data, setData, put, processing, errors, wasSuccessful } = useForm({
+        key: setting.key || '',
+        value: setting.value || '',
+    });
+
+    useEffect(() => {
+        if (wasSuccessful) toast.success('Setting updated successfully.');
+    }, [wasSuccessful]);
+
+    return (
+        <AppLayout
+            breadcrumbs={[
+                { title: 'Super Admin', href: '/super-admin/dashboard' },
+                { title: 'Settings', href: '/super-admin/settings' },
+                { title: 'Edit', href: '#' },
+            ]}
+        >
+            <Head title="Edit Setting" />
+            <div className="px-4 py-6">
+                <h1 className="mb-4 text-2xl font-bold">Edit Setting</h1>
+                <Card className="mx-auto max-w-2xl">
+                    <CardHeader>
+                        <CardTitle>Setting Information</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <form
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                put(route('super-admin.settings.update', { setting: setting.id }));
+                            }}
+                            className="space-y-4"
+                        >
+                            <div>
+                                <Label htmlFor="key">Setting Key</Label>
+                                <Input
+                                    id="key"
+                                    type="text"
+                                    value={data.key}
+                                    onChange={(e) => setData('key', e.target.value)}
+                                    className={errors.key ? 'border-red-500' : ''}
+                                    placeholder="e.g., school_name, payment_location"
+                                />
+                                {errors.key && <p className="text-sm text-red-500">{errors.key}</p>}
+                                <p className="mt-1 text-xs text-muted-foreground">Use lowercase with underscores (e.g., payment_hours)</p>
+                            </div>
+
+                            <div>
+                                <Label htmlFor="value">Setting Value</Label>
+                                <Textarea
+                                    id="value"
+                                    value={data.value}
+                                    onChange={(e) => setData('value', e.target.value)}
+                                    className={errors.value ? 'border-red-500' : ''}
+                                    placeholder="Enter the setting value..."
+                                    rows={5}
+                                />
+                                {errors.value && <p className="text-sm text-red-500">{errors.value}</p>}
+                            </div>
+
+                            <div className="flex gap-4">
+                                <Button type="submit" disabled={processing}>
+                                    Update Setting
+                                </Button>
+                                <Button type="button" variant="outline" onClick={() => window.history.back()}>
+                                    Cancel
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/settings/index.tsx
+++ b/resources/js/pages/super-admin/settings/index.tsx
@@ -1,0 +1,99 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { DataTable } from '@/components/ui/data-table';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link, router } from '@inertiajs/react';
+import { ColumnDef } from '@tanstack/react-table';
+import { Eye, Plus } from 'lucide-react';
+
+interface Setting {
+    id: number;
+    key: string;
+    value: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+interface PaginatedSettings {
+    data: Setting[];
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+}
+
+interface Props {
+    settings: PaginatedSettings;
+}
+
+export default function SettingsIndex({ settings }: Props) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Super Admin', href: '/super-admin/dashboard' },
+        { title: 'Settings', href: '/super-admin/settings' },
+    ];
+
+    const columns: ColumnDef<Setting>[] = [
+        {
+            accessorKey: 'key',
+            header: 'Setting Key',
+            cell: ({ row }) => <span className="font-mono text-sm font-medium">{row.original.key}</span>,
+        },
+        {
+            accessorKey: 'value',
+            header: 'Value',
+            cell: ({ row }) => (
+                <div className="max-w-md truncate">
+                    {row.original.value ? (
+                        <span className="text-sm">{row.original.value}</span>
+                    ) : (
+                        <Badge variant="outline" className="text-muted-foreground">
+                            No value
+                        </Badge>
+                    )}
+                </div>
+            ),
+        },
+        {
+            accessorKey: 'updated_at',
+            header: 'Last Updated',
+            cell: ({ row }) => new Date(row.original.updated_at).toLocaleDateString(),
+        },
+        {
+            id: 'actions',
+            header: 'Actions',
+            cell: ({ row }) => (
+                <div className="flex gap-2">
+                    <Button size="sm" variant="outline" onClick={() => router.visit(`/super-admin/settings/${row.original.id}`)}>
+                        <Eye className="mr-1 h-3 w-3" />
+                        View
+                    </Button>
+                    <Button size="sm" variant="outline" onClick={() => router.visit(`/super-admin/settings/${row.original.id}/edit`)}>
+                        Edit
+                    </Button>
+                </div>
+            ),
+        },
+    ];
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Settings" />
+            <div className="px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <div>
+                        <h1 className="text-2xl font-bold">System Settings</h1>
+                        <p className="mt-1 text-sm text-muted-foreground">Manage application configuration and settings</p>
+                    </div>
+                    <Link href="/super-admin/settings/create">
+                        <Button>
+                            <Plus className="mr-2 h-4 w-4" />
+                            Create Setting
+                        </Button>
+                    </Link>
+                </div>
+                <DataTable columns={columns} data={settings.data} />
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/super-admin/settings/show.tsx
+++ b/resources/js/pages/super-admin/settings/show.tsx
@@ -1,0 +1,117 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AppLayout from '@/layouts/app-layout';
+import { Head, Link, router } from '@inertiajs/react';
+import { ArrowLeft, Calendar, Key } from 'lucide-react';
+
+interface Setting {
+    id: number;
+    key: string;
+    value: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+interface Props {
+    setting: Setting;
+}
+
+export default function SettingShow({ setting }: Props) {
+    const handleDelete = () => {
+        if (confirm('Are you sure you want to delete this setting? This action cannot be undone.')) {
+            router.delete(`/super-admin/settings/${setting.id}`);
+        }
+    };
+
+    return (
+        <AppLayout
+            breadcrumbs={[
+                { title: 'Super Admin', href: '/super-admin/dashboard' },
+                { title: 'Settings', href: '/super-admin/settings' },
+                { title: setting.key, href: '#' },
+            ]}
+        >
+            <Head title={setting.key} />
+            <div className="px-4 py-6">
+                <div className="mb-6 flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                        <Link href="/super-admin/settings">
+                            <Button variant="outline" size="sm">
+                                <ArrowLeft className="mr-2 h-4 w-4" />
+                                Back to Settings
+                            </Button>
+                        </Link>
+                        <div>
+                            <h1 className="font-mono text-2xl font-bold">{setting.key}</h1>
+                            <p className="text-sm text-muted-foreground">System Setting</p>
+                        </div>
+                    </div>
+                    <div className="flex gap-2">
+                        <Link href={`/super-admin/settings/${setting.id}/edit`}>
+                            <Button variant="outline">Edit Setting</Button>
+                        </Link>
+                        <Button variant="destructive" onClick={handleDelete}>
+                            Delete Setting
+                        </Button>
+                    </div>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">Setting Key</CardTitle>
+                            <Key className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="font-mono text-2xl font-bold">{setting.key}</div>
+                            <p className="text-xs text-muted-foreground">Configuration identifier</p>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                            <CardTitle className="text-sm font-medium">Last Updated</CardTitle>
+                            <Calendar className="h-4 w-4 text-muted-foreground" />
+                        </CardHeader>
+                        <CardContent>
+                            <div className="text-2xl font-bold">{new Date(setting.updated_at).toLocaleDateString()}</div>
+                            <p className="text-xs text-muted-foreground">{new Date(setting.updated_at).toLocaleTimeString()}</p>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <Card className="mt-4">
+                    <CardHeader>
+                        <CardTitle>Setting Value</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        {setting.value ? (
+                            <div className="rounded-md bg-muted p-4">
+                                <p className="text-sm whitespace-pre-wrap">{setting.value}</p>
+                            </div>
+                        ) : (
+                            <Badge variant="outline" className="text-muted-foreground">
+                                No value set
+                            </Badge>
+                        )}
+                    </CardContent>
+                </Card>
+
+                <Card className="mt-4">
+                    <CardHeader>
+                        <CardTitle>Metadata</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2">
+                        <div>
+                            <span className="font-medium">Created:</span> {new Date(setting.created_at).toLocaleString()}
+                        </div>
+                        <div>
+                            <span className="font-medium">Last Modified:</span> {new Date(setting.updated_at).toLocaleString()}
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,7 @@ use App\Http\Controllers\SuperAdmin\InvoiceController as SuperAdminInvoiceContro
 use App\Http\Controllers\SuperAdmin\PaymentController as SuperAdminPaymentController;
 use App\Http\Controllers\SuperAdmin\SchoolInformationController as SuperAdminSchoolInformationController;
 use App\Http\Controllers\SuperAdmin\SchoolYearController as SuperAdminSchoolYearController;
+use App\Http\Controllers\SuperAdmin\SettingController as SuperAdminSettingController;
 use App\Http\Controllers\SuperAdmin\StudentController as SuperAdminStudentController;
 use App\Http\Controllers\SuperAdmin\UserController as SuperAdminUserController;
 use App\Http\Controllers\TuitionController;
@@ -185,6 +186,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
             Route::get('/', [SuperAdminSchoolInformationController::class, 'index'])->name('index');
             Route::put('/', [SuperAdminSchoolInformationController::class, 'update'])->name('update');
         });
+
+        // Settings Management
+        Route::resource('settings', SuperAdminSettingController::class);
     });
 
     // Admin Routes (for administrator roles)


### PR DESCRIPTION
## Summary

Implements complete CRUD operations for System Settings management in the Super Admin section, including navigation integration.

### Backend Implementation
- Created `SettingController` with full CRUD methods (index, create, store, show, edit, update, destroy)
- Added `StoreSettingRequest` and `UpdateSettingRequest` for validation
- Created `SettingPolicy` for authorization (super_admin and administrator roles only)
- Updated Setting model with proper fillable fields and PHPDoc type annotations
- Key-value pair structure for flexible configuration storage
- Includes activity logging for all mutations
- Search functionality by key and value
- Unique key constraint validation

### Frontend Implementation
- Created index page with DataTable showing all system settings
- Created create form for new settings with key/value inputs
- Created edit form for updating existing settings
- Created show page displaying setting details with metadata
- All forms use shadcn/ui components (Card, Input, Label, Textarea, Badge)
- Proper TypeScript interfaces for Setting model
- Real-time form validation with error handling
- Monospace font styling for setting keys for better readability

### Navigation & Routes
- Added "System Settings" menu item to super-admin sidebar with Settings2 icon
- Positioned between "Audit Logs" and "Profile Settings" for logical grouping
- Registered resourceful routes in web.php under super-admin namespace

### Key Features
- Key-value storage for application configuration
- Support for multi-line values using Textarea component
- Validation ensures unique keys across the system
- Display of created/updated timestamps
- Notes about proper key naming conventions (lowercase with underscores)
- Configures application-wide settings like:
  - Payment information (location, hours, methods)
  - School contact details (name, address, phone, email)
  - Any other system-wide configuration parameters

## Test Plan
- [x] All pre-push checks passed (PHPStan, Pint, ESLint, Prettier, tests)
- [x] Build successful with no TypeScript errors
- [ ] Manual testing: Navigate to /super-admin/settings
- [ ] Manual testing: Create a new setting
- [ ] Manual testing: Edit an existing setting  
- [ ] Manual testing: View setting details
- [ ] Manual testing: Delete a setting
- [ ] Manual testing: Search settings by key or value
- [ ] Verify sidebar navigation works correctly
- [ ] Check authorization for administrator and super_admin roles

## Related
- Part of series adding complete CRUD for all models
- Previous PRs: SchoolYear CRUD (#311), Document CRUD (#312), Receipt CRUD (#313)
- This is the final CRUD PR in the series