### PR TITLE
fix: Exclude completed/enrolled students from enrollments table (Issue #358)

### DIFF
--- a/app/Http/Controllers/Admin/EnrollmentController.php
+++ b/app/Http/Controllers/Admin/EnrollmentController.php
@@ -19,8 +19,14 @@ class EnrollmentController extends Controller
     {
         $enrollmentsQuery = Enrollment::query();
 
+        // Exclude completed and enrolled enrollments from count (they should appear in Students page only)
+        $activeEnrollmentsQuery = Enrollment::whereNotIn('status', [
+            EnrollmentStatus::COMPLETED,
+            EnrollmentStatus::ENROLLED,
+        ]);
+
         $statusCounts = [
-            'all' => (clone $enrollmentsQuery)->count(),
+            'all' => (clone $activeEnrollmentsQuery)->count(),
             'pending' => (clone $enrollmentsQuery)->where('status', 'pending')->count(),
             'approved' => (clone $enrollmentsQuery)->where('status', 'approved')->count(),
             'rejected' => (clone $enrollmentsQuery)->where('status', 'rejected')->count(),
@@ -28,7 +34,13 @@ class EnrollmentController extends Controller
             'completed' => (clone $enrollmentsQuery)->where('status', 'completed')->count(),
         ];
 
-        $enrollments = $enrollmentsQuery->with(['student'])
+        // Exclude completed and enrolled enrollments from index (they should appear in Students page only)
+        $enrollments = $enrollmentsQuery
+            ->whereNotIn('status', [
+                EnrollmentStatus::COMPLETED,
+                EnrollmentStatus::ENROLLED,
+            ])
+            ->with(['student'])
             ->when($request->input('search'), function ($query, $search) {
                 $query->whereHas('student', function ($q) use ($search) {
                     $q->where('first_name', 'like', "%{$search}%")

--- a/app/Http/Controllers/Registrar/EnrollmentController.php
+++ b/app/Http/Controllers/Registrar/EnrollmentController.php
@@ -25,6 +25,12 @@ class EnrollmentController extends Controller
     {
         $query = Enrollment::with(['student', 'guardian.user']);
 
+        // Exclude completed and enrolled enrollments (they should appear in Students page only)
+        $query->whereNotIn('status', [
+            EnrollmentStatus::COMPLETED,
+            EnrollmentStatus::ENROLLED,
+        ]);
+
         // Apply filters
         if ($request->filled('status')) {
             $query->where('status', $request->status);

--- a/app/Http/Controllers/SuperAdmin/EnrollmentController.php
+++ b/app/Http/Controllers/SuperAdmin/EnrollmentController.php
@@ -31,6 +31,12 @@ class EnrollmentController extends Controller
 
         $query = Enrollment::with(['student', 'guardian.user']);
 
+        // Exclude completed and enrolled enrollments (they should appear in Students page only)
+        $query->whereNotIn('status', [
+            EnrollmentStatus::COMPLETED,
+            EnrollmentStatus::ENROLLED,
+        ]);
+
         // Search functionality
         if ($request->filled('search')) {
             $search = $request->get('search');

--- a/tests/Feature/EnrollmentControllerTest.php
+++ b/tests/Feature/EnrollmentControllerTest.php
@@ -75,9 +75,10 @@ describe('enrollment controller', function () {
         $admin = User::factory()->create();
         $admin->assignRole('administrator');
 
-        // Create some enrollments
+        // Create some enrollments with statuses that won't be filtered out
+        // (COMPLETED and ENROLLED statuses are excluded from the enrollments index)
         Student::factory()->count(3)->create()->each(function ($student) {
-            Enrollment::factory()->create(['student_id' => $student->id]);
+            Enrollment::factory()->pending()->create(['student_id' => $student->id]);
         });
 
         $response = $this->actingAs($admin)->get(route('registrar.enrollments.index'));


### PR DESCRIPTION
## Description
Fixes #358 - Completed and enrolled students should only appear in the Students page, not in the Enrollments table.

## Changes Made
- Updated `Registrar\EnrollmentController` to exclude COMPLETED and ENROLLED statuses
- Updated `SuperAdmin\EnrollmentController` to exclude COMPLETED and ENROLLED statuses  
- Updated `Admin\EnrollmentController` to exclude COMPLETED and ENROLLED statuses
- Added `whereNotIn` filter to index methods to filter out these statuses

## Impact
- Enrollments table now only shows active enrollment applications (Pending, Pending Review, Approved, Rejected)
- Reduces clutter in registrar workflow
- Improves focus on enrollments that need processing
- Enrolled/completed students should be viewed in the Students page

## Testing
- ✅ All pre-push checks passed
- ✅ PHPStan static analysis passed
- ✅ Code style checks passed
- ✅ Tests passed with 60%+ coverage

## Screenshots
N/A - Backend query change only

## Additional Notes
This change maintains the separation of concerns between active enrollments (processing queue) and enrolled students (student management).