### PR TITLE
Fix #457: Add View Enrollments page for students

### DIFF
--- a/app/Http/Controllers/SuperAdmin/StudentController.php
+++ b/app/Http/Controllers/SuperAdmin/StudentController.php
@@ -232,26 +232,28 @@ class StudentController extends Controller
     {
         Gate::authorize('view', $student);
 
-        $enrollments = $student->enrollments()
+        $collection = $student->enrollments()
             ->with(['guardian', 'schoolYear'])
             ->latest()
-            ->get()
-            ->map(function (Enrollment $enrollment): array {
-                return [
-                    'id' => $enrollment->id,
-                    'enrollment_id' => $enrollment->enrollment_id,
-                    'status' => $enrollment->status->value,
-                    'grade_level' => $enrollment->grade_level->value,
-                    'quarter' => $enrollment->quarter->value,
-                    'school_year' => $enrollment->schoolYear ? $enrollment->schoolYear->name : 'N/A',
-                    'guardian' => [
-                        'id' => $enrollment->guardian->id,
-                        'first_name' => $enrollment->guardian->first_name,
-                        'last_name' => $enrollment->guardian->last_name,
-                    ],
-                    'created_at' => $enrollment->created_at?->toISOString() ?? '',
-                ];
-            });
+            ->get();
+
+        $enrollments = [];
+        foreach ($collection as $enrollment) {
+            $enrollments[] = [
+                'id' => $enrollment->id,
+                'enrollment_id' => $enrollment->enrollment_id,
+                'status' => $enrollment->status->value,
+                'grade_level' => $enrollment->grade_level->value,
+                'quarter' => $enrollment->quarter->value,
+                'school_year' => $enrollment->schoolYear ? $enrollment->schoolYear->name : 'N/A',
+                'guardian' => [
+                    'id' => $enrollment->guardian->id,
+                    'first_name' => $enrollment->guardian->first_name,
+                    'last_name' => $enrollment->guardian->last_name,
+                ],
+                'created_at' => $enrollment->created_at?->toISOString() ?? '',
+            ];
+        }
 
         return Inertia::render('super-admin/students/enrollments', [
             'student' => $student,

--- a/app/Http/Controllers/SuperAdmin/StudentController.php
+++ b/app/Http/Controllers/SuperAdmin/StudentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\SuperAdmin;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\SuperAdmin\StoreStudentRequest;
 use App\Http\Requests\SuperAdmin\UpdateStudentRequest;
+use App\Models\Enrollment;
 use App\Models\Guardian;
 use App\Models\Student;
 use Illuminate\Http\Request;
@@ -222,5 +223,39 @@ class StudentController extends Controller
 
         return redirect()->route('super-admin.students.index')
             ->with('success', 'Student deleted successfully.');
+    }
+
+    /**
+     * Display the student's enrollments.
+     */
+    public function enrollments(Student $student)
+    {
+        Gate::authorize('view', $student);
+
+        $enrollments = $student->enrollments()
+            ->with(['guardian', 'schoolYear'])
+            ->latest()
+            ->get()
+            ->map(function (Enrollment $enrollment): array {
+                return [
+                    'id' => $enrollment->id,
+                    'enrollment_id' => $enrollment->enrollment_id,
+                    'status' => $enrollment->status->value,
+                    'grade_level' => $enrollment->grade_level->value,
+                    'quarter' => $enrollment->quarter->value,
+                    'school_year' => $enrollment->schoolYear ? $enrollment->schoolYear->name : 'N/A',
+                    'guardian' => [
+                        'id' => $enrollment->guardian->id,
+                        'first_name' => $enrollment->guardian->first_name,
+                        'last_name' => $enrollment->guardian->last_name,
+                    ],
+                    'created_at' => $enrollment->created_at?->toISOString() ?? '',
+                ];
+            });
+
+        return Inertia::render('super-admin/students/enrollments', [
+            'student' => $student,
+            'enrollments' => $enrollments,
+        ]);
     }
 }

--- a/resources/js/pages/super-admin/students/enrollments.tsx
+++ b/resources/js/pages/super-admin/students/enrollments.tsx
@@ -1,0 +1,144 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import AppLayout from '@/layouts/app-layout';
+import { type BreadcrumbItem } from '@/types';
+import { Head, Link } from '@inertiajs/react';
+import { ArrowLeft } from 'lucide-react';
+
+interface Student {
+    id: number;
+    student_id: string;
+    first_name: string;
+    last_name: string;
+}
+
+interface Guardian {
+    id: number;
+    first_name: string;
+    last_name: string;
+}
+
+interface Enrollment {
+    id: number;
+    enrollment_id: string;
+    status: string;
+    grade_level: string;
+    quarter: string;
+    school_year: string;
+    guardian: Guardian;
+    created_at: string;
+}
+
+interface Props {
+    student: Student;
+    enrollments: Enrollment[];
+}
+
+function getStatusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+    switch (status) {
+        case 'enrolled':
+        case 'completed':
+        case 'paid':
+        case 'approved':
+            return 'default';
+        case 'pending':
+        case 'ready_for_payment':
+            return 'secondary';
+        case 'rejected':
+            return 'destructive';
+        default:
+            return 'outline';
+    }
+}
+
+export default function StudentEnrollments({ student, enrollments }: Props) {
+    const breadcrumbs: BreadcrumbItem[] = [
+        { title: 'Super Admin', href: '/super-admin/dashboard' },
+        { title: 'Students', href: '/super-admin/students' },
+        {
+            title: `${student.first_name} ${student.last_name}`,
+            href: `/super-admin/students/${student.id}`,
+        },
+        { title: 'Enrollments', href: `/super-admin/students/${student.id}/enrollments` },
+    ];
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title={`Enrollments - ${student.first_name} ${student.last_name}`} />
+            <div className="container mx-auto px-4 py-6">
+                <div className="mb-6 flex items-center gap-4">
+                    <Link href="/super-admin/students">
+                        <Button variant="outline" size="icon">
+                            <ArrowLeft className="h-4 w-4" />
+                        </Button>
+                    </Link>
+                    <div>
+                        <h1 className="text-2xl font-bold">
+                            Enrollments for {student.first_name} {student.last_name}
+                        </h1>
+                        <p className="text-sm text-muted-foreground">Student ID: {student.student_id}</p>
+                    </div>
+                </div>
+
+                {enrollments.length === 0 ? (
+                    <Card>
+                        <CardContent className="flex min-h-[200px] flex-col items-center justify-center">
+                            <p className="text-muted-foreground">No enrollments found for this student.</p>
+                        </CardContent>
+                    </Card>
+                ) : (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Enrollment History</CardTitle>
+                            <CardDescription>All enrollment records for this student</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <Table>
+                                <TableHeader>
+                                    <TableRow>
+                                        <TableHead>Enrollment ID</TableHead>
+                                        <TableHead>School Year</TableHead>
+                                        <TableHead>Grade Level</TableHead>
+                                        <TableHead>Quarter</TableHead>
+                                        <TableHead>Guardian</TableHead>
+                                        <TableHead>Status</TableHead>
+                                        <TableHead>Enrolled Date</TableHead>
+                                        <TableHead>Actions</TableHead>
+                                    </TableRow>
+                                </TableHeader>
+                                <TableBody>
+                                    {enrollments.map((enrollment) => (
+                                        <TableRow key={enrollment.id}>
+                                            <TableCell className="font-medium">{enrollment.enrollment_id}</TableCell>
+                                            <TableCell>{enrollment.school_year}</TableCell>
+                                            <TableCell className="capitalize">{enrollment.grade_level}</TableCell>
+                                            <TableCell className="capitalize">{enrollment.quarter}</TableCell>
+                                            <TableCell>
+                                                {enrollment.guardian.first_name} {enrollment.guardian.last_name}
+                                            </TableCell>
+                                            <TableCell>
+                                                <Badge variant={getStatusVariant(enrollment.status)} className="capitalize">
+                                                    {enrollment.status.replace('_', ' ')}
+                                                </Badge>
+                                            </TableCell>
+                                            <TableCell>{new Date(enrollment.created_at).toLocaleDateString()}</TableCell>
+                                            <TableCell>
+                                                <Link href={`/super-admin/enrollments/${enrollment.id}`}>
+                                                    <Button variant="ghost" size="sm">
+                                                        View Details
+                                                    </Button>
+                                                </Link>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </CardContent>
+                    </Card>
+                )}
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -142,6 +142,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::resource('users', SuperAdminUserController::class);
 
         // Students Management
+        Route::get('/students/{student}/enrollments', [SuperAdminStudentController::class, 'enrollments'])->name('students.enrollments');
         Route::resource('students', SuperAdminStudentController::class);
 
         // Guardians Management

--- a/tests/Browser/ViewEnrollmentsTest.php
+++ b/tests/Browser/ViewEnrollmentsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Models\Student;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+
+uses(\Illuminate\Foundation\Testing\DatabaseMigrations::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+describe('View Enrollments Functionality', function () {
+
+    test('super admin can view student enrollments without 404 error', function () {
+        // Create super admin user
+        $admin = User::factory()->superAdmin()->create([
+            'email' => 'admin@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        // Create a student
+        $student = Student::factory()->create([
+            'first_name' => 'John',
+            'last_name' => 'Enrollee',
+        ]);
+
+        // Login as super admin
+        visit('/login')
+            ->type('email', $admin->email)
+            ->type('password', 'password')
+            ->press('Log in')
+            ->waitForText('Dashboard');
+
+        // Navigate to students list
+        visit('/super-admin/students')
+            ->waitForText('Students Index')
+            ->assertSee('John Enrollee');
+
+        // Test backend - visit enrollments page
+        $this->actingAs($admin);
+        $response = $this->get("/super-admin/students/{$student->id}/enrollments");
+
+        // Should not get 404
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('super-admin/students/enrollments')
+            ->has('student')
+            ->where('student.id', $student->id)
+            ->has('enrollments')
+        );
+
+        // Visit the page via browser
+        visit("/super-admin/students/{$student->id}/enrollments")
+            ->waitForText('Enrollments for')
+            ->assertSee('John Enrollee')
+            ->assertSee('No enrollments found for this student')
+            ->assertDontSee('404')
+            ->assertDontSee('NOT FOUND');
+
+    })->group('view-enrollments', 'critical');
+
+    test('super admin can view student with enrollments', function () {
+        $admin = User::factory()->superAdmin()->create([
+            'email' => 'admin@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        // Create a student with enrollments
+        $student = Student::factory()
+            ->hasEnrollments(2, [
+                'type' => 'new',
+                'payment_plan' => 'annual',
+            ])
+            ->create([
+                'first_name' => 'Jane',
+                'last_name' => 'HasEnrollments',
+            ]);
+
+        $this->actingAs($admin);
+
+        visit("/super-admin/students/{$student->id}/enrollments")
+            ->waitForText('Enrollments for')
+            ->assertSee('Jane HasEnrollments')
+            ->assertSee('Enrollment History')
+            // Should see the enrollment IDs in the table
+            ->assertSee('ENR-');
+
+    })->group('view-enrollments', 'critical');
+});

--- a/tests/Feature/SuperAdmin/StudentEnrollmentsTest.php
+++ b/tests/Feature/SuperAdmin/StudentEnrollmentsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use App\Models\Enrollment;
+use App\Models\Student;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+    $this->admin = User::factory()->superAdmin()->create();
+});
+
+describe('Student Enrollments Feature', function () {
+
+    test('super admin can view student enrollments', function () {
+        $student = Student::factory()->create();
+
+        $response = $this->actingAs($this->admin)
+            ->get("/super-admin/students/{$student->id}/enrollments");
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('super-admin/students/enrollments')
+            ->has('student')
+            ->has('enrollments')
+        );
+    });
+
+    test('enrollments are properly formatted with all required fields', function () {
+        $student = Student::factory()->create();
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'type' => 'new',
+            'payment_plan' => 'annual',
+        ]);
+
+        $response = $this->actingAs($this->admin)
+            ->get("/super-admin/students/{$student->id}/enrollments");
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('super-admin/students/enrollments')
+            ->where('student.id', $student->id)
+            ->has('enrollments', 1)
+            ->where('enrollments.0.id', $enrollment->id)
+            ->where('enrollments.0.enrollment_id', $enrollment->enrollment_id)
+            ->has('enrollments.0.status')
+            ->has('enrollments.0.grade_level')
+            ->has('enrollments.0.quarter')
+            ->has('enrollments.0.school_year')
+            ->has('enrollments.0.guardian')
+            ->has('enrollments.0.created_at')
+        );
+    });
+
+    test('shows empty array when student has no enrollments', function () {
+        $student = Student::factory()->create();
+
+        $response = $this->actingAs($this->admin)
+            ->get("/super-admin/students/{$student->id}/enrollments");
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('super-admin/students/enrollments')
+            ->where('student.id', $student->id)
+            ->has('enrollments', 0)
+        );
+    });
+
+    test('unauthorized users cannot view student enrollments', function () {
+        $student = Student::factory()->create();
+        $user = User::factory()->create(); // Regular user without permissions
+
+        $response = $this->actingAs($user)
+            ->get("/super-admin/students/{$student->id}/enrollments");
+
+        $response->assertForbidden();
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes #457: View Enrollments returning 404 error
- Added route for viewing student enrollments at `/super-admin/students/{student}/enrollments`
- Created `enrollments()` controller method in SuperAdminStudentController
- Built React view component to display enrollment history
- Refactored map() to foreach loop for PHPStan compatibility

## Changes Made
- **Route:** Added GET route `/students/{student}/enrollments`
- **Controller:** Created `enrollments()` method to fetch and format enrollment data  
- **View:** Created `enrollments.tsx` React component with student info and enrollment table
- **Tests:** Added comprehensive browser tests and feature tests

## Testing
- ✅ Browser tests verify 404 is fixed and page renders correctly
- ✅ Feature tests cover authorization and data formatting
- ✅ All existing tests pass
- ✅ Code coverage above 60% threshold

## Test Coverage
- Super admin can view student enrollments without 404
- Students with and without enrollments display correctly
- Unauthorized users are properly blocked
- All enrollment data fields are properly formatted

Closes #457