### PR TITLE
feat: verify enrollment_periods migration and add enum casting (#474)

### DIFF
--- a/app/Models/EnrollmentPeriod.php
+++ b/app/Models/EnrollmentPeriod.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\EnrollmentPeriodStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,6 +31,7 @@ class EnrollmentPeriod extends Model
         'early_registration_deadline' => 'date',
         'regular_registration_deadline' => 'date',
         'late_registration_deadline' => 'date',
+        'status' => EnrollmentPeriodStatus::class,
         'allow_new_students' => 'boolean',
         'allow_returning_students' => 'boolean',
     ];
@@ -49,32 +51,32 @@ class EnrollmentPeriod extends Model
             }
 
             // Only one active period at a time
-            if ($period->status === 'active') {
-                static::where('status', 'active')
+            if ($period->status === EnrollmentPeriodStatus::ACTIVE) {
+                static::where('status', EnrollmentPeriodStatus::ACTIVE)
                     ->where('id', '!=', $period->id)
-                    ->update(['status' => 'closed']);
+                    ->update(['status' => EnrollmentPeriodStatus::CLOSED]);
             }
         });
     }
 
     public function scopeActive($query)
     {
-        return $query->where('status', 'active');
+        return $query->where('status', EnrollmentPeriodStatus::ACTIVE);
     }
 
     public function scopeUpcoming($query)
     {
-        return $query->where('status', 'upcoming');
+        return $query->where('status', EnrollmentPeriodStatus::UPCOMING);
     }
 
     public function scopeClosed($query)
     {
-        return $query->where('status', 'closed');
+        return $query->where('status', EnrollmentPeriodStatus::CLOSED);
     }
 
     public function isActive(): bool
     {
-        return $this->status === 'active';
+        return $this->status === EnrollmentPeriodStatus::ACTIVE;
     }
 
     public function isOpen(): bool

--- a/tests/Browser/EnrollmentPeriodMigrationTest.php
+++ b/tests/Browser/EnrollmentPeriodMigrationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Enums\EnrollmentPeriodStatus;
+use App\Models\EnrollmentPeriod;
+use App\Models\SchoolYear;
+use Database\Seeders\RolesAndPermissionsSeeder;
+use Illuminate\Support\Facades\Schema;
+
+uses(\Illuminate\Foundation\Testing\DatabaseMigrations::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+describe('Enrollment Period Migration', function () {
+
+    test('enrollment_periods table exists with all required columns', function () {
+        expect(Schema::hasTable('enrollment_periods'))->toBeTrue();
+
+        // Verify all required columns exist
+        $columns = [
+            'id',
+            'school_year_id',
+            'start_date',
+            'end_date',
+            'early_registration_deadline',
+            'regular_registration_deadline',
+            'late_registration_deadline',
+            'status',
+            'description',
+            'allow_new_students',
+            'allow_returning_students',
+            'created_at',
+            'updated_at',
+        ];
+
+        foreach ($columns as $column) {
+            expect(Schema::hasColumn('enrollment_periods', $column))
+                ->toBeTrue("Column {$column} should exist in enrollment_periods table");
+        }
+    })->group('enrollment-period', 'migration');
+
+    test('can create enrollment period with all required fields', function () {
+        $schoolYear = SchoolYear::factory()->create([
+            'name' => '2025-2026',
+            'start_year' => 2025,
+            'end_year' => 2026,
+        ]);
+
+        $period = EnrollmentPeriod::create([
+            'school_year_id' => $schoolYear->id,
+            'start_date' => '2025-06-01',
+            'end_date' => '2026-05-31',
+            'early_registration_deadline' => '2025-07-15',
+            'regular_registration_deadline' => '2025-08-31',
+            'late_registration_deadline' => '2025-09-15',
+            'status' => EnrollmentPeriodStatus::ACTIVE,
+            'description' => 'School Year 2025-2026 Enrollment Period',
+            'allow_new_students' => true,
+            'allow_returning_students' => true,
+        ]);
+
+        expect($period->exists())->toBeTrue();
+        expect($period->school_year_id)->toBe($schoolYear->id);
+        expect($period->start_date->format('Y-m-d'))->toBe('2025-06-01');
+        expect($period->end_date->format('Y-m-d'))->toBe('2026-05-31');
+        expect($period->early_registration_deadline->format('Y-m-d'))->toBe('2025-07-15');
+        expect($period->regular_registration_deadline->format('Y-m-d'))->toBe('2025-08-31');
+        expect($period->late_registration_deadline->format('Y-m-d'))->toBe('2025-09-15');
+        expect($period->status)->toBe(EnrollmentPeriodStatus::ACTIVE);
+        expect($period->description)->toBe('School Year 2025-2026 Enrollment Period');
+        expect($period->allow_new_students)->toBeTrue();
+        expect($period->allow_returning_students)->toBeTrue();
+    })->group('enrollment-period', 'migration');
+
+    test('enrollment period status enum works correctly', function () {
+        $schoolYear = SchoolYear::factory()->create();
+
+        // Test ACTIVE status
+        $activePeriod = EnrollmentPeriod::factory()->create([
+            'school_year_id' => $schoolYear->id,
+            'status' => EnrollmentPeriodStatus::ACTIVE,
+        ]);
+        expect($activePeriod->status)->toBe(EnrollmentPeriodStatus::ACTIVE);
+        expect($activePeriod->isActive())->toBeTrue();
+
+        // Test UPCOMING status
+        $upcomingPeriod = EnrollmentPeriod::factory()->create([
+            'school_year_id' => $schoolYear->id,
+            'status' => EnrollmentPeriodStatus::UPCOMING,
+        ]);
+        expect($upcomingPeriod->status)->toBe(EnrollmentPeriodStatus::UPCOMING);
+        expect($upcomingPeriod->isActive())->toBeFalse();
+
+        // Test CLOSED status
+        $closedPeriod = EnrollmentPeriod::factory()->create([
+            'school_year_id' => $schoolYear->id,
+            'status' => EnrollmentPeriodStatus::CLOSED,
+        ]);
+        expect($closedPeriod->status)->toBe(EnrollmentPeriodStatus::CLOSED);
+        expect($closedPeriod->isActive())->toBeFalse();
+    })->group('enrollment-period', 'migration');
+
+    test('enrollment period boolean fields default correctly', function () {
+        $schoolYear = SchoolYear::factory()->create();
+
+        $period = EnrollmentPeriod::factory()->create([
+            'school_year_id' => $schoolYear->id,
+        ]);
+
+        expect($period->allow_new_students)->toBeTrue();
+        expect($period->allow_returning_students)->toBeTrue();
+    })->group('enrollment-period', 'migration');
+
+    test('enrollment period nullable fields work correctly', function () {
+        $schoolYear = SchoolYear::factory()->create();
+
+        $period = EnrollmentPeriod::create([
+            'school_year_id' => $schoolYear->id,
+            'start_date' => '2025-06-01',
+            'end_date' => '2026-05-31',
+            'regular_registration_deadline' => '2025-08-31',
+            'status' => EnrollmentPeriodStatus::UPCOMING,
+            // Omit nullable fields
+        ]);
+
+        expect($period->exists())->toBeTrue();
+        expect($period->early_registration_deadline)->toBeNull();
+        expect($period->late_registration_deadline)->toBeNull();
+        expect($period->description)->toBeNull();
+    })->group('enrollment-period', 'migration');
+
+    test('enrollment period scope methods work correctly', function () {
+        $schoolYear = SchoolYear::factory()->create();
+
+        EnrollmentPeriod::factory()->active()->create(['school_year_id' => $schoolYear->id]);
+        EnrollmentPeriod::factory()->upcoming()->create(['school_year_id' => $schoolYear->id]);
+        EnrollmentPeriod::factory()->closed()->create(['school_year_id' => $schoolYear->id]);
+
+        expect(EnrollmentPeriod::active()->count())->toBe(1);
+        expect(EnrollmentPeriod::upcoming()->count())->toBe(1);
+        expect(EnrollmentPeriod::closed()->count())->toBe(1);
+    })->group('enrollment-period', 'migration');
+});

--- a/tests/Feature/Guardian/EnrollmentPeriodValidationTest.php
+++ b/tests/Feature/Guardian/EnrollmentPeriodValidationTest.php
@@ -89,7 +89,7 @@ test('guardian cannot view create form when no active enrollment period', functi
     // Debug: Check what periods exist
     $periods = EnrollmentPeriod::all();
     expect($periods)->toHaveCount(1);
-    expect($periods->first()->status)->toBe('upcoming');
+    expect($periods->first()->status)->toBe(EnrollmentPeriodStatus::UPCOMING);
 
     // Verify no active periods exist
     $activePeriod = EnrollmentPeriod::where('status', 'active')->first();

--- a/tests/Feature/SuperAdmin/EnrollmentPeriodControllerTest.php
+++ b/tests/Feature/SuperAdmin/EnrollmentPeriodControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\EnrollmentPeriodStatus;
 use App\Models\Enrollment;
 use App\Models\EnrollmentPeriod;
 use App\Models\User;
@@ -325,7 +326,7 @@ test('cannot delete active enrollment period', function () {
 
 test('cannot delete period with existing enrollments', function () {
     $period = EnrollmentPeriod::factory()->schoolYear('2025-2026')->create([
-        'status' => 'completed',
+        'status' => EnrollmentPeriodStatus::CLOSED,
         'start_date' => now()->subYear(),
         'end_date' => now()->subMonths(2),
         'regular_registration_deadline' => now()->subMonths(10),
@@ -370,7 +371,7 @@ test('super admin can activate enrollment period', function () {
     $response->assertSessionHas('success');
 
     $period->refresh();
-    expect($period->status)->toBe('active');
+    expect($period->status)->toBe(EnrollmentPeriodStatus::ACTIVE);
 });
 
 test('activating period closes other active periods', function () {
@@ -398,8 +399,8 @@ test('activating period closes other active periods', function () {
     $oldPeriod->refresh();
     $newPeriod->refresh();
 
-    expect($oldPeriod->status)->toBe('closed');
-    expect($newPeriod->status)->toBe('active');
+    expect($oldPeriod->status)->toBe(EnrollmentPeriodStatus::CLOSED);
+    expect($newPeriod->status)->toBe(EnrollmentPeriodStatus::ACTIVE);
 });
 
 test('activating period logs activity', function () {
@@ -443,7 +444,7 @@ test('super admin can close active enrollment period', function () {
     $response->assertSessionHas('success');
 
     $period->refresh();
-    expect($period->status)->toBe('closed');
+    expect($period->status)->toBe(EnrollmentPeriodStatus::CLOSED);
 });
 
 test('cannot close non-active enrollment period', function () {
@@ -462,7 +463,7 @@ test('cannot close non-active enrollment period', function () {
     $response->assertSessionHasErrors('period');
 
     $period->refresh();
-    expect($period->status)->toBe('upcoming');
+    expect($period->status)->toBe(EnrollmentPeriodStatus::UPCOMING);
 });
 
 test('closing period logs activity', function () {

--- a/tests/Feature/UpdateEnrollmentPeriodStatusCommandTest.php
+++ b/tests/Feature/UpdateEnrollmentPeriodStatusCommandTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\EnrollmentPeriodStatus;
 use App\Models\EnrollmentPeriod;
 use App\Models\User;
 use App\Notifications\EnrollmentPeriodStatusChangedNotification;
@@ -64,7 +65,7 @@ test('command activates upcoming periods when start date is reached', function (
     Artisan::call('enrollment-periods:update-status');
 
     $period->refresh();
-    expect($period->status)->toBe('active');
+    expect($period->status)->toBe(EnrollmentPeriodStatus::ACTIVE);
 });
 
 test('command closes active periods when end date is passed', function () {
@@ -83,7 +84,7 @@ test('command closes active periods when end date is passed', function () {
     Artisan::call('enrollment-periods:update-status');
 
     $period->refresh();
-    expect($period->status)->toBe('closed');
+    expect($period->status)->toBe(EnrollmentPeriodStatus::CLOSED);
 });
 
 test('command does not change periods that are not ready', function () {
@@ -116,8 +117,8 @@ test('command does not change periods that are not ready', function () {
     $upcomingPeriod->refresh();
     $activePeriod->refresh();
 
-    expect($upcomingPeriod->status)->toBe('upcoming');
-    expect($activePeriod->status)->toBe('active');
+    expect($upcomingPeriod->status)->toBe(EnrollmentPeriodStatus::UPCOMING);
+    expect($activePeriod->status)->toBe(EnrollmentPeriodStatus::ACTIVE);
 });
 
 test('command closes previously active periods when activating new period', function () {
@@ -150,8 +151,8 @@ test('command closes previously active periods when activating new period', func
     $oldPeriod->refresh();
     $newPeriod->refresh();
 
-    expect($oldPeriod->status)->toBe('closed');
-    expect($newPeriod->status)->toBe('active');
+    expect($oldPeriod->status)->toBe(EnrollmentPeriodStatus::CLOSED);
+    expect($newPeriod->status)->toBe(EnrollmentPeriodStatus::ACTIVE);
 });
 
 test('command runs successfully with dry-run option', function () {
@@ -170,7 +171,7 @@ test('command runs successfully with dry-run option', function () {
     Artisan::call('enrollment-periods:update-status', ['--dry-run' => true]);
 
     $period->refresh();
-    expect($period->status)->toBe('upcoming');
+    expect($period->status)->toBe(EnrollmentPeriodStatus::UPCOMING);
 });
 
 test('command sends notifications when notify option is used', function () {
@@ -311,7 +312,7 @@ test('command handles multiple periods correctly', function () {
     Artisan::call('enrollment-periods:update-status');
 
     $toClose->refresh();
-    expect($toClose->status)->toBe('closed');
+    expect($toClose->status)->toBe(EnrollmentPeriodStatus::CLOSED);
 
     $activeCount = EnrollmentPeriod::where('status', 'active')->count();
     expect($activeCount)->toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
## Summary
Addresses issue #474 by verifying the enrollment_periods migration exists with all required fields and improving the codebase with proper enum casting.

## Changes
- ✅ Verified enrollment_periods migration exists with all required fields:
  - school_year_id (foreign key to school_years)
  - start_date, end_date
  - early_registration_deadline, regular_registration_deadline, late_registration_deadline
  - status, description
  - allow_new_students, allow_returning_students
  - timestamps
- ✨ Added EnrollmentPeriodStatus enum casting to EnrollmentPeriod model
- 🔧 Updated all model methods to use enum constants instead of strings
- ✅ Created comprehensive browser tests for migration verification (6 tests, 40 assertions)
- 🔧 Updated existing tests to use enum instead of string comparisons
- ✅ All tests passing with 60.6% coverage

## Test Results
```
✅ Tests: 888 passed (3549 assertions)
✅ Coverage: 60.6% (exceeds 60% minimum)
✅ Browser Tests: 6 passed
✅ All CI/CD checks: PASSED
```

## Note
The enrollment_periods table was already created in migration `2025_10_11_174123_create_enrollment_periods_table.php` before this issue was reported. This PR verifies the migration meets all requirements and adds proper enum casting for improved type safety.

Closes #474