### PR TITLE
Fix #430: Add missing route import in Create Receipt form

### DIFF
--- a/resources/js/pages/super-admin/receipts/create.tsx
+++ b/resources/js/pages/super-admin/receipts/create.tsx
@@ -7,6 +7,7 @@ import AppLayout from '@/layouts/app-layout';
 import { Head, useForm } from '@inertiajs/react';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
+import { route } from 'ziggy-js';
 
 interface Student {
     id: number;


### PR DESCRIPTION
## Problem
When clicking the "Create Receipt" button on the Super Admin receipt creation form, nothing happened. The form did not submit, no loading indicator appeared, and no error message was shown.

## Root Cause
JavaScript error: 

The  file was using the  helper function without importing it, causing a runtime error that prevented form submission.

## Solution
Added the missing import statement:
```typescript
import { route } from 'ziggy-js';
```

## Visual Verification
✅ Navigated to /super-admin/receipts/create as Super Admin
✅ Form loads correctly with all fields
✅ Filled out form with test data (Amount: 10000, Payment Method: Cash)
✅ Identified JavaScript console error: "route is not defined"
✅ Added missing import
✅ Form now submits correctly (verified via tests)

## Testing
✅ All tests passing
✅ Coverage above 60%
✅ TypeScript checks passed
✅ Vite build successful
✅ Code style checks passed

Closes #430