### PR TITLE
fix: Add auto-filtering for enrollments status/grade/school year (#326)

### DIFF
--- a/resources/js/pages/super-admin/enrollments/index.tsx
+++ b/resources/js/pages/super-admin/enrollments/index.tsx
@@ -8,7 +8,7 @@ import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/react';
 import { PlusCircle, Search } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { columns, type Enrollment } from './columns';
 
 interface PaginationLink {
@@ -51,6 +51,24 @@ export default function SuperAdminEnrollmentsIndex({ enrollments, filters, statu
         { title: 'Super Admin', href: '/super-admin/dashboard' },
         { title: 'Enrollments', href: '/super-admin/enrollments' },
     ];
+
+    // Auto-filter when status, grade, or school year changes
+    useEffect(() => {
+        router.get(
+            '/super-admin/enrollments',
+            {
+                search: search || undefined,
+                status: status && status !== 'all' ? status : undefined,
+                grade: grade && grade !== 'all' ? grade : undefined,
+                school_year_id: schoolYearId && schoolYearId !== 'all' ? schoolYearId : undefined,
+            },
+            {
+                preserveState: true,
+                preserveScroll: true,
+                only: ['enrollments'],
+            },
+        );
+    }, [status, grade, schoolYearId]);
 
     const handleSearch = () => {
         router.get(


### PR DESCRIPTION
## Problem
On `/super-admin/enrollments`, the status filter doesn't work 100% correctly. Users have to click a search button for filters to apply.

## Root Cause
The status, grade, and school year dropdown filters were updating state but not triggering backend requests. The `handleSearch()` function existed but was only called via a search button.

## Solution
- Added `useEffect` hook that monitors status, grade, and schoolYearId changes
- Automatically triggers `router.get()` when any filter dropdown changes
- Uses `only: ['enrollments']` for efficient partial reloads
- Maintains scroll position with `preserveScroll: true`

## Testing
- All pre-push checks passing ✅
- TypeScript compilation successful
- Assets built successfully  
- Code coverage maintained above 60%

## Closes
Closes #326