### PR TITLE
Fix: Remove redundant Invoices menu item from guardian sidebar

### DIFF
--- a/resources/js/components/sidebars/guardian-sidebar.tsx
+++ b/resources/js/components/sidebars/guardian-sidebar.tsx
@@ -27,11 +27,6 @@ const mainNavItems: NavItem[] = [
         icon: FileCheck,
     },
     {
-        title: 'Invoices',
-        href: '/invoices',
-        icon: FileCheck,
-    },
-    {
         title: 'Tuition Fees',
         href: '/tuition',
         icon: CreditCard,


### PR DESCRIPTION
## Summary
Fixes #351 (Partial) - Removes the redundant "Invoices" navigation item from the guardian sidebar that was causing confusion and showing empty/broken content.

## Problem
The guardian sidebar had both a "Billing" and "Invoices" menu item:
- "Billing" links to `/guardian/billing` (proper scoped route)
- "Invoices" linked to `/invoices` (improper unscoped route, see #366)
- The "Invoices" item showed empty/broken dropdown content
- This created confusion with two similar menu items for the same functionality

## Solution
Removed the redundant "Invoices" menu item from the guardian sidebar navigation. The "Billing" section already provides access to invoice information with the correct route scoping.

## Changes Made
- Removed "Invoices" navigation item from `guardian-sidebar.tsx`
- Kept "Billing" as the single source for billing/invoice information
- Maintains clean, non-redundant navigation structure

## Visual Confirmation
**Before:**
- Dashboard
- My Children
- Enrollments
- Billing
- ❌ Invoices (redundant, broken)
- Tuition Fees
- Profile Settings

**After:**
- Dashboard
- My Children
- Enrollments
- Billing ✅
- Tuition Fees
- Profile Settings

## Testing
- ✅ Visually verified sidebar no longer shows "Invoices" item
- ✅ All pre-push checks passed
- ✅ TypeScript compilation passed
- ✅ ESLint and Prettier checks passed
- ✅ Test suite passed with 60%+ coverage

## Files Changed
- `resources/js/components/sidebars/guardian-sidebar.tsx`

## Related Issues
- Partially addresses #351
- Related to #366 (invoice routing structure issue)

## Note
Issue #351 also mentions removing inappropriate payment method options for cash-only system. That will need to be addressed separately as it requires changes to billing/payment pages, not just sidebar navigation.