### PR TITLE
Fix #429: Add Link to View Enrollments button

### DIFF
--- a/resources/js/pages/super-admin/students/columns.tsx
+++ b/resources/js/pages/super-admin/students/columns.tsx
@@ -87,7 +87,9 @@ function ActionsCell({ student }: { student: Student }) {
                     <DropdownMenuItem asChild>
                         <Link href={`/super-admin/students/${student.id}/edit`}>Edit Student</Link>
                     </DropdownMenuItem>
-                    <DropdownMenuItem>View Enrollments</DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                        <Link href={`/super-admin/students/${student.id}/enrollments`}>View Enrollments</Link>
+                    </DropdownMenuItem>
                     {student.activeEnrollmentId && (
                         <DropdownMenuItem asChild>
                             <Link href={`/super-admin/enrollments/${student.activeEnrollmentId}`}>Update Payment Status</Link>


### PR DESCRIPTION
## Problem
When clicking "View Enrollments" from the Students table action menu, nothing happened. The button was non-functional and did not navigate to the student's enrollments page.

## Root Cause
The "View Enrollments" menu item was missing the `asChild` prop and `Link` component, unlike other menu items in the dropdown. It was just a plain `<DropdownMenuItem>` with no navigation action attached.

## Solution
Added proper Link component with route to student enrollments:
```tsx
<DropdownMenuItem asChild>
    <Link href={`/super-admin/students/${student.id}/enrollments`}>View Enrollments</Link>
</DropdownMenuItem>
```

## Visual Verification
✅ Navigated to /super-admin/students as Super Admin
✅ Clicked action menu ("...") on a student row
✅ Confirmed "View Enrollments" menu item was visible
✅ Identified that clicking it did nothing (no navigation)
✅ Found missing Link component in columns.tsx
✅ Added Link with proper route
✅ Button now navigates correctly

## Testing
✅ All tests passing
✅ Coverage above 60%
✅ TypeScript checks passed
✅ Code style checks passed

Closes #429