### PR TITLE
fix: resolve enrollment status not updating issue (#458)

### DIFF
--- a/app/Http/Controllers/SuperAdmin/EnrollmentController.php
+++ b/app/Http/Controllers/SuperAdmin/EnrollmentController.php
@@ -248,7 +248,7 @@ class EnrollmentController extends Controller
             $oldStatus = $enrollment->status;
             $newStatus = $validated['status'] ?? $oldStatus;
 
-            // Update enrollment without status (status will be handled by service methods)
+            // Update enrollment without status (status will be handled separately)
             $dataToUpdate = collect($validated)->except('status')->toArray();
             $enrollment->update($dataToUpdate);
 
@@ -258,6 +258,10 @@ class EnrollmentController extends Controller
                     $this->enrollmentService->approveEnrollment($enrollment);
                 } elseif ($newStatus === EnrollmentStatus::REJECTED->value) {
                     $this->enrollmentService->rejectEnrollment($enrollment, 'Updated by admin');
+                } else {
+                    // For all other status changes (ENROLLED, COMPLETED, PAID, READY_FOR_PAYMENT, etc.)
+                    // Update the status directly
+                    $enrollment->update(['status' => $newStatus]);
                 }
             }
         });

--- a/tests/Browser/UpdateEnrollmentStatusTest.php
+++ b/tests/Browser/UpdateEnrollmentStatusTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use App\Enums\EnrollmentStatus;
+use App\Models\Enrollment;
+use App\Models\Student;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+
+uses(\Illuminate\Foundation\Testing\DatabaseMigrations::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+describe('Update Enrollment Status Functionality', function () {
+
+    test('super admin can update enrollment status to enrolled', function () {
+        // Create super admin user
+        $admin = User::factory()->superAdmin()->create([
+            'email' => 'admin@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        // Create a student with a pending enrollment
+        $student = Student::factory()->create([
+            'first_name' => 'John',
+            'last_name' => 'StatusTest',
+        ]);
+
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'status' => EnrollmentStatus::PENDING,
+        ]);
+
+        // Verify initial status
+        expect($enrollment->status)->toBe(EnrollmentStatus::PENDING);
+
+        // Login and navigate to edit enrollment page
+        visit('/login')
+            ->type('email', $admin->email)
+            ->type('password', 'password')
+            ->press('Log in')
+            ->waitForText('Dashboard');
+
+        // Navigate to enrollments list
+        visit('/super-admin/enrollments')
+            ->waitForText('Enrollments')
+            ->assertSee($student->first_name);
+
+        // Test backend directly - update enrollment status to enrolled
+        $this->actingAs($admin);
+
+        // Get fresh enrollment data
+        $enrollment->refresh();
+
+        $response = $this->put("/super-admin/enrollments/{$enrollment->id}", [
+            'student_id' => $enrollment->student_id,
+            'guardian_id' => $enrollment->guardian_id,
+            'grade_level' => $enrollment->grade_level->value,
+            'quarter' => $enrollment->quarter->value,
+            'school_year_id' => $enrollment->school_year_id,
+            'status' => EnrollmentStatus::ENROLLED->value,
+            'type' => $enrollment->type,
+            'payment_plan' => $enrollment->payment_plan,
+        ]);
+
+        $response->assertRedirect('/super-admin/enrollments');
+        $response->assertSessionHas('success', 'Enrollment updated successfully.');
+
+        // Verify status was actually updated in database
+        $enrollment->refresh();
+        expect($enrollment->status)->toBe(EnrollmentStatus::ENROLLED);
+
+        // Visit enrollments page and verify status is displayed as enrolled
+        visit('/super-admin/enrollments')
+            ->waitForText('Enrollments')
+            ->assertSee('enrolled'); // Status badge should show 'enrolled'
+
+    })->group('update-enrollment', 'critical');
+
+    test('super admin can update enrollment status to ready for payment', function () {
+        $admin = User::factory()->superAdmin()->create([
+            'email' => 'admin@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'status' => EnrollmentStatus::PENDING,
+            'type' => 'new',
+            'payment_plan' => 'annual',
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->put("/super-admin/enrollments/{$enrollment->id}", [
+            'student_id' => $enrollment->student_id,
+            'guardian_id' => $enrollment->guardian_id,
+            'grade_level' => $enrollment->grade_level->value,
+            'quarter' => $enrollment->quarter->value,
+            'school_year_id' => $enrollment->school_year_id,
+            'status' => EnrollmentStatus::READY_FOR_PAYMENT->value,
+            'type' => $enrollment->type,
+            'payment_plan' => $enrollment->payment_plan,
+        ]);
+
+        $response->assertRedirect('/super-admin/enrollments');
+
+        $enrollment->refresh();
+        expect($enrollment->status)->toBe(EnrollmentStatus::READY_FOR_PAYMENT);
+
+    })->group('update-enrollment', 'critical');
+
+    test('super admin can update enrollment status to paid', function () {
+        $admin = User::factory()->superAdmin()->create([
+            'email' => 'admin@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'status' => EnrollmentStatus::READY_FOR_PAYMENT,
+            'type' => 'new',
+            'payment_plan' => 'annual',
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->put("/super-admin/enrollments/{$enrollment->id}", [
+            'student_id' => $enrollment->student_id,
+            'guardian_id' => $enrollment->guardian_id,
+            'grade_level' => $enrollment->grade_level->value,
+            'quarter' => $enrollment->quarter->value,
+            'school_year_id' => $enrollment->school_year_id,
+            'status' => EnrollmentStatus::PAID->value,
+            'type' => $enrollment->type,
+            'payment_plan' => $enrollment->payment_plan,
+        ]);
+
+        $response->assertRedirect('/super-admin/enrollments');
+
+        $enrollment->refresh();
+        expect($enrollment->status)->toBe(EnrollmentStatus::PAID);
+
+    })->group('update-enrollment', 'critical');
+
+    test('super admin can update enrollment status to completed', function () {
+        $admin = User::factory()->superAdmin()->create([
+            'email' => 'admin@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'status' => EnrollmentStatus::ENROLLED,
+            'type' => 'new',
+            'payment_plan' => 'annual',
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->put("/super-admin/enrollments/{$enrollment->id}", [
+            'student_id' => $enrollment->student_id,
+            'guardian_id' => $enrollment->guardian_id,
+            'grade_level' => $enrollment->grade_level->value,
+            'quarter' => $enrollment->quarter->value,
+            'school_year_id' => $enrollment->school_year_id,
+            'status' => EnrollmentStatus::COMPLETED->value,
+            'type' => $enrollment->type,
+            'payment_plan' => $enrollment->payment_plan,
+        ]);
+
+        $response->assertRedirect('/super-admin/enrollments');
+
+        $enrollment->refresh();
+        expect($enrollment->status)->toBe(EnrollmentStatus::COMPLETED);
+
+    })->group('update-enrollment', 'critical');
+});


### PR DESCRIPTION
## Problem
When updating enrollment status via the "Update Enrollment Status" option in the Students Module kebab menu, the status change was not persisting. The success message appeared but the status remained unchanged in the database and UI.

## Root Cause
In `app/Http/Controllers/SuperAdmin/EnrollmentController.php:241-267`, the `update()` method explicitly excluded the status field from the update (line 252) and only handled `APPROVED` and `REJECTED` status changes through service methods (lines 257-261).

All other status changes (`ENROLLED`, `COMPLETED`, `PAID`, `READY_FOR_PAYMENT`) were never actually saved to the database.

## Solution
Added an `else` branch to handle all other status changes by directly updating the status field when it's not `APPROVED` or `REJECTED`.

```php
// Lines 261-265
} else {
    // For all other status changes (ENROLLED, COMPLETED, PAID, READY_FOR_PAYMENT, etc.)
    // Update the status directly
    $enrollment->update(['status' => $newStatus]);
}
```

## Technical Details
- The status field is excluded from the initial update because `APPROVED` and `REJECTED` statuses require special service method handling (approval/rejection workflows)
- For all other status transitions, we now directly update the status field in the database
- This maintains the existing workflow logic while fixing the bug for other status types

## Testing
- Created comprehensive browser tests in `tests/Browser/UpdateEnrollmentStatusTest.php`
- Tests verify status updates for: ENROLLED, READY_FOR_PAYMENT, PAID, and COMPLETED
- All existing tests pass with 60%+ coverage
- Pre-push hooks pass successfully

## Files Changed
- `app/Http/Controllers/SuperAdmin/EnrollmentController.php` (bug fix)
- `tests/Browser/UpdateEnrollmentStatusTest.php` (new test file with 4 tests)

Closes #458