### PR TITLE
Fix #410: Add Update Payment Status action to Super Admin Students page

### DIFF
--- a/resources/js/pages/super-admin/students/columns.tsx
+++ b/resources/js/pages/super-admin/students/columns.tsx
@@ -26,6 +26,7 @@ export type Student = {
     paymentStatus: string;
     balance: number;
     netAmount: number;
+    activeEnrollmentId: number | null;
 };
 
 function formatCurrency(amount: number) {
@@ -87,6 +88,11 @@ function ActionsCell({ student }: { student: Student }) {
                         <Link href={`/super-admin/students/${student.id}/edit`}>Edit Student</Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem>View Enrollments</DropdownMenuItem>
+                    {student.activeEnrollmentId && (
+                        <DropdownMenuItem asChild>
+                            <Link href={`/super-admin/enrollments/${student.activeEnrollmentId}`}>Update Payment Status</Link>
+                        </DropdownMenuItem>
+                    )}
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onClick={() => setDeleteDialogOpen(true)}>Delete Student</DropdownMenuItem>
                 </DropdownMenuContent>

--- a/resources/js/pages/super-admin/students/index.tsx
+++ b/resources/js/pages/super-admin/students/index.tsx
@@ -14,6 +14,7 @@ export type Student = {
     grade_level: string;
     guardians: { first_name: string; last_name: string }[];
     enrollments: {
+        id: number;
         status: string;
         payment_status: string;
         balance: number;
@@ -64,6 +65,7 @@ export default function StudentsIndex({ students, filters }: Props) {
         paymentStatus: student.enrollments.length > 0 ? student.enrollments[0].payment_status : 'N/A',
         balance: student.enrollments.length > 0 ? parseCurrency(student.enrollments[0].balance) : 0,
         netAmount: student.enrollments.length > 0 ? parseCurrency(student.enrollments[0].net_amount) : 0,
+        activeEnrollmentId: student.enrollments.length > 0 ? student.enrollments[0].id : null,
     }));
 
     return (


### PR DESCRIPTION
## Problem
Super Admin could view student payment statuses but couldn't update payments from the Students page. The 'Update Payment Status' action was missing from the actions menu.

## Solution
Added 'Update Payment Status' menu item to student actions dropdown:
- Only appears for students with active enrollments
- Links to enrollment detail page for payment updates
- Follows same pattern as Registrar's payment update workflow

## Changes
- Added `activeEnrollmentId` field to Student type
- Added enrollment ID to formatted students data
- Added conditional 'Update Payment Status' menu item
- Menu item only shows when student has an active enrollment

## Visual Verification
✅ Students with active enrollments show 'Update Payment Status' option
✅ Students without enrollments (N/A status) do NOT show the option
✅ Menu item properly positioned between 'View Enrollments' and 'Delete Student'
✅ Links correctly to enrollment detail page

## Benefits
- Super Admin has same payment update access as Registrar
- Consistent with role hierarchy (Super Admin should have all Registrar permissions)
- Enables administrative override and emergency access
- Improves workflow efficiency

Closes #410