### PR TITLE
feat: add audit logs cleanup command with scheduling (#485)

### DIFF
--- a/app/Console/Commands/CleanAuditLogs.php
+++ b/app/Console/Commands/CleanAuditLogs.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\Activitylog\Models\Activity;
+
+class CleanAuditLogs extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'audit-logs:clean
+                            {--days=90 : Number of days to keep audit logs}
+                            {--dry-run : Show what would be deleted without actually deleting}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete audit logs older than the specified number of days';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $days = (int) $this->option('days');
+        $dryRun = $this->option('dry-run');
+
+        if ($days <= 0) {
+            $this->error('Days must be a positive integer.');
+
+            return self::FAILURE;
+        }
+
+        $cutoffDate = now()->subDays($days);
+
+        $this->info("Cleaning audit logs older than {$days} days (before {$cutoffDate->toDateString()})...");
+
+        // Get count of logs to delete
+        $count = Activity::where('created_at', '<', $cutoffDate)->count();
+
+        if ($count === 0) {
+            $this->info('No audit logs to clean.');
+
+            return self::SUCCESS;
+        }
+
+        if ($dryRun) {
+            $this->warn("DRY RUN: Would delete {$count} audit log(s).");
+            $this->info('Run without --dry-run to actually delete the logs.');
+
+            return self::SUCCESS;
+        }
+
+        // Delete old logs
+        $deleted = Activity::where('created_at', '<', $cutoffDate)->delete();
+
+        $this->info("Successfully deleted {$deleted} audit log(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -20,3 +20,10 @@ Schedule::command('enrollment:send-payment-reminders')
     ->timezone('Asia/Manila')
     ->withoutOverlapping()
     ->onOneServer();
+
+// Audit logs cleanup - runs daily at 2 AM, keeps logs for 90 days
+Schedule::command('audit-logs:clean --days=90')
+    ->dailyAt('02:00')
+    ->timezone('Asia/Manila')
+    ->withoutOverlapping()
+    ->onOneServer();

--- a/tests/Feature/CleanAuditLogsCommandTest.php
+++ b/tests/Feature/CleanAuditLogsCommandTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Spatie\Activitylog\Models\Activity;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('Clean Audit Logs Command', function () {
+
+    test('command deletes logs older than specified days', function () {
+        // Create recent logs (within 90 days)
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Recent activity',
+            'created_at' => now()->subDays(30),
+        ]);
+
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Recent activity 2',
+            'created_at' => now()->subDays(60),
+        ]);
+
+        // Create old logs (older than 90 days)
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Old activity',
+            'created_at' => now()->subDays(100),
+        ]);
+
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Old activity 2',
+            'created_at' => now()->subDays(120),
+        ]);
+
+        expect(Activity::count())->toBe(4);
+
+        // Run command
+        Artisan::call('audit-logs:clean', ['--days' => 90]);
+
+        // Should delete 2 old logs, keep 2 recent logs
+        expect(Activity::count())->toBe(2);
+    })->group('audit-logs', 'command');
+
+    test('command with dry-run does not delete logs', function () {
+        // Create old logs
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Old activity',
+            'created_at' => now()->subDays(100),
+        ]);
+
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Old activity 2',
+            'created_at' => now()->subDays(120),
+        ]);
+
+        expect(Activity::count())->toBe(2);
+
+        // Run command with dry-run
+        Artisan::call('audit-logs:clean', ['--days' => 90, '--dry-run' => true]);
+
+        // Should not delete any logs
+        expect(Activity::count())->toBe(2);
+    })->group('audit-logs', 'command');
+
+    test('command returns success when no logs to delete', function () {
+        // Create only recent logs
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Recent activity',
+            'created_at' => now()->subDays(30),
+        ]);
+
+        $exitCode = Artisan::call('audit-logs:clean', ['--days' => 90]);
+
+        expect($exitCode)->toBe(0);
+    })->group('audit-logs', 'command');
+
+    test('command returns failure for invalid days parameter', function () {
+        $exitCode = Artisan::call('audit-logs:clean', ['--days' => 0]);
+
+        expect($exitCode)->toBe(1);
+
+        $exitCode = Artisan::call('audit-logs:clean', ['--days' => -10]);
+
+        expect($exitCode)->toBe(1);
+    })->group('audit-logs', 'command');
+
+    test('command uses default 90 days when no parameter provided', function () {
+        // Create old logs (older than 90 days)
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Old activity',
+            'created_at' => now()->subDays(100),
+        ]);
+
+        // Create recent log
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Recent activity',
+            'created_at' => now()->subDays(30),
+        ]);
+
+        expect(Activity::count())->toBe(2);
+
+        // Run command without days parameter (should use default 90)
+        Artisan::call('audit-logs:clean');
+
+        expect(Activity::count())->toBe(1);
+    })->group('audit-logs', 'command');
+
+    test('command can delete logs with custom retention period', function () {
+        // Create logs at different ages
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Activity 15 days old',
+            'created_at' => now()->subDays(15),
+        ]);
+
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Activity 40 days old',
+            'created_at' => now()->subDays(40),
+        ]);
+
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Activity 100 days old',
+            'created_at' => now()->subDays(100),
+        ]);
+
+        expect(Activity::count())->toBe(3);
+
+        // Delete logs older than 30 days
+        Artisan::call('audit-logs:clean', ['--days' => 30]);
+
+        // Should keep 1 log (15 days old), delete 2 logs (40 and 100 days old)
+        expect(Activity::count())->toBe(1);
+    })->group('audit-logs', 'command');
+
+    test('command output shows correct counts', function () {
+        // Create old logs
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Old activity 1',
+            'created_at' => now()->subDays(100),
+        ]);
+
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Old activity 2',
+            'created_at' => now()->subDays(120),
+        ]);
+
+        Activity::create([
+            'log_name' => 'default',
+            'description' => 'Old activity 3',
+            'created_at' => now()->subDays(150),
+        ]);
+
+        Artisan::call('audit-logs:clean', ['--days' => 90]);
+
+        $output = Artisan::output();
+
+        expect($output)->toContain('Successfully deleted 3 audit log(s)');
+    })->group('audit-logs', 'command');
+});


### PR DESCRIPTION
## Summary
Addresses issue #485 by implementing an audit logs cleanup command with configurable retention and automatic scheduling.

## Changes
- ✨ Created `audit-logs:clean` artisan command
- 🔧 Configurable retention period via `--days` option (default: 90 days)
- 🧪 Dry-run mode via `--dry-run` option for testing
- ⏰ Scheduled to run daily at 2 AM Manila time via Laravel Scheduler
- ✅ Comprehensive tests (7 tests, 12 assertions)
- 📊 All tests passing with 60.7% coverage

## Command Usage
```bash
# Delete logs older than 90 days (default)
php artisan audit-logs:clean

# Delete logs older than 30 days
php artisan audit-logs:clean --days=30

# Test what would be deleted without actually deleting
php artisan audit-logs:clean --dry-run
```

## Scheduling
The command is automatically scheduled to run daily at 2:00 AM Manila time with:
- 90-day retention period
- Prevents overlapping executions
- Runs on single server only (for multi-server setups)

## Test Results
```
✅ Tests: 904 passed (3614 assertions)
✅ Coverage: 60.7% (exceeds 60% minimum)
✅ Feature Tests: 7 passed
✅ All CI/CD checks: PASSED
```

Closes #485