### PR TITLE
fix: Remove duplicate index on receipts.receipt_number (#390)

### DIFF
--- a/database/migrations/2025_10_28_093116_remove_duplicate_receipt_number_index_from_receipts.php
+++ b/database/migrations/2025_10_28_093116_remove_duplicate_receipt_number_index_from_receipts.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('receipts', function (Blueprint $table) {
+            // Remove duplicate index on receipt_number
+            // The unique constraint already creates an index
+            $table->dropIndex('receipts_receipt_number_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('receipts', function (Blueprint $table) {
+            // Recreate the regular index if rolling back
+            $table->index('receipt_number');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
This PR removes a redundant index on the `receipts.receipt_number` column, improving database performance and reducing storage overhead.

## Issue Fixed
Fixes #390 - Remove duplicate index on receipts.receipt_number

## Problem
The `receipts` table had two indexes on the `receipt_number` column:
1. **UNIQUE constraint:** `receipts_receipt_number_unique` (automatically creates an index)
2. **Regular index:** `receipts_receipt_number_index` ❌ **REDUNDANT**

Since UNIQUE constraints automatically create an index, the additional regular index was unnecessary and caused:
- Minor performance overhead on INSERT/UPDATE operations
- Unnecessary index storage
- Maintenance confusion

## Changes Made

### New Migration
- **database/migrations/2025_10_28_093116_remove_duplicate_receipt_number_index_from_receipts.php**
  - `up()`: Drops the redundant `receipts_receipt_number_index`
  - `down()`: Recreates the regular index if rolling back

```php
public function up(): void
{
    Schema::table('receipts', function (Blueprint $table) {
        $table->dropIndex('receipts_receipt_number_index');
    });
}
```

## After This Fix

The `receipts` table will have optimal indexing:
```
✅ PRIMARY: id
✅ UNIQUE: receipts_receipt_number_unique (provides index for receipt_number)
✅ INDEX: receipts_receipt_date_index
✅ INDEX: receipts_payment_id_index
✅ INDEX: receipts_invoice_id_index
✅ FK INDEX: receipts_received_by_foreign
```

## Performance Impact
- ✅ Slightly faster INSERT/UPDATE operations (one less index to maintain)
- ✅ Reduced index storage
- ✅ No impact on query performance (unique constraint index provides same benefits)

## Testing
- ✅ Migration ran successfully on MySQL database
- ✅ All unit and feature tests passing
- ✅ Code coverage above 60% threshold
- ✅ Visual verification: Receipts page loads correctly
- ✅ Static analysis and security checks passed

## Visual Verification
- Navigated to Receipts page at http://localhost:8080/super-admin/receipts
- Confirmed page loads correctly after migration
- Verified no performance degradation in receipt lookups

## Technical Notes
Queries using `receipt_number` (e.g., `WHERE receipt_number = 'RCP-000001'`) will continue to use the index automatically created by the unique constraint, maintaining optimal query performance.