### PR TITLE
Feature #394: Create PaymentPlan and EnrollmentType enums - Complete enum refactoring\!

### DIFF
--- a/app/Enums/EnrollmentType.php
+++ b/app/Enums/EnrollmentType.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Enums;
+
+enum EnrollmentType: string
+{
+    case NEW = 'new';
+    case CONTINUING = 'continuing';
+    case RETURNEE = 'returnee';
+    case TRANSFEREE = 'transferee';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::NEW => 'New Student',
+            self::CONTINUING => 'Continuing Student',
+            self::RETURNEE => 'Returnee',
+            self::TRANSFEREE => 'Transferee',
+        };
+    }
+
+    /**
+     * Get a description of the enrollment type
+     */
+    public function description(): string
+    {
+        return match ($this) {
+            self::NEW => 'First time enrolling in the school',
+            self::CONTINUING => 'Continuing from previous school year',
+            self::RETURNEE => 'Returning after absence',
+            self::TRANSFEREE => 'Transferring from another school',
+        };
+    }
+
+    /**
+     * Check if this enrollment type requires previous school information
+     */
+    public function requiresPreviousSchool(): bool
+    {
+        return $this === self::TRANSFEREE;
+    }
+}

--- a/app/Enums/PaymentPlan.php
+++ b/app/Enums/PaymentPlan.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Enums;
+
+enum PaymentPlan: string
+{
+    case ANNUAL = 'annual';
+    case SEMESTRAL = 'semestral';
+    case QUARTERLY = 'quarterly';
+    case MONTHLY = 'monthly';
+
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ANNUAL => 'Annual',
+            self::SEMESTRAL => 'Semestral',
+            self::QUARTERLY => 'Quarterly',
+            self::MONTHLY => 'Monthly',
+        };
+    }
+
+    /**
+     * Get the number of installments for this payment plan
+     */
+    public function installments(): int
+    {
+        return match ($this) {
+            self::ANNUAL => 1,
+            self::SEMESTRAL => 2,
+            self::QUARTERLY => 4,
+            self::MONTHLY => 10, // Typically 10 months in a school year
+        };
+    }
+
+    /**
+     * Get a description of the payment plan
+     */
+    public function description(): string
+    {
+        return match ($this) {
+            self::ANNUAL => 'Pay full amount once per year',
+            self::SEMESTRAL => 'Pay in 2 installments per year',
+            self::QUARTERLY => 'Pay in 4 installments per year',
+            self::MONTHLY => 'Pay in 10 monthly installments',
+        };
+    }
+}

--- a/app/Http/Requests/Guardian/StoreEnrollmentRequest.php
+++ b/app/Http/Requests/Guardian/StoreEnrollmentRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Guardian;
 
 use App\Enums\EnrollmentStatus;
 use App\Enums\GradeLevel;
+use App\Enums\PaymentPlan;
 use App\Enums\Quarter;
 use App\Models\Enrollment;
 use App\Models\EnrollmentPeriod;
@@ -148,7 +149,7 @@ class StoreEnrollmentRequest extends FormRequest
                     }
                 },
             ],
-            'payment_plan' => ['required', 'in:annual,semestral,quarterly,monthly'],
+            'payment_plan' => ['required', Rule::in(PaymentPlan::values())],
         ];
     }
 

--- a/app/Http/Requests/SuperAdmin/StoreEnrollmentRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreEnrollmentRequest.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Requests\SuperAdmin;
 
+use App\Enums\EnrollmentType;
 use App\Enums\GradeLevel;
+use App\Enums\PaymentPlan;
 use App\Enums\Quarter;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -29,9 +31,9 @@ class StoreEnrollmentRequest extends FormRequest
             'grade_level' => ['required', Rule::in(GradeLevel::values())],
             'school_year_id' => ['required', 'exists:school_years,id'],
             'quarter' => ['required', Rule::in(Quarter::values())],
-            'type' => ['required', 'in:new,continuing,returnee,transferee'],
+            'type' => ['required', Rule::in(EnrollmentType::values())],
             'previous_school' => ['nullable', 'required_if:type,transferee', 'string', 'max:255'],
-            'payment_plan' => ['required', 'in:annual,semestral,quarterly,monthly'],
+            'payment_plan' => ['required', Rule::in(PaymentPlan::values())],
         ];
     }
 }

--- a/app/Http/Requests/SuperAdmin/UpdateEnrollmentRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateEnrollmentRequest.php
@@ -3,7 +3,9 @@
 namespace App\Http\Requests\SuperAdmin;
 
 use App\Enums\EnrollmentStatus;
+use App\Enums\EnrollmentType;
 use App\Enums\GradeLevel;
+use App\Enums\PaymentPlan;
 use App\Enums\Quarter;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -31,9 +33,9 @@ class UpdateEnrollmentRequest extends FormRequest
             'grade_level' => ['required', Rule::in(GradeLevel::values())],
             'school_year_id' => ['required', 'exists:school_years,id'],
             'quarter' => ['required', Rule::in(Quarter::values())],
-            'type' => ['required', 'in:new,continuing,returnee,transferee'],
+            'type' => ['required', Rule::in(EnrollmentType::values())],
             'previous_school' => ['nullable', 'string', 'max:255'],
-            'payment_plan' => ['required', 'in:annual,semestral,quarterly,monthly'],
+            'payment_plan' => ['required', Rule::in(PaymentPlan::values())],
             'status' => ['required', 'string', 'in:'.implode(',', array_column(EnrollmentStatus::cases(), 'value'))],
         ];
     }

--- a/tests/Unit/Enums/EnrollmentTypeTest.php
+++ b/tests/Unit/Enums/EnrollmentTypeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\EnrollmentType;
+use PHPUnit\Framework\TestCase;
+
+class EnrollmentTypeTest extends TestCase
+{
+    public function test_values_returns_all_enrollment_type_values(): void
+    {
+        $values = EnrollmentType::values();
+
+        $this->assertCount(4, $values);
+        $this->assertContains('new', $values);
+        $this->assertContains('continuing', $values);
+        $this->assertContains('returnee', $values);
+        $this->assertContains('transferee', $values);
+    }
+
+    public function test_label_returns_correct_labels(): void
+    {
+        $this->assertEquals('New Student', EnrollmentType::NEW->label());
+        $this->assertEquals('Continuing Student', EnrollmentType::CONTINUING->label());
+        $this->assertEquals('Returnee', EnrollmentType::RETURNEE->label());
+        $this->assertEquals('Transferee', EnrollmentType::TRANSFEREE->label());
+    }
+
+    public function test_description_returns_valid_descriptions(): void
+    {
+        $this->assertNotEmpty(EnrollmentType::NEW->description());
+        $this->assertNotEmpty(EnrollmentType::CONTINUING->description());
+        $this->assertNotEmpty(EnrollmentType::RETURNEE->description());
+        $this->assertNotEmpty(EnrollmentType::TRANSFEREE->description());
+    }
+
+    public function test_requires_previous_school_only_for_transferee(): void
+    {
+        $this->assertFalse(EnrollmentType::NEW->requiresPreviousSchool());
+        $this->assertFalse(EnrollmentType::CONTINUING->requiresPreviousSchool());
+        $this->assertFalse(EnrollmentType::RETURNEE->requiresPreviousSchool());
+        $this->assertTrue(EnrollmentType::TRANSFEREE->requiresPreviousSchool());
+    }
+}

--- a/tests/Unit/Enums/PaymentPlanTest.php
+++ b/tests/Unit/Enums/PaymentPlanTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\PaymentPlan;
+use PHPUnit\Framework\TestCase;
+
+class PaymentPlanTest extends TestCase
+{
+    public function test_values_returns_all_payment_plan_values(): void
+    {
+        $values = PaymentPlan::values();
+
+        $this->assertCount(4, $values);
+        $this->assertContains('annual', $values);
+        $this->assertContains('semestral', $values);
+        $this->assertContains('quarterly', $values);
+        $this->assertContains('monthly', $values);
+    }
+
+    public function test_label_returns_correct_labels(): void
+    {
+        $this->assertEquals('Annual', PaymentPlan::ANNUAL->label());
+        $this->assertEquals('Semestral', PaymentPlan::SEMESTRAL->label());
+        $this->assertEquals('Quarterly', PaymentPlan::QUARTERLY->label());
+        $this->assertEquals('Monthly', PaymentPlan::MONTHLY->label());
+    }
+
+    public function test_installments_returns_correct_counts(): void
+    {
+        $this->assertEquals(1, PaymentPlan::ANNUAL->installments());
+        $this->assertEquals(2, PaymentPlan::SEMESTRAL->installments());
+        $this->assertEquals(4, PaymentPlan::QUARTERLY->installments());
+        $this->assertEquals(10, PaymentPlan::MONTHLY->installments());
+    }
+
+    public function test_description_returns_valid_descriptions(): void
+    {
+        $this->assertNotEmpty(PaymentPlan::ANNUAL->description());
+        $this->assertNotEmpty(PaymentPlan::SEMESTRAL->description());
+        $this->assertNotEmpty(PaymentPlan::QUARTERLY->description());
+        $this->assertNotEmpty(PaymentPlan::MONTHLY->description());
+    }
+}


### PR DESCRIPTION
## Summary
This PR **completes issue #394** by creating the final two missing enums and refactoring all hardcoded validation strings\!

## New Enums Created

### 1. PaymentPlan Enum
```php
enum PaymentPlan: string
{
    case ANNUAL = 'annual';
    case SEMESTRAL = 'semestral';
    case QUARTERLY = 'quarterly';
    case MONTHLY = 'monthly';
}
```

**Methods:**
- `values()` - Get all enum values
- `label()` - Get human-readable label
- `installments()` - Get number of installments (1, 2, 4, 10)
- `description()` - Get payment plan description

### 2. EnrollmentType Enum
```php
enum EnrollmentType: string
{
    case NEW = 'new';
    case CONTINUING = 'continuing';
    case RETURNEE = 'returnee';
    case TRANSFEREE = 'transferee';
}
```

**Methods:**
- `values()` - Get all enum values
- `label()` - Get human-readable label
- `requiresPreviousSchool()` - Returns true only for TRANSFEREE
- `description()` - Get enrollment type description

## Files Changed

### New Files (4):
- ✅ `app/Enums/PaymentPlan.php`
- ✅ `app/Enums/EnrollmentType.php`
- ✅ `tests/Unit/Enums/PaymentPlanTest.php`
- ✅ `tests/Unit/Enums/EnrollmentTypeTest.php`

### Updated Request Files (3):
- ✅ `SuperAdmin/StoreEnrollmentRequest.php`
- ✅ `SuperAdmin/UpdateEnrollmentRequest.php`
- ✅ `Guardian/StoreEnrollmentRequest.php`

## Before & After

**Before:**
```php
'payment_plan' => ['required', 'in:annual,semestral,quarterly,monthly'],  // ❌ Hardcoded
'type' => ['required', 'in:new,continuing,returnee,transferee'],  // ❌ Hardcoded
```

**After:**
```php
'payment_plan' => ['required', Rule::in(PaymentPlan::values())],  // ✅ Type-safe
'type' => ['required', Rule::in(EnrollmentType::values())],  // ✅ Type-safe
```

## Benefits
✅ **Type Safety** - Only valid enum values accepted
✅ **Business Logic** - Enums include helpful methods (installments, requiresPreviousSchool)
✅ **Single Source of Truth** - No more scattered hardcoded strings
✅ **Refactoring Safe** - Changes propagate automatically
✅ **Better IDE Support** - Autocomplete and type hints

## 🎊 Issue #394 Status: COMPLETE\!

All enums in the codebase are now properly typed:
- ✅ PaymentMethod (PR #441)
- ✅ GradeLevel (PR #442)
- ✅ Quarter (PR #443)
- ✅ PaymentPlan (This PR) **NEW\!**
- ✅ EnrollmentType (This PR) **NEW\!**
- ✅ EnrollmentStatus (Already correct)
- ✅ InvoiceStatus (Already correct)
- ✅ Gender (Already correct)

**No more hardcoded enum strings in validation\!** 🎉

## Testing
✅ All tests passing (8 new test methods)
✅ Coverage above 60%
✅ Code style checks passed
✅ Static analysis passed

Closes #394