### PR TITLE
Fix #413: Add notifications for Super Admin and Registrar

### DIFF
--- a/app/Events/EnrollmentCreated.php
+++ b/app/Events/EnrollmentCreated.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Enrollment;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class EnrollmentCreated
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Enrollment $enrollment
+    ) {}
+}

--- a/app/Events/StudentCreated.php
+++ b/app/Events/StudentCreated.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Student;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class StudentCreated
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Student $student
+    ) {}
+}

--- a/app/Http/Controllers/Admin/EnrollmentController.php
+++ b/app/Http/Controllers/Admin/EnrollmentController.php
@@ -164,6 +164,9 @@ class EnrollmentController extends Controller
             'balance_cents' => $balanceCents,
         ]);
 
+        // Dispatch event to notify registrars
+        event(new \App\Events\EnrollmentCreated($enrollment));
+
         return redirect()->route('admin.enrollments.index')
             ->with('success', 'Enrollment application submitted successfully.');
     }

--- a/app/Http/Controllers/Guardian/EnrollmentController.php
+++ b/app/Http/Controllers/Guardian/EnrollmentController.php
@@ -274,6 +274,9 @@ class EnrollmentController extends Controller
         // Load relationships for notifications
         $enrollment->load(['student', 'guardian.user', 'schoolYear']);
 
+        // Dispatch event to notify registrars
+        event(new \App\Events\EnrollmentCreated($enrollment));
+
         // Notify guardian of submission
         if ($guardian->user) {
             /** @var \App\Models\User $user */

--- a/app/Http/Controllers/Guardian/StudentController.php
+++ b/app/Http/Controllers/Guardian/StudentController.php
@@ -164,6 +164,9 @@ class StudentController extends Controller
 
         $student = Student::create($studentData);
 
+        // Dispatch event to notify registrars
+        event(new \App\Events\StudentCreated($student));
+
         // Get Guardian model for authenticated user
         $guardian = Guardian::where('user_id', Auth::id())->firstOrFail();
 

--- a/app/Http/Controllers/Registrar/StudentController.php
+++ b/app/Http/Controllers/Registrar/StudentController.php
@@ -132,6 +132,9 @@ class StudentController extends Controller
 
         $student = Student::create($validated);
 
+        // Dispatch event to notify registrars
+        event(new \App\Events\StudentCreated($student));
+
         return redirect()->route('registrar.students.show', $student->id)
             ->with('success', 'Student created successfully.');
     }

--- a/app/Http/Controllers/SuperAdmin/StudentController.php
+++ b/app/Http/Controllers/SuperAdmin/StudentController.php
@@ -82,7 +82,7 @@ class StudentController extends Controller
 
         $validated = $request->validated();
 
-        DB::transaction(function () use ($validated) {
+        $student = DB::transaction(function () use ($validated) {
             $student = Student::create([
                 'first_name' => $validated['first_name'],
                 'middle_name' => $validated['middle_name'],
@@ -105,7 +105,12 @@ class StudentController extends Controller
                     'is_primary' => $index === 0,
                 ]);
             }
+
+            return $student;
         });
+
+        // Dispatch event to notify registrars
+        event(new \App\Events\StudentCreated($student));
 
         return redirect()->route('super-admin.students.index')
             ->with('success', 'Student created successfully.');

--- a/app/Listeners/NotifyRegistrarOfNewEnrollment.php
+++ b/app/Listeners/NotifyRegistrarOfNewEnrollment.php
@@ -5,13 +5,9 @@ namespace App\Listeners;
 use App\Events\EnrollmentCreated;
 use App\Models\User;
 use App\Notifications\NewEnrollmentCreatedNotification;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
 
-class NotifyRegistrarOfNewEnrollment implements ShouldQueue
+class NotifyRegistrarOfNewEnrollment
 {
-    use InteractsWithQueue;
-
     /**
      * Create the event listener.
      */

--- a/app/Listeners/NotifyRegistrarOfNewEnrollment.php
+++ b/app/Listeners/NotifyRegistrarOfNewEnrollment.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\EnrollmentCreated;
+use App\Models\User;
+use App\Notifications\NewEnrollmentCreatedNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class NotifyRegistrarOfNewEnrollment implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(EnrollmentCreated $event): void
+    {
+        // Get all registrars
+        $registrars = User::role('registrar')->get();
+
+        // Notify each registrar
+        foreach ($registrars as $registrar) {
+            $registrar->notify(new NewEnrollmentCreatedNotification($event->enrollment));
+        }
+    }
+}

--- a/app/Listeners/NotifyRegistrarOfNewStudent.php
+++ b/app/Listeners/NotifyRegistrarOfNewStudent.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\StudentCreated;
+use App\Models\User;
+use App\Notifications\NewStudentCreatedNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class NotifyRegistrarOfNewStudent implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(StudentCreated $event): void
+    {
+        // Get all registrars
+        $registrars = User::role('registrar')->get();
+
+        // Notify each registrar
+        foreach ($registrars as $registrar) {
+            $registrar->notify(new NewStudentCreatedNotification($event->student));
+        }
+    }
+}

--- a/app/Listeners/NotifyRegistrarOfNewStudent.php
+++ b/app/Listeners/NotifyRegistrarOfNewStudent.php
@@ -5,13 +5,9 @@ namespace App\Listeners;
 use App\Events\StudentCreated;
 use App\Models\User;
 use App\Notifications\NewStudentCreatedNotification;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
 
-class NotifyRegistrarOfNewStudent implements ShouldQueue
+class NotifyRegistrarOfNewStudent
 {
-    use InteractsWithQueue;
-
     /**
      * Create the event listener.
      */

--- a/app/Listeners/NotifySuperAdminOfNewUser.php
+++ b/app/Listeners/NotifySuperAdminOfNewUser.php
@@ -28,9 +28,13 @@ class NotifySuperAdminOfNewUser implements ShouldQueue
         // Get all super admins
         $superAdmins = User::role('super_admin')->get();
 
+        // Get the registered user
+        /** @var User $registeredUser */
+        $registeredUser = $event->user;
+
         // Notify each super admin
         foreach ($superAdmins as $superAdmin) {
-            $superAdmin->notify(new NewUserRegisteredNotification($event->user));
+            $superAdmin->notify(new NewUserRegisteredNotification($registeredUser));
         }
     }
 }

--- a/app/Listeners/NotifySuperAdminOfNewUser.php
+++ b/app/Listeners/NotifySuperAdminOfNewUser.php
@@ -5,13 +5,9 @@ namespace App\Listeners;
 use App\Models\User;
 use App\Notifications\NewUserRegisteredNotification;
 use Illuminate\Auth\Events\Registered;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
 
-class NotifySuperAdminOfNewUser implements ShouldQueue
+class NotifySuperAdminOfNewUser
 {
-    use InteractsWithQueue;
-
     /**
      * Create the event listener.
      */

--- a/app/Listeners/NotifySuperAdminOfNewUser.php
+++ b/app/Listeners/NotifySuperAdminOfNewUser.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\User;
+use App\Notifications\NewUserRegisteredNotification;
+use Illuminate\Auth\Events\Registered;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class NotifySuperAdminOfNewUser implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(Registered $event): void
+    {
+        // Get all super admins
+        $superAdmins = User::role('super_admin')->get();
+
+        // Notify each super admin
+        foreach ($superAdmins as $superAdmin) {
+            $superAdmin->notify(new NewUserRegisteredNotification($event->user));
+        }
+    }
+}

--- a/app/Notifications/NewEnrollmentCreatedNotification.php
+++ b/app/Notifications/NewEnrollmentCreatedNotification.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Enrollment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NewEnrollmentCreatedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public Enrollment $enrollment
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $student = $this->enrollment->student;
+
+        return (new MailMessage)
+            ->subject('New Enrollment Created')
+            ->greeting('Hello '.$notifiable->name.',')
+            ->line('A new enrollment has been created in the system.')
+            ->line('Enrollment Details:')
+            ->line('Student: '.$student->full_name)
+            ->line('Student ID: '.$student->student_id)
+            ->line('Grade Level: '.$this->enrollment->grade_level->label())
+            ->line('School Year: '.$this->enrollment->schoolYear->name)
+            ->line('Quarter: '.$this->enrollment->quarter->label())
+            ->line('Status: '.ucfirst($this->enrollment->status->value))
+            ->line('Created on: '.$this->enrollment->created_at->format('F d, Y h:i A'))
+            ->action('View Enrollment', route('registrar.enrollments.show', $this->enrollment))
+            ->line('Please review this new enrollment.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'enrollment_id' => $this->enrollment->id,
+            'enrollment_number' => $this->enrollment->enrollment_id,
+            'student_id' => $this->enrollment->student_id,
+            'student_name' => $this->enrollment->student->full_name,
+            'grade_level' => $this->enrollment->grade_level->label(),
+            'school_year' => $this->enrollment->schoolYear->name,
+            'status' => $this->enrollment->status->value,
+            'created_at' => $this->enrollment->created_at,
+            'message' => 'New enrollment for '.$this->enrollment->student->full_name.' has been created',
+        ];
+    }
+}

--- a/app/Notifications/NewStudentCreatedNotification.php
+++ b/app/Notifications/NewStudentCreatedNotification.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Student;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NewStudentCreatedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public Student $student
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('New Student Added to System')
+            ->greeting('Hello '.$notifiable->name.',')
+            ->line('A new student has been added to the system.')
+            ->line('Student Details:')
+            ->line('Student ID: '.$this->student->student_id)
+            ->line('Name: '.$this->student->full_name)
+            ->line('Grade Level: '.$this->student->grade_level)
+            ->line('Email: '.$this->student->email)
+            ->line('Added on: '.$this->student->created_at->format('F d, Y h:i A'))
+            ->action('View Student', route('registrar.students.show', $this->student))
+            ->line('Please review this new student record.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'student_id' => $this->student->id,
+            'student_number' => $this->student->student_id,
+            'student_name' => $this->student->full_name,
+            'grade_level' => $this->student->grade_level,
+            'email' => $this->student->email,
+            'created_at' => $this->student->created_at,
+            'message' => 'New student '.$this->student->full_name.' has been added',
+        ];
+    }
+}

--- a/app/Notifications/NewStudentCreatedNotification.php
+++ b/app/Notifications/NewStudentCreatedNotification.php
@@ -40,7 +40,7 @@ class NewStudentCreatedNotification extends Notification
             ->line('Student Details:')
             ->line('Student ID: '.$this->student->student_id)
             ->line('Name: '.$this->student->full_name)
-            ->line('Grade Level: '.$this->student->grade_level)
+            ->line('Grade Level: '.($this->student->grade_level instanceof \BackedEnum ? $this->student->grade_level->value : $this->student->grade_level))
             ->line('Email: '.$this->student->email)
             ->line('Added on: '.$this->student->created_at->format('F d, Y h:i A'))
             ->action('View Student', route('registrar.students.show', $this->student))
@@ -58,7 +58,7 @@ class NewStudentCreatedNotification extends Notification
             'student_id' => $this->student->id,
             'student_number' => $this->student->student_id,
             'student_name' => $this->student->full_name,
-            'grade_level' => $this->student->grade_level,
+            'grade_level' => $this->student->grade_level instanceof \BackedEnum ? $this->student->grade_level->value : $this->student->grade_level,
             'email' => $this->student->email,
             'created_at' => $this->student->created_at,
             'message' => 'New student '.$this->student->full_name.' has been added',

--- a/app/Notifications/NewUserRegisteredNotification.php
+++ b/app/Notifications/NewUserRegisteredNotification.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NewUserRegisteredNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public User $user
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $roles = $this->user->roles->pluck('name')->map(fn ($role) => ucwords(str_replace('_', ' ', $role)))->implode(', ');
+
+        return (new MailMessage)
+            ->subject('New User Registration')
+            ->greeting('Hello '.$notifiable->name.',')
+            ->line('A new user has registered in the system.')
+            ->line('User Details:')
+            ->line('Name: '.$this->user->name)
+            ->line('Email: '.$this->user->email)
+            ->line('Role(s): '.$roles)
+            ->line('Registration Date: '.$this->user->created_at->format('F d, Y h:i A'))
+            ->action('View User', route('super-admin.users.show', $this->user))
+            ->line('Please review this new user registration.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'user_id' => $this->user->id,
+            'user_name' => $this->user->name,
+            'user_email' => $this->user->email,
+            'roles' => $this->user->roles->pluck('name')->toArray(),
+            'registered_at' => $this->user->created_at,
+            'message' => 'New user '.$this->user->name.' has registered',
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,11 +2,17 @@
 
 namespace App\Providers;
 
+use App\Events\EnrollmentCreated;
+use App\Events\StudentCreated;
 use App\Listeners\LogAuthenticationActivity;
+use App\Listeners\NotifyRegistrarOfNewEnrollment;
+use App\Listeners\NotifyRegistrarOfNewStudent;
+use App\Listeners\NotifySuperAdminOfNewUser;
 use App\Models\User;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
+use Illuminate\Auth\Events\Registered;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
@@ -33,6 +39,11 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(Login::class, [LogAuthenticationActivity::class, 'handleLogin']);
         Event::listen(Logout::class, [LogAuthenticationActivity::class, 'handleLogout']);
         Event::listen(Failed::class, [LogAuthenticationActivity::class, 'handleFailed']);
+
+        // Register notification event listeners
+        Event::listen(Registered::class, NotifySuperAdminOfNewUser::class);
+        Event::listen(StudentCreated::class, NotifyRegistrarOfNewStudent::class);
+        Event::listen(EnrollmentCreated::class, NotifyRegistrarOfNewEnrollment::class);
 
         // Super admin has access to everything
         Gate::before(function (User $user, string $ability) {

--- a/resources/js/components/notifications/notification-item.tsx
+++ b/resources/js/components/notifications/notification-item.tsx
@@ -61,9 +61,9 @@ export function NotificationItem({ notification, onRead, onDelete, showActions =
                 <div className={cn('mt-0.5 flex-shrink-0', getIconColor(notification.type))}>{getNotificationIcon(notification.type)}</div>
 
                 <div className="min-w-0 flex-1 space-y-1">
-                    <p className={cn('text-sm', isUnread && 'font-semibold')}>{notification.data.message}</p>
+                    <p className={cn('text-sm text-foreground', isUnread && 'font-semibold')}>{notification.data.message}</p>
 
-                    <p className="text-xs text-muted-foreground">{formatDistanceToNow(new Date(notification.created_at), { addSuffix: true })}</p>
+                    <p className="text-xs text-muted-foreground/80">{formatDistanceToNow(new Date(notification.created_at), { addSuffix: true })}</p>
 
                     {showActions && !compact && (
                         <div className="mt-2 flex gap-2">


### PR DESCRIPTION
## Problem
Super Admin was not receiving notifications when new users registered, and Registrar was not receiving notifications when students were created or enrollments were submitted.

## Solution
Implemented comprehensive notification system:

### Notifications Created:
- **NewUserRegisteredNotification** - Notifies Super Admin when new users register
- **NewStudentCreatedNotification** - Notifies Registrar when students are created
- **NewEnrollmentCreatedNotification** - Notifies Registrar when enrollments are created

### Events & Listeners:
- **StudentCreated** event with **NotifyRegistrarOfNewStudent** listener
- **EnrollmentCreated** event with **NotifyRegistrarOfNewEnrollment** listener
- **NotifySuperAdminOfNewUser** listener for existing Registered event

### Event Dispatching:
- Added event dispatching in all Student controllers (Guardian, Registrar, SuperAdmin)
- Added event dispatching in all Enrollment controllers (Guardian, Admin)

### UI Improvements:
- Fixed notification text color for better visibility in dark mode
- Notifications show in real-time with badge count
- Email and database notifications for all events

## Visual Verification
✅ Registered new test user - Super Admin received notification
✅ Notification badge shows count (2 notifications)
✅ Notification panel displays messages clearly
✅ Text is readable with proper contrast
✅ Timestamp shows relative time ("5m ago")
✅ "Mark all read" functionality present

## Testing
✅ All tests passing
✅ Coverage above 60%
✅ PHPStan analysis passed
✅ Code style checks passed

Closes #413