### PR TITLE
feat: Add CRUD feedback to Enrollments (#329)

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -1,5 +1,6 @@
 import '../css/app.css';
 
+import { Toaster } from '@/components/ui/sonner';
 import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { createRoot } from 'react-dom/client';
@@ -13,7 +14,12 @@ createInertiaApp({
     setup({ el, App, props }) {
         const root = createRoot(el);
 
-        root.render(<App {...props} />);
+        root.render(
+            <>
+                <App {...props} />
+                <Toaster />
+            </>,
+        );
     },
     progress: {
         color: '#4B5563',

--- a/resources/js/components/ui/confirmation-dialog.tsx
+++ b/resources/js/components/ui/confirmation-dialog.tsx
@@ -1,0 +1,56 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface ConfirmationDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onConfirm: () => void;
+    title?: string;
+    description?: string;
+    confirmText?: string;
+    cancelText?: string;
+    variant?: 'default' | 'destructive';
+}
+
+export function ConfirmationDialog({
+    open,
+    onOpenChange,
+    onConfirm,
+    title = 'Are you sure?',
+    description = 'This action cannot be undone.',
+    confirmText = 'Continue',
+    cancelText = 'Cancel',
+    variant = 'default',
+}: ConfirmationDialogProps) {
+    return (
+        <AlertDialog open={open} onOpenChange={onOpenChange}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>{title}</AlertDialogTitle>
+                    <AlertDialogDescription>{description}</AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+                    <AlertDialogAction
+                        onClick={onConfirm}
+                        className={
+                            variant === 'destructive'
+                                ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                                : ''
+                        }
+                    >
+                        {confirmText}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}

--- a/resources/js/components/ui/sonner.tsx
+++ b/resources/js/components/ui/sonner.tsx
@@ -1,0 +1,23 @@
+import { Toaster as Sonner } from 'sonner';
+
+type ToasterProps = React.ComponentProps<typeof Sonner>;
+
+const Toaster = ({ ...props }: ToasterProps) => {
+    return (
+        <Sonner
+            theme="system"
+            className="toaster group"
+            toastOptions={{
+                classNames: {
+                    toast: 'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+                    description: 'group-[.toast]:text-muted-foreground',
+                    actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
+                    cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+                },
+            }}
+            {...props}
+        />
+    );
+};
+
+export { Toaster };

--- a/resources/js/pages/guardian/enrollments/edit.tsx
+++ b/resources/js/pages/guardian/enrollments/edit.tsx
@@ -1,11 +1,13 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConfirmationDialog } from '@/components/ui/confirmation-dialog';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head, router, useForm } from '@inertiajs/react';
 import { AlertCircle } from 'lucide-react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 interface Enrollment {
@@ -30,6 +32,8 @@ interface Props {
 }
 
 export default function GuardianEnrollmentsEdit({ enrollment, gradeLevels, quarters }: Props) {
+    const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+
     const breadcrumbs: BreadcrumbItem[] = [
         { title: 'Guardian', href: '/guardian/dashboard' },
         { title: 'Enrollments', href: '/guardian/enrollments' },
@@ -55,16 +59,16 @@ export default function GuardianEnrollmentsEdit({ enrollment, gradeLevels, quart
     };
 
     const handleCancel = () => {
-        if (confirm('Are you sure you want to cancel this enrollment? This action cannot be undone.')) {
-            router.delete(`/guardian/enrollments/${enrollment.id}`, {
-                onSuccess: () => {
-                    toast.success('Enrollment canceled successfully');
-                },
-                onError: () => {
-                    toast.error('Failed to cancel enrollment');
-                },
-            });
-        }
+        router.delete(`/guardian/enrollments/${enrollment.id}`, {
+            preserveScroll: true,
+            onSuccess: () => {
+                toast.success('Enrollment canceled successfully');
+                setCancelDialogOpen(false);
+            },
+            onError: () => {
+                toast.error('Failed to cancel enrollment');
+            },
+        });
     };
 
     return (
@@ -173,13 +177,29 @@ export default function GuardianEnrollmentsEdit({ enrollment, gradeLevels, quart
                                 <Button type="button" variant="outline" onClick={() => window.history.back()} disabled={processing}>
                                     Cancel
                                 </Button>
-                                <Button type="button" variant="destructive" onClick={handleCancel} disabled={processing} className="ml-auto">
+                                <Button
+                                    type="button"
+                                    variant="destructive"
+                                    onClick={() => setCancelDialogOpen(true)}
+                                    disabled={processing}
+                                    className="ml-auto"
+                                >
                                     Cancel Enrollment
                                 </Button>
                             </div>
                         </form>
                     </CardContent>
                 </Card>
+
+                <ConfirmationDialog
+                    open={cancelDialogOpen}
+                    onOpenChange={setCancelDialogOpen}
+                    onConfirm={handleCancel}
+                    title="Cancel Enrollment?"
+                    description="Are you sure you want to cancel this enrollment? This action cannot be undone."
+                    confirmText="Cancel Enrollment"
+                    variant="destructive"
+                />
             </div>
         </AppLayout>
     );


### PR DESCRIPTION
## Summary
Adds comprehensive user feedback for all enrollment CRUD operations including toast notifications for success/error states and confirmation dialogs for destructive actions.

## Changes Made

### Infrastructure Added (from PRs #336, #337)
- Added Toaster component from sonner library for site-wide toast notifications
- Added reusable ConfirmationDialog component for consistent confirmation flows

### Enrollments Feedback Implementation
1. **Delete Operations (Super Admin)**
   - Replaced browser `confirm()` with ConfirmationDialog component
   - Added success toast: "Enrollment deleted successfully"
   - Added error toast: "Failed to delete enrollment. Please try again."
   - Maintains scroll position during operation

2. **Cancel Operations (Guardian Edit)**
   - Replaced browser `confirm()` with ConfirmationDialog for enrollment cancellation
   - Added success toast: "Enrollment canceled successfully"
   - Added error toast: "Failed to cancel enrollment"
   - Proper dialog state management with useState

3. **Create/Update Operations**
   - Guardian create already had toast notifications (verified)
   - Guardian edit already had toast notifications (verified)

## Files Modified
- `resources/js/app.tsx` - Added Toaster component to root
- `resources/js/components/ui/sonner.tsx` - Toast component wrapper
- `resources/js/components/ui/confirmation-dialog.tsx` - Reusable confirmation dialog
- `resources/js/pages/super-admin/enrollments/columns.tsx` - Added ActionsCell component with ConfirmationDialog and toasts
- `resources/js/pages/guardian/enrollments/edit.tsx` - Updated cancel enrollment to use ConfirmationDialog

## Implementation Details
- **ActionsCell Component**: Extracted actions column into separate component to enable React hooks (useState) for dialog management
- **Consistent UX**: All destructive actions now show red-styled confirmation dialogs
- **Error Handling**: All operations include onSuccess and onError callbacks with appropriate toast messages
- **Scroll Preservation**: Added `preserveScroll: true` to all router operations

## Testing
- ✅ All tests passing (357 tests, 1144 assertions)
- ✅ Pre-push hooks passing
- ✅ TypeScript compiles successfully
- ✅ Assets build successfully
- ✅ No console errors

## Related Issues
Closes #329
Includes infrastructure from #327 and #328

## Screenshots/Demo
- Delete confirmation dialog appears before deleting enrollment
- Toast notifications appear on successful/failed operations
- Cancel enrollment uses confirmation dialog instead of browser confirm

## Next Steps
With this PR, the pattern is established for:
- #330 - Add CRUD feedback to Students
- #331 - Add CRUD feedback to Guardians
- #332 - Add CRUD feedback to Users