### PR TITLE
fix(payment-history): Resolve PDF display issues

### DIFF
--- a/app/Http/Controllers/Guardian/EnrollmentController.php
+++ b/app/Http/Controllers/Guardian/EnrollmentController.php
@@ -13,6 +13,7 @@ use App\Models\Enrollment;
 use App\Models\EnrollmentPeriod;
 use App\Models\GuardianStudent;
 use App\Models\Payment;
+use App\Models\SchoolInformation;
 use App\Models\SchoolYear;
 use App\Models\Student;
 use App\Models\User;
@@ -448,7 +449,12 @@ class EnrollmentController extends Controller
         $enrollment->load([
             'student',
             'invoices.payments',
+            'schoolYear',
         ]);
+
+        $schoolAddress = SchoolInformation::getByKey('school_address', 'Lantapan, Bukidnon');
+        $schoolPhone = SchoolInformation::getByKey('school_phone', '');
+        $schoolEmail = SchoolInformation::getByKey('school_email', 'cbhlc@example.com');
 
         // Get all payments for this enrollment through invoices
         $payments = collect();
@@ -460,6 +466,9 @@ class EnrollmentController extends Controller
         $pdf = Pdf::loadView('pdf.payment-history', [
             'enrollment' => $enrollment,
             'payments' => $payments,
+            'schoolAddress' => $schoolAddress,
+            'schoolPhone' => $schoolPhone,
+            'schoolEmail' => $schoolEmail,
         ])
             ->setPaper('a4', 'portrait')
             ->setOption('isHtml5ParserEnabled', true)
@@ -490,10 +499,15 @@ class EnrollmentController extends Controller
             abort(403, 'Certificate only available for enrolled students.');
         }
 
-        $enrollment->load('student', 'guardian');
+        $enrollment->load('student', 'guardian', 'schoolYear');
+
+        $schoolAddress = SchoolInformation::getByKey('school_address', 'Lantapan, Bukidnon');
+        $schoolPhone = SchoolInformation::getByKey('school_phone', '');
 
         $pdf = Pdf::loadView('pdf.enrollment-certificate', [
             'enrollment' => $enrollment,
+            'schoolAddress' => $schoolAddress,
+            'schoolPhone' => $schoolPhone,
         ])
             ->setPaper('a4', 'portrait')
             ->setOption('isHtml5ParserEnabled', true)

--- a/resources/views/pdf/payment-history.blade.php
+++ b/resources/views/pdf/payment-history.blade.php
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="UTF-8">
     <title>Payment History Report</title>
     <style>
-        body { font-family: Arial, sans-serif; font-size: 12px; }
+        body { font-family: 'DejaVu Sans', sans-serif; font-size: 12px; }
         .header { text-align: center; margin-bottom: 30px; border-bottom: 2px solid #333; padding-bottom: 20px; }
         .school-name { font-size: 24px; font-weight: bold; }
         .report-title { font-size: 18px; margin-top: 10px; }
@@ -22,8 +23,8 @@
 <body>
     <div class="header">
         <div class="school-name">Christian Bible Heritage Learning Center</div>
-        <div>{{ config('app.school_address', 'Lantapan, Bukidnon') }}</div>
-        <div>{{ config('app.school_phone', '') }} | {{ config('app.school_email', 'cbhlc@example.com') }}</div>
+        <div>{{ $schoolAddress }}</div>
+        <div>{{ $schoolPhone }} | {{ $schoolEmail }}</div>
         <div class="report-title">PAYMENT HISTORY REPORT</div>
     </div>
 
@@ -42,7 +43,7 @@
         </div>
         <div class="info-row">
             <strong>School Year:</strong>
-            <span>{{ $enrollment->school_year }}</span>
+            <span>{{ $enrollment->schoolYear->name }}</span>
         </div>
         <div class="info-row">
             <strong>Enrollment ID:</strong>
@@ -118,7 +119,7 @@
                 <tr>
                     <td>{{ $payment->payment_date->format('M d, Y') }}</td>
                     <td>₱{{ number_format($payment->amount, 2) }}</td>
-                    <td>{{ ucfirst($payment->payment_method) }}</td>
+                    <td>{{ ucfirst($payment->payment_method->value) }}</td>
                     <td>{{ $payment->reference_number ?? 'N/A' }}</td>
                     <td style="text-align: right;">₱{{ number_format($runningBalance, 2) }}</td>
                 </tr>


### PR DESCRIPTION
This commit addresses several issues in the payment history PDF report:
- Corrected the TypeError when using ucfirst() with the PaymentMethod enum.
- Ensured dynamic display of school address, phone, and email by retrieving them from SchoolInformation settings.
- Updated the font-family to 'DejaVu Sans' to correctly render the peso sign (₱).

**Before:**
<img width="771" height="877" alt="image" src="https://github.com/user-attachments/assets/95bb1403-11a0-4dc7-9992-43067dae76ff" />

**After**
<img width="759" height="898" alt="image" src="https://github.com/user-attachments/assets/589031b1-67c1-41ed-9cc6-62487e65a741" />
