### PR TITLE
feat: Add reusable ConfirmationDialog component (#328)

### DIFF
--- a/resources/js/components/ui/confirmation-dialog.tsx
+++ b/resources/js/components/ui/confirmation-dialog.tsx
@@ -1,0 +1,56 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface ConfirmationDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onConfirm: () => void;
+    title?: string;
+    description?: string;
+    confirmText?: string;
+    cancelText?: string;
+    variant?: 'default' | 'destructive';
+}
+
+export function ConfirmationDialog({
+    open,
+    onOpenChange,
+    onConfirm,
+    title = 'Are you sure?',
+    description = 'This action cannot be undone.',
+    confirmText = 'Continue',
+    cancelText = 'Cancel',
+    variant = 'default',
+}: ConfirmationDialogProps) {
+    return (
+        <AlertDialog open={open} onOpenChange={onOpenChange}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{title}</AlertDialogTitle>
+                    <AlertDialogDescription>{description}</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+                    <AlertDialogAction
+                        onClick={onConfirm}
+                        className={
+                            variant === 'destructive'
+                                ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                                : ''
+                        }
+                    >
+                        {confirmText}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}


### PR DESCRIPTION
## Summary
Adds a reusable ConfirmationDialog component for consistent confirmation dialogs across all CRUD operations. This infrastructure component is required for implementing user feedback in issues #329-#332.

## Changes Made
- Created `confirmation-dialog.tsx` component wrapping AlertDialog from shadcn/ui
- Supports two variants:
  - `default`: Standard confirmation dialogs
  - `destructive`: Delete and other destructive actions (red styling)
- Provides flexible props for customization:
  - `title`: Dialog title (default: "Are you sure?")
  - `description`: Description text (default: "This action cannot be undone.")
  - `confirmText`: Confirm button text (default: "Continue")
  - `cancelText`: Cancel button text (default: "Cancel")
  - `variant`: Visual style variant

## Implementation Details
- **Base Component**: Uses existing AlertDialog from shadcn/ui (already installed)
- **State Management**: Accepts `open` and `onOpenChange` props for controlled state
- **Callback**: `onConfirm` prop for handling confirmation action
- **Styling**: Destructive variant applies red background matching design system
- **Accessibility**: Inherits all AlertDialog accessibility features

## Usage Example
```tsx
const [open, setOpen] = useState(false);

<ConfirmationDialog
    open={open}
    onOpenChange={setOpen}
    onConfirm={() => {
        // Handle confirmation
    }}
    title="Delete Student?"
    description="This will permanently delete the student record and cannot be undone."
    confirmText="Delete"
    variant="destructive"
/>
```

## Testing
- ✅ All tests passing (357 tests, 1144 assertions)
- ✅ Pre-push hooks passing
- ✅ TypeScript compiles successfully
- ✅ Assets build successfully

## Related Issues
Closes #328

## Next Steps
This PR enables the following dependent issues:
- #329 - Add CRUD feedback to Enrollments (depends on #327, #328)
- #330 - Add CRUD feedback to Students (depends on #327, #328)
- #331 - Add CRUD feedback to Guardians (depends on #327, #328)
- #332 - Add CRUD feedback to Users (depends on #327, #328)