### PR TITLE
Refactor #394: Replace hardcoded grade_level strings with GradeLevel enum

### DIFF
--- a/app/Http/Requests/Guardian/StoreStudentRequest.php
+++ b/app/Http/Requests/Guardian/StoreStudentRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests\Guardian;
 
+use App\Enums\GradeLevel;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class StoreStudentRequest extends FormRequest
 {
@@ -32,7 +34,7 @@ class StoreStudentRequest extends FormRequest
             'address' => ['required', 'string', 'max:500'],
             'contact_number' => ['nullable', 'string', 'max:20', 'regex:/^[0-9+\-\(\)\s]+$/'],
             'email' => ['nullable', 'email', 'max:255'],
-            'grade_level' => ['required', 'string', 'in:Kinder,Grade 1,Grade 2,Grade 3,Grade 4,Grade 5,Grade 6'],
+            'grade_level' => ['required', Rule::in(GradeLevel::values())],
             'birth_place' => ['required', 'string', 'max:255'],
             'nationality' => ['required', 'string', 'max:100'],
             'religion' => ['required', 'string', 'max:100'],

--- a/app/Http/Requests/Registrar/StoreStudentRequest.php
+++ b/app/Http/Requests/Registrar/StoreStudentRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests\Registrar;
 
+use App\Enums\GradeLevel;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class StoreStudentRequest extends FormRequest
 {
@@ -34,7 +36,7 @@ class StoreStudentRequest extends FormRequest
             'birth_place' => ['nullable', 'string', 'max:255'],
             'nationality' => ['nullable', 'string', 'max:100'],
             'religion' => ['nullable', 'string', 'max:100'],
-            'grade_level' => ['nullable', 'string', 'max:20'],
+            'grade_level' => ['nullable', Rule::in(GradeLevel::values())],
             'section' => ['nullable', 'string', 'max:50'],
         ];
     }

--- a/app/Http/Requests/Registrar/UpdateStudentRequest.php
+++ b/app/Http/Requests/Registrar/UpdateStudentRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Registrar;
 
+use App\Enums\GradeLevel;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
@@ -40,7 +41,7 @@ class UpdateStudentRequest extends FormRequest
             'birth_place' => ['nullable', 'string', 'max:255'],
             'nationality' => ['nullable', 'string', 'max:100'],
             'religion' => ['nullable', 'string', 'max:100'],
-            'grade_level' => ['nullable', 'string', 'max:20'],
+            'grade_level' => ['nullable', Rule::in(GradeLevel::values())],
             'section' => ['nullable', 'string', 'max:50'],
         ];
     }

--- a/app/Http/Requests/SuperAdmin/StoreEnrollmentRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreEnrollmentRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\SuperAdmin;
 
+use App\Enums\GradeLevel;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreEnrollmentRequest extends FormRequest
 {
@@ -23,7 +25,7 @@ class StoreEnrollmentRequest extends FormRequest
     {
         return [
             'student_id' => ['required', 'exists:students,id'],
-            'grade_level' => ['required', 'string'],
+            'grade_level' => ['required', Rule::in(GradeLevel::values())],
             'school_year_id' => ['required', 'exists:school_years,id'],
             'quarter' => ['required', 'string'],
             'type' => ['required', 'in:new,continuing,returnee,transferee'],

--- a/app/Http/Requests/SuperAdmin/StoreStudentRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreStudentRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\SuperAdmin;
 
 use App\Enums\Gender;
+use App\Enums\GradeLevel;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -35,7 +36,7 @@ class StoreStudentRequest extends FormRequest
             'address' => ['required', 'string', 'max:500'],
             'phone' => ['nullable', 'string', 'max:20'],
             'email' => ['nullable', 'email', 'unique:students'],
-            'grade_level' => ['required', 'string'],
+            'grade_level' => ['required', Rule::in(GradeLevel::values())],
             'guardian_ids' => ['required', 'array', 'min:1'],
             'guardian_ids.*' => ['exists:guardians,id'],
         ];

--- a/app/Http/Requests/SuperAdmin/UpdateEnrollmentRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateEnrollmentRequest.php
@@ -3,7 +3,9 @@
 namespace App\Http\Requests\SuperAdmin;
 
 use App\Enums\EnrollmentStatus;
+use App\Enums\GradeLevel;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateEnrollmentRequest extends FormRequest
 {
@@ -25,7 +27,7 @@ class UpdateEnrollmentRequest extends FormRequest
         return [
             'student_id' => ['required', 'exists:students,id'],
             'guardian_id' => ['required', 'exists:guardians,id'],
-            'grade_level' => ['required', 'string'],
+            'grade_level' => ['required', Rule::in(GradeLevel::values())],
             'school_year_id' => ['required', 'exists:school_years,id'],
             'quarter' => ['required', 'string'],
             'type' => ['required', 'in:new,continuing,returnee,transferee'],

--- a/app/Http/Requests/SuperAdmin/UpdateStudentRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateStudentRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\SuperAdmin;
 
 use App\Enums\Gender;
+use App\Enums\GradeLevel;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -37,7 +38,7 @@ class UpdateStudentRequest extends FormRequest
             'address' => ['required', 'string', 'max:500'],
             'phone' => ['nullable', 'string', 'max:20'],
             'email' => ['nullable', 'email', 'unique:students,email,'.$student->id],
-            'grade_level' => ['required', 'string'],
+            'grade_level' => ['required', Rule::in(GradeLevel::values())],
             'guardian_ids' => ['required', 'array', 'min:1'],
             'guardian_ids.*' => ['exists:guardians,id'],
         ];

--- a/tests/Unit/Http/Requests/SuperAdmin/StoreEnrollmentRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/StoreEnrollmentRequestTest.php
@@ -53,7 +53,7 @@ class StoreEnrollmentRequestTest extends TestCase
 
         $data = [
             'student_id' => $student->id,
-            'grade_level' => 'grade_1',
+            'grade_level' => 'Grade 1',
             'school_year_id' => $schoolYear->id,
             'quarter' => 'first_quarter',
             'type' => 'new',

--- a/tests/Unit/Http/Requests/SuperAdmin/UpdateEnrollmentRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/UpdateEnrollmentRequestTest.php
@@ -57,7 +57,7 @@ class UpdateEnrollmentRequestTest extends TestCase
         $data = [
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
-            'grade_level' => 'grade_1',
+            'grade_level' => 'Grade 1',
             'school_year_id' => $schoolYear->id,
             'quarter' => '1st',
             'type' => 'new',
@@ -81,7 +81,7 @@ class UpdateEnrollmentRequestTest extends TestCase
         $data = [
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
-            'grade_level' => 'grade_2',
+            'grade_level' => 'Grade 2',
             'school_year_id' => $schoolYear->id,
             'quarter' => '2nd',
             'type' => 'continuing',
@@ -103,7 +103,7 @@ class UpdateEnrollmentRequestTest extends TestCase
         $data = [
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
-            'grade_level' => 'grade_1',
+            'grade_level' => 'Grade 1',
             'school_year_id' => 99999, // Non-existent ID
             'quarter' => '1st',
             'type' => 'new',
@@ -127,7 +127,7 @@ class UpdateEnrollmentRequestTest extends TestCase
         $data = [
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
-            'grade_level' => 'grade_1',
+            'grade_level' => 'Grade 1',
             'school_year_id' => $schoolYear->id,
             'quarter' => '1st',
             'type' => 'invalid_type',
@@ -151,7 +151,7 @@ class UpdateEnrollmentRequestTest extends TestCase
         $data = [
             'student_id' => $student->id,
             'guardian_id' => $guardian->id,
-            'grade_level' => 'grade_1',
+            'grade_level' => 'Grade 1',
             'school_year_id' => $schoolYear->id,
             'quarter' => '1st',
             'type' => 'new',


### PR DESCRIPTION
## Problem
Multiple request files were using hardcoded strings or overly permissive validation for `grade_level`:

**Hardcoded strings:**
```php
'grade_level' => ['required', 'string', 'in:Kinder,Grade 1,Grade 2,Grade 3,Grade 4,Grade 5,Grade 6'],
```

**Too permissive:**
```php
'grade_level' => ['required', 'string'],  // Accepts ANY string\!
'grade_level' => ['nullable', 'string', 'max:20'],  // Accepts any 20-char string\!
```

## Solution
Replaced all with proper `GradeLevel` enum validation:
```php
use App\Enums\GradeLevel;
use Illuminate\Validation\Rule;

'grade_level' => ['required', Rule::in(GradeLevel::values())],
```

## Files Changed (7 request files + 2 test files)

### Request Files:
- ✅ `Guardian/StoreStudentRequest.php` - Replaced hardcoded list
- ✅ `Registrar/StoreStudentRequest.php` - Replaced 'string', 'max:20'
- ✅ `Registrar/UpdateStudentRequest.php` - Replaced 'string', 'max:20'
- ✅ `SuperAdmin/StoreStudentRequest.php` - Replaced 'string'
- ✅ `SuperAdmin/UpdateStudentRequest.php` - Replaced 'string'
- ✅ `SuperAdmin/StoreEnrollmentRequest.php` - Replaced 'string'
- ✅ `SuperAdmin/UpdateEnrollmentRequest.php` - Replaced 'string'

### Test Files:
- ✅ `tests/Unit/Http/Requests/SuperAdmin/StoreEnrollmentRequestTest.php`
- ✅ `tests/Unit/Http/Requests/SuperAdmin/UpdateEnrollmentRequestTest.php`

## Benefits
✅ **Type Safety** - Only valid GradeLevel enum values accepted
✅ **Single Source of Truth** - Validation matches enum definition
✅ **Prevents Invalid Data** - No more accepting arbitrary strings
✅ **Refactoring Safe** - Changes to enum automatically reflected
✅ **Consistency** - All grade_level validations now use same pattern

## Testing
✅ All tests passing (updated test data to use correct enum values)
✅ Coverage above 60%
✅ Code style checks passed

Part of #394 (Replace hardcoded enum strings with proper enum usage)