### PR TITLE
fix: Add Gender enum and support 'Other' gender option (#391, #392)

### DIFF
--- a/app/Enums/Gender.php
+++ b/app/Enums/Gender.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Enums;
+
+enum Gender: string
+{
+    case MALE = 'Male';
+    case FEMALE = 'Female';
+    case OTHER = 'Other';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return $this->value;
+    }
+}

--- a/app/Http/Requests/SuperAdmin/StoreStudentRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreStudentRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\SuperAdmin;
 
+use App\Enums\Gender;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreStudentRequest extends FormRequest
 {
@@ -27,7 +29,7 @@ class StoreStudentRequest extends FormRequest
             'last_name' => ['required', 'string', 'max:100'],
             'birth_date' => ['required', 'date', 'before:today'],
             'birth_place' => ['nullable', 'string', 'max:255'],
-            'gender' => ['required', 'in:Male,Female'],
+            'gender' => ['required', Rule::in(Gender::values())],
             'nationality' => ['nullable', 'string', 'max:100'],
             'religion' => ['nullable', 'string', 'max:100'],
             'address' => ['required', 'string', 'max:500'],

--- a/app/Http/Requests/SuperAdmin/UpdateStudentRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateStudentRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\SuperAdmin;
 
+use App\Enums\Gender;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateStudentRequest extends FormRequest
 {
@@ -29,7 +31,7 @@ class UpdateStudentRequest extends FormRequest
             'last_name' => ['required', 'string', 'max:100'],
             'birth_date' => ['required', 'date', 'before:today'],
             'birth_place' => ['nullable', 'string', 'max:255'],
-            'gender' => ['required', 'in:Male,Female,Other'],
+            'gender' => ['required', Rule::in(Gender::values())],
             'nationality' => ['nullable', 'string', 'max:100'],
             'religion' => ['nullable', 'string', 'max:100'],
             'address' => ['required', 'string', 'max:500'],

--- a/database/migrations/2025_10_28_091529_add_other_to_gender_enum_in_students_table.php
+++ b/database/migrations/2025_10_28_091529_add_other_to_gender_enum_in_students_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Only run for MySQL - SQLite doesn't support ENUM
+        // SQLite will store as TEXT and validation happens at application layer
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE students MODIFY COLUMN gender ENUM('Male', 'Female', 'Other') NOT NULL");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Only run for MySQL
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE students MODIFY COLUMN gender ENUM('Male', 'Female') NOT NULL");
+        }
+    }
+};


### PR DESCRIPTION
## Summary
This PR addresses two critical issues related to gender validation:
- Creates a type-safe Gender enum to replace hardcoded strings throughout the application
- Adds support for 'Other' gender option in the database and validation layer

## Issues Fixed
Fixes #391 - Create Gender enum for type-safe gender validation
Fixes #392 - CRITICAL: Gender validation accepts 'Other' but database rejects it

## Changes Made

### New Files
- **app/Enums/Gender.php** - Type-safe enum with Male, Female, and Other values
  - Provides `values()` method for validation rules
  - Provides `label()` method for display purposes

### Modified Files
- **app/Http/Requests/SuperAdmin/StoreStudentRequest.php** - Updated gender validation to use `Rule::in(Gender::values())`
- **app/Http/Requests/SuperAdmin/UpdateStudentRequest.php** - Updated gender validation to use `Rule::in(Gender::values())`

### Database Migration
- **database/migrations/2025_10_28_091529_add_other_to_gender_enum_in_students_table.php**
  - Extends gender ENUM to include 'Other' option
  - Includes database driver check for MySQL vs SQLite compatibility
  - SQLite stores as TEXT with validation at application layer
  - MySQL uses proper ENUM constraint

## Testing
- ✅ All unit and feature tests passing
- ✅ Code coverage above 60% threshold
- ✅ Visual verification completed via Chrome DevTools
- ✅ Migration tested on both MySQL (production) and SQLite (tests)

## Visual Verification
Logged into application as super.admin@cbhlc.edu and verified:
- Students page loads correctly
- Application functionality intact
- No breaking changes to existing features

## Technical Notes
This implementation ensures cross-database compatibility by checking the database driver before executing MySQL-specific ALTER statements. The Gender enum provides validation regardless of the underlying database engine.