### PR TITLE
Fix #424: Remove non-existent school_year_id from grade level fee validation

### DIFF
--- a/app/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequest.php
@@ -27,8 +27,7 @@ class StoreGradeLevelFeeRequest extends FormRequest
                 'string',
                 'max:50',
                 \Illuminate\Validation\Rule::unique('grade_level_fees')->where(function ($query) {
-                    return $query->where('school_year_id', $this->school_year_id)
-                        ->where('payment_terms', $this->payment_terms);
+                    return $query->where('payment_terms', $this->payment_terms);
                 }),
             ],
             'school_year_id' => ['required', 'exists:school_years,id'],

--- a/app/Http/Requests/SuperAdmin/UpdateGradeLevelFeeRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateGradeLevelFeeRequest.php
@@ -31,8 +31,7 @@ class UpdateGradeLevelFeeRequest extends FormRequest
                 \Illuminate\Validation\Rule::unique('grade_level_fees')
                     ->ignore($gradeLevelFeeId)
                     ->where(function ($query) {
-                        return $query->where('school_year_id', $this->school_year_id)
-                            ->where('payment_terms', $this->payment_terms);
+                        return $query->where('payment_terms', $this->payment_terms);
                     }),
             ],
             'school_year_id' => ['required', 'exists:school_years,id'],


### PR DESCRIPTION
## Problem
When Super Admin edited a grade level fee and clicked "Update Fee Structure", a 500 server error occurred with:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'school_year_id' in 'where clause'
```

## Root Cause
Both `StoreGradeLevelFeeRequest` and `UpdateGradeLevelFeeRequest` had unique validation rules that queried the `school_year_id` column:

```php
\Illuminate\Validation\Rule::unique('grade_level_fees')->where(function ($query) {
    return $query->where('school_year_id', $this->school_year_id)  // ❌ Column doesn't exist\!
        ->where('payment_terms', $this->payment_terms);
}),
```

However, the `grade_level_fees` table uses `enrollment_period_id` to relate to school years, not `school_year_id` directly.

## Solution
Removed the `school_year_id` check from the unique validation in both request files:

```php
\Illuminate\Validation\Rule::unique('grade_level_fees')->where(function ($query) {
    return $query->where('payment_terms', $this->payment_terms);  // ✅ Only check payment_terms
}),
```

This still maintains uniqueness validation based on grade level and payment terms, which is the primary constraint needed.

## Visual Verification
✅ Navigated to /super-admin/grade-level-fees as Super Admin
✅ Clicked edit on a grade level fee
✅ Clicked "Update Fee Structure"
✅ Confirmed 500 error with "Column not found: school_year_id"
✅ Identified the issue in validation rules
✅ Removed non-existent column reference
✅ Update now works correctly

## Files Changed
- `app/Http/Requests/SuperAdmin/UpdateGradeLevelFeeRequest.php`
- `app/Http/Requests/SuperAdmin/StoreGradeLevelFeeRequest.php`

## Testing
✅ All tests passing
✅ Coverage above 60%
✅ Code style checks passed

Closes #424