### PR TITLE
Feature #428: Add Update Enrollment Status to Students Index

### DIFF
--- a/resources/js/pages/super-admin/students/columns.tsx
+++ b/resources/js/pages/super-admin/students/columns.tsx
@@ -91,9 +91,14 @@ function ActionsCell({ student }: { student: Student }) {
                         <Link href={`/super-admin/students/${student.id}/enrollments`}>View Enrollments</Link>
                     </DropdownMenuItem>
                     {student.activeEnrollmentId && (
-                        <DropdownMenuItem asChild>
-                            <Link href={`/super-admin/enrollments/${student.activeEnrollmentId}`}>Update Payment Status</Link>
-                        </DropdownMenuItem>
+                        <>
+                            <DropdownMenuItem asChild>
+                                <Link href={`/super-admin/enrollments/${student.activeEnrollmentId}/edit`}>Update Enrollment Status</Link>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                                <Link href={`/super-admin/enrollments/${student.activeEnrollmentId}`}>Update Payment Status</Link>
+                            </DropdownMenuItem>
+                        </>
                     )}
                     <DropdownMenuSeparator />
                     <DropdownMenuItem onClick={() => setDeleteDialogOpen(true)}>Delete Student</DropdownMenuItem>


### PR DESCRIPTION
## Feature Request
Super Admin should be able to update enrollment status directly from the Students Index page, similar to how they can update payment status.

## Implementation
Added **"Update Enrollment Status"** menu item to the student action dropdown menu.

### Changes Made:
- Added new menu item in `resources/js/pages/super-admin/students/columns.tsx`
- Links to enrollment edit page: `/super-admin/enrollments/{activeEnrollmentId}/edit`
- Only displays when student has an active enrollment (`student.activeEnrollmentId` exists)
- Positioned logically before "Update Payment Status"

### Menu Structure (After):
1. Copy Student ID
2. ---
3. View Student
4. Edit Student
5. View Enrollments
6. **Update Enrollment Status** ← NEW
7. Update Payment Status
8. ---
9. Delete Student

## Benefits:
✅ Faster workflow for Super Admins
✅ No need to navigate to Enrollments page first
✅ Consistent with existing "Update Payment Status" feature
✅ Improves user experience and efficiency

## Visual Verification:
✅ Navigated to /super-admin/students
✅ Clicked action menu on student with active enrollment
✅ Confirmed "Update Enrollment Status" appears in menu
✅ Verified it links to correct enrollment edit page
✅ Confirmed it only shows for students with active enrollments

## Testing:
✅ All tests passing
✅ Coverage above 60%
✅ TypeScript checks passed
✅ Code style checks passed

Closes #428