### PR TITLE
refactor: Replace hardcoded payment method strings with PaymentMethod enum (#394)

### DIFF
--- a/app/Http/Requests/SuperAdmin/StorePaymentRequest.php
+++ b/app/Http/Requests/SuperAdmin/StorePaymentRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\SuperAdmin;
 
+use App\Enums\PaymentMethod;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StorePaymentRequest extends FormRequest
 {
@@ -25,7 +27,7 @@ class StorePaymentRequest extends FormRequest
             'invoice_id' => ['required', 'exists:invoices,id'],
             'payment_date' => ['required', 'date'],
             'amount' => ['required', 'numeric', 'min:0.01'],
-            'payment_method' => ['required', 'in:cash,bank_transfer,check,credit_card,gcash,paymaya'],
+            'payment_method' => ['required', Rule::in(PaymentMethod::values())],
             'reference_number' => ['nullable', 'string', 'max:100'],
             'notes' => ['nullable', 'string', 'max:500'],
         ];

--- a/app/Http/Requests/SuperAdmin/UpdatePaymentRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdatePaymentRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\SuperAdmin;
 
+use App\Enums\PaymentMethod;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdatePaymentRequest extends FormRequest
 {
@@ -25,7 +27,7 @@ class UpdatePaymentRequest extends FormRequest
             'invoice_id' => ['required', 'exists:invoices,id'],
             'payment_date' => ['required', 'date'],
             'amount' => ['required', 'numeric', 'min:0.01'],
-            'payment_method' => ['required', 'in:cash,bank_transfer,check,credit_card,gcash,paymaya'],
+            'payment_method' => ['required', Rule::in(PaymentMethod::values())],
             'reference_number' => ['nullable', 'string', 'max:100'],
             'notes' => ['nullable', 'string', 'max:500'],
         ];


### PR DESCRIPTION
## Summary
This PR replaces hardcoded payment method validation strings with proper `PaymentMethod` enum usage, improving type safety and maintainability.

## Issue
Relates to #394 - Replace hardcoded enum strings with proper enum usage in Request validation

**Note:** This is a **partial implementation** of issue #394. The Gender enum updates will be completed after PR #401 (Gender enum creation) is merged to main.

## Problem
Payment request validation was using hardcoded strings for payment methods:
```php
'payment_method' => ['required', 'in:cash,bank_transfer,check,credit_card,gcash,paymaya'],
```

This approach has several issues:
- ❌ No type safety
- ❌ Duplication of enum values
- ❌ Risk of typos in hardcoded strings
- ❌ Difficult to refactor
- ❌ Can get out of sync with the PaymentMethod enum

## Changes Made

### Modified Files
- **app/Http/Requests/SuperAdmin/StorePaymentRequest.php**
  - Added `use App\Enums\PaymentMethod;` and `use Illuminate\Validation\Rule;`
  - Replaced hardcoded string with `Rule::in(PaymentMethod::values())`

- **app/Http/Requests/SuperAdmin/UpdatePaymentRequest.php**
  - Added `use App\Enums\PaymentMethod;` and `use Illuminate\Validation\Rule;`
  - Replaced hardcoded string with `Rule::in(PaymentMethod::values())`

## Benefits
- ✅ Single source of truth for payment methods
- ✅ Type-safe validation using enum
- ✅ Automatic sync with PaymentMethod enum values (cash, bank_transfer, check, credit_card, gcash, paymaya)
- ✅ Easier to add/modify payment methods in the future
- ✅ Better IDE autocomplete and refactoring support
- ✅ Consistent with best practices already used for Quarter and EnrollmentStatus enums

## Testing
- ✅ All unit and feature tests passing
- ✅ Code coverage above 60% threshold
- ✅ PHPStan static analysis passed
- ✅ Laravel Pint code style checks passed
- ✅ Visual verification: Edit payment form loads correctly
- ✅ All 6 payment method options displayed correctly in dropdown

## Visual Verification
Navigated to payment edit form and verified:
- Payment method dropdown displays all 6 enum values:
  - Cash
  - Bank Transfer
  - Check
  - Credit Card
  - GCash
  - PayMaya
- Form submission works correctly with enum validation
- No breaking changes to existing functionality

## Remaining Work for #394
After PR #401 (Gender enum) is merged, a follow-up PR will address:
- Gender validation in 6 student request files (Registrar/Guardian/SuperAdmin)
- Any other hardcoded enum strings identified in the audit

## Technical Notes
The PaymentMethod enum already existed and includes a `values()` method that returns all enum values. This PR simply updates the validation rules to use that enum instead of hardcoded strings, following the same pattern already established for Quarter and EnrollmentStatus enums in the codebase.