### PR TITLE
Refactor #394: Replace hardcoded payment_method strings with PaymentMethod enum

### DIFF
--- a/app/Http/Requests/SuperAdmin/StoreReceiptRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreReceiptRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\SuperAdmin;
 
+use App\Enums\PaymentMethod;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreReceiptRequest extends FormRequest
 {
@@ -26,7 +28,7 @@ class StoreReceiptRequest extends FormRequest
             'invoice_id' => ['nullable', 'exists:invoices,id'],
             'receipt_date' => ['required', 'date'],
             'amount' => ['required', 'numeric', 'min:0.01'],
-            'payment_method' => ['required', 'string', 'max:50'],
+            'payment_method' => ['required', Rule::in(PaymentMethod::values())],
             'notes' => ['nullable', 'string', 'max:1000'],
         ];
     }

--- a/app/Http/Requests/SuperAdmin/UpdateReceiptRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateReceiptRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\SuperAdmin;
 
+use App\Enums\PaymentMethod;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateReceiptRequest extends FormRequest
 {
@@ -26,7 +28,7 @@ class UpdateReceiptRequest extends FormRequest
             'invoice_id' => ['nullable', 'exists:invoices,id'],
             'receipt_date' => ['required', 'date'],
             'amount' => ['required', 'numeric', 'min:0.01'],
-            'payment_method' => ['required', 'string', 'max:50'],
+            'payment_method' => ['required', Rule::in(PaymentMethod::values())],
             'notes' => ['nullable', 'string', 'max:1000'],
         ];
     }


### PR DESCRIPTION
## Problem
Receipt request validation was using hardcoded string validation for `payment_method`:
```php
'payment_method' => ['required', 'string', 'max:50'],  // ❌ Too permissive, no type safety
```

This allowed any string up to 50 characters, not just valid payment methods.

## Solution
Replaced with proper enum validation using `PaymentMethod` enum:
```php
use App\Enums\PaymentMethod;
use Illuminate\Validation\Rule;

'payment_method' => ['required', Rule::in(PaymentMethod::values())],  // ✅ Type-safe
```

## Files Changed
- ✅ `app/Http/Requests/SuperAdmin/StoreReceiptRequest.php`
- ✅ `app/Http/Requests/SuperAdmin/UpdateReceiptRequest.php`

## Benefits
✅ **Type Safety** - Only valid PaymentMethod enum values accepted
✅ **Single Source of Truth** - Validation matches enum definition
✅ **Refactoring Safe** - Changes to enum automatically reflected
✅ **IDE Support** - Better autocomplete and type hints
✅ **Consistency** - Matches pattern used in Payment requests

## Note
Payment requests (`StorePaymentRequest`, `UpdatePaymentRequest`) already use this pattern correctly. This PR brings Receipt requests in line with the same standard.

## Testing
✅ All tests passing
✅ Coverage above 60%
✅ Code style checks passed

Part of #394 (Replace hardcoded enum strings with proper enum usage)