### PR TITLE
Fix #408: Add invoice, payment, and receipt notifications for Guardians

### DIFF
--- a/app/Http/Controllers/SuperAdmin/ReceiptController.php
+++ b/app/Http/Controllers/SuperAdmin/ReceiptController.php
@@ -91,6 +91,14 @@ class ReceiptController extends Controller
             ->withProperties($receipt->toArray())
             ->log('Receipt created');
 
+        // Notify guardian about the receipt
+        if ($receipt->payment && $receipt->payment->invoice && $receipt->payment->invoice->enrollment) {
+            $guardian = $receipt->payment->invoice->enrollment->guardian;
+            if ($guardian && $guardian->user) {
+                $guardian->user->notify(new \App\Notifications\ReceiptGeneratedNotification($receipt));
+            }
+        }
+
         return redirect()->route('super-admin.receipts.index')
             ->with('success', 'Receipt created successfully.');
     }

--- a/app/Notifications/InvoiceCreatedNotification.php
+++ b/app/Notifications/InvoiceCreatedNotification.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Invoice;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class InvoiceCreatedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public Invoice $invoice
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $enrollment = $this->invoice->enrollment;
+        $student = $enrollment?->student;
+
+        return (new MailMessage)
+            ->subject('New Invoice Generated')
+            ->greeting('Hello '.$notifiable->name.',')
+            ->line('A new invoice has been generated for your account.')
+            ->line('Invoice Details:')
+            ->line('Invoice Number: '.$this->invoice->invoice_number)
+            ->line('Student: '.($student ? $student->full_name : 'N/A'))
+            ->line('Amount: ₱'.number_format((float) $this->invoice->total_amount, 2))
+            ->line('Due Date: '.($this->invoice->due_date ? $this->invoice->due_date->format('F d, Y') : 'N/A'))
+            ->line('Status: '.ucfirst($this->invoice->status->value))
+            ->action('View Invoice', route('guardian.invoices.show', $this->invoice))
+            ->line('Please ensure payment is made before the due date.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'invoice_id' => $this->invoice->id,
+            'invoice_number' => $this->invoice->invoice_number,
+            'amount' => $this->invoice->total_amount,
+            'due_date' => $this->invoice->due_date,
+            'status' => $this->invoice->status->value,
+            'message' => 'New invoice '.$this->invoice->invoice_number.' has been generated',
+        ];
+    }
+}

--- a/app/Notifications/PaymentReceivedNotification.php
+++ b/app/Notifications/PaymentReceivedNotification.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Payment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PaymentReceivedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public Payment $payment
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $invoice = $this->payment->invoice;
+        $amount = $this->payment->amount_cents / 100;
+
+        return (new MailMessage)
+            ->subject('Payment Received')
+            ->greeting('Hello '.$notifiable->name.',')
+            ->line('We have received your payment. Thank you!')
+            ->line('Payment Details:')
+            ->line('Reference Number: '.$this->payment->reference_number)
+            ->line('Amount: ₱'.number_format($amount, 2))
+            ->line('Payment Method: '.ucfirst($this->payment->payment_method->value))
+            ->line('Payment Date: '.$this->payment->payment_date->format('F d, Y'))
+            ->line('Invoice: '.($invoice ? $invoice->invoice_number : 'N/A'))
+            ->action('View Payment', route('guardian.payments.show', $this->payment))
+            ->line('A receipt will be generated shortly.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'payment_id' => $this->payment->id,
+            'reference_number' => $this->payment->reference_number,
+            'amount' => $this->payment->amount_cents / 100,
+            'payment_method' => $this->payment->payment_method->value,
+            'payment_date' => $this->payment->payment_date,
+            'message' => 'Payment of ₱'.number_format($this->payment->amount_cents / 100, 2).' received',
+        ];
+    }
+}

--- a/app/Notifications/PaymentReceivedNotification.php
+++ b/app/Notifications/PaymentReceivedNotification.php
@@ -46,7 +46,6 @@ class PaymentReceivedNotification extends Notification
             ->line('Payment Method: '.ucfirst($this->payment->payment_method->value))
             ->line('Payment Date: '.$this->payment->payment_date->format('F d, Y'))
             ->line('Invoice: '.($invoice ? $invoice->invoice_number : 'N/A'))
-            ->action('View Payment', route('guardian.payments.show', $this->payment))
             ->line('A receipt will be generated shortly.');
     }
 

--- a/app/Notifications/ReceiptGeneratedNotification.php
+++ b/app/Notifications/ReceiptGeneratedNotification.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Receipt;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ReceiptGeneratedNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        public Receipt $receipt
+    ) {}
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        $payment = $this->receipt->payment;
+        $amount = $payment ? $payment->amount_cents / 100 : 0;
+
+        return (new MailMessage)
+            ->subject('Receipt Generated')
+            ->greeting('Hello '.$notifiable->name.',')
+            ->line('Your payment receipt has been generated.')
+            ->line('Receipt Details:')
+            ->line('Receipt Number: '.$this->receipt->receipt_number)
+            ->line('Amount: ₱'.number_format($amount, 2))
+            ->line('Issue Date: '.$this->receipt->created_at->format('F d, Y'))
+            ->line('Payment Reference: '.($payment ? $payment->reference_number : 'N/A'))
+            ->action('View Receipt', route('guardian.receipts.show', $this->receipt))
+            ->line('Thank you for your payment!');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'receipt_id' => $this->receipt->id,
+            'receipt_number' => $this->receipt->receipt_number,
+            'amount' => $this->receipt->payment ? $this->receipt->payment->amount_cents / 100 : 0,
+            'issue_date' => $this->receipt->created_at,
+            'message' => 'Receipt '.$this->receipt->receipt_number.' has been generated',
+        ];
+    }
+}

--- a/app/Notifications/ReceiptGeneratedNotification.php
+++ b/app/Notifications/ReceiptGeneratedNotification.php
@@ -45,7 +45,6 @@ class ReceiptGeneratedNotification extends Notification
             ->line('Amount: ₱'.number_format($amount, 2))
             ->line('Issue Date: '.$this->receipt->created_at->format('F d, Y'))
             ->line('Payment Reference: '.($payment ? $payment->reference_number : 'N/A'))
-            ->action('View Receipt', route('guardian.receipts.show', $this->receipt))
             ->line('Thank you for your payment!');
     }
 

--- a/app/Observers/InvoiceObserver.php
+++ b/app/Observers/InvoiceObserver.php
@@ -34,6 +34,11 @@ class InvoiceObserver
     public function created(Invoice $invoice): void
     {
         // Note: Activity logging is handled automatically by LogsActivity trait
+
+        // Notify guardian about the new invoice
+        if ($invoice->enrollment && $invoice->enrollment->guardian && $invoice->enrollment->guardian->user) {
+            $invoice->enrollment->guardian->user->notify(new \App\Notifications\InvoiceCreatedNotification($invoice));
+        }
     }
 
     /**

--- a/app/Observers/PaymentObserver.php
+++ b/app/Observers/PaymentObserver.php
@@ -63,6 +63,11 @@ class PaymentObserver
         }
 
         // Note: Activity logging is handled automatically by LogsActivity trait
+
+        // Notify guardian about the payment
+        if ($payment->invoice && $payment->invoice->enrollment && $payment->invoice->enrollment->guardian && $payment->invoice->enrollment->guardian->user) {
+            $payment->invoice->enrollment->guardian->user->notify(new \App\Notifications\PaymentReceivedNotification($payment));
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem
Guardians were not receiving notifications when invoices were generated, payments were received, or receipts were issued, leaving them uninformed about important financial transactions.

## Solution
Implemented comprehensive financial notification system for Guardians:

### Notifications Created:
- **InvoiceCreatedNotification** - Notifies Guardian when invoice is generated
- **PaymentReceivedNotification** - Notifies Guardian when payment is received
- **ReceiptGeneratedNotification** - Notifies Guardian when receipt is issued

### Implementation:
- Added notification dispatch in **InvoiceObserver** (created event)
- Added notification dispatch in **PaymentObserver** (created event)
- Added notification dispatch in **ReceiptController** (after creation)
- All notifications sent via email and database
- Notifications include relevant details (amounts, dates, reference numbers)

## Notification Details

### Invoice Notification:
- Invoice number
- Student name
- Amount due
- Due date
- Status

### Payment Notification:
- Reference number
- Amount paid
- Payment method
- Payment date
- Related invoice

### Receipt Notification:
- Receipt number
- Amount
- Issue date
- Payment reference

## Benefits
- Guardians stay informed about financial transactions
- Reduces need for manual communication
- Improves transparency and trust
- Provides audit trail of notifications
- Real-time updates via email and in-app notifications

## Testing
✅ All tests passing
✅ Coverage above 60%
✅ PHPStan analysis passed
✅ Code style checks passed

Closes #408