### PR TITLE
feat(certificate): Dynamic school info and hardcoded names

### DIFF
--- a/app/Http/Controllers/Guardian/EnrollmentController.php
+++ b/app/Http/Controllers/Guardian/EnrollmentController.php
@@ -13,6 +13,7 @@ use App\Models\Enrollment;
 use App\Models\EnrollmentPeriod;
 use App\Models\GuardianStudent;
 use App\Models\Payment;
+use App\Models\SchoolInformation;
 use App\Models\SchoolYear;
 use App\Models\Student;
 use App\Models\User;
@@ -97,7 +98,6 @@ class EnrollmentController extends Controller
                 'school_year_id' => $request->school_year_id,
                 'student_id' => $request->student_id,
                 'status' => $request->status,
-                'search' => $request->search,
             ],
             'filterOptions' => [
                 'students' => $students,
@@ -490,10 +490,15 @@ class EnrollmentController extends Controller
             abort(403, 'Certificate only available for enrolled students.');
         }
 
-        $enrollment->load('student', 'guardian');
+        $enrollment->load('student', 'guardian', 'schoolYear');
+
+        $schoolAddress = SchoolInformation::getByKey('school_address', 'Lantapan, Bukidnon');
+        $schoolPhone = SchoolInformation::getByKey('school_phone', '');
 
         $pdf = Pdf::loadView('pdf.enrollment-certificate', [
             'enrollment' => $enrollment,
+            'schoolAddress' => $schoolAddress,
+            'schoolPhone' => $schoolPhone,
         ])
             ->setPaper('a4', 'portrait')
             ->setOption('isHtml5ParserEnabled', true)

--- a/resources/views/pdf/enrollment-certificate.blade.php
+++ b/resources/views/pdf/enrollment-certificate.blade.php
@@ -123,8 +123,8 @@
         <div class="header">
             <div style="font-size: 14px;">Republic of the Philippines</div>
             <div class="school-name">Christian Bible Heritage Learning Center</div>
-            <div>{{ config('app.school_address', 'Lantapan, Bukidnon') }}</div>
-            <div>Tel: {{ config('app.school_phone', '') }}</div>
+            <div>{{ $schoolAddress }}</div>
+            <div>Tel: {{ $schoolPhone }}</div>
         </div>
 
         <div class="certificate-title">Certificate of Enrollment</div>
@@ -139,7 +139,7 @@
             </div>
 
             <p>is officially enrolled in this institution for the</p>
-            <p><strong>School Year {{ $enrollment->school_year }}</strong></p>
+            <p><strong>School Year {{ $enrollment->schoolYear->name }}</strong></p>
         </div>
 
         <div class="details-section">
@@ -172,12 +172,12 @@
 
         <div class="signatures">
             <div class="signature-box">
-                <div class="signature-line">Registrar</div>
-                <div class="signature-title">Christian Bible Heritage Learning Center</div>
+                <div class="signature-line">MARIECHRIS HACHERO</div>
+                <div class="signature-title">Registrar</div>
             </div>
             <div class="signature-box">
-                <div class="signature-line">Principal</div>
-                <div class="signature-title">Christian Bible Heritage Learning Center</div>
+                <div class="signature-line">NORMA ARROYO</div>
+                <div class="signature-title">Principal</div>
             </div>
         </div>
 


### PR DESCRIPTION
 This commit introduces the following changes to the enrollment certificate:                                                                    │
 │    - The school address and phone number are now dynamically retrieved from the system's SchoolInformation settings.                               │
 │    - The school year displayed on the certificate is now based on the student's enrollment details.                                               │
 │    - Hardcoded the names of the Registrar (Mariechris Hachero) and Principal (Norma Arroyo) into the certificate.'
 
 
 Before:
 
<img width="644" height="900" alt="image" src="https://github.com/user-attachments/assets/86656d10-4800-49d0-b01e-c7298c6535fd" />

<img width="505" height="711" alt="image" src="https://github.com/user-attachments/assets/877fccc9-ec42-44b3-b763-8b903d9704a5" />

After:

<img width="646" height="626" alt="image" src="https://github.com/user-attachments/assets/50e65d89-1096-4c5f-97c6-01e011cb233a" />

<img width="679" height="566" alt="image" src="https://github.com/user-attachments/assets/3134992b-1f1d-4a21-b4e3-cda2f97b4f90" />
