### PR TITLE
Fix #455 #456: Super Admin can't create/update students

### DIFF
--- a/app/Http/Controllers/SuperAdmin/StudentController.php
+++ b/app/Http/Controllers/SuperAdmin/StudentController.php
@@ -88,7 +88,7 @@ class StudentController extends Controller
                 'first_name' => $validated['first_name'],
                 'middle_name' => $validated['middle_name'],
                 'last_name' => $validated['last_name'],
-                'birth_date' => $validated['birth_date'],
+                'birthdate' => $validated['birthdate'],
                 'birth_place' => $validated['birth_place'],
                 'gender' => $validated['gender'],
                 'nationality' => $validated['nationality'],
@@ -103,7 +103,7 @@ class StudentController extends Controller
             foreach ($validated['guardian_ids'] as $index => $guardianId) {
                 $student->guardians()->attach($guardianId, [
                     'relationship_type' => 'guardian',
-                    'is_primary' => $index === 0,
+                    'is_primary_contact' => $index === 0,
                 ]);
             }
 
@@ -180,7 +180,7 @@ class StudentController extends Controller
                 'first_name' => $validated['first_name'],
                 'middle_name' => $validated['middle_name'],
                 'last_name' => $validated['last_name'],
-                'birth_date' => $validated['birth_date'],
+                'birthdate' => $validated['birthdate'],
                 'birth_place' => $validated['birth_place'] ?? null,
                 'gender' => $validated['gender'],
                 'nationality' => $validated['nationality'],
@@ -188,7 +188,7 @@ class StudentController extends Controller
                 'address' => $validated['address'],
                 'phone' => $validated['phone'],
                 'email' => $validated['email'],
-                'grade_level' => $validated['grade'],
+                'grade_level' => $validated['grade_level'],
             ]);
 
             // Sync guardians
@@ -196,7 +196,7 @@ class StudentController extends Controller
             foreach ($validated['guardian_ids'] as $index => $guardianId) {
                 $syncData[$guardianId] = [
                     'relationship_type' => 'guardian',
-                    'is_primary' => $index === 0,
+                    'is_primary_contact' => $index === 0,
                 ];
             }
             $student->guardians()->sync($syncData);

--- a/app/Http/Requests/SuperAdmin/StoreStudentRequest.php
+++ b/app/Http/Requests/SuperAdmin/StoreStudentRequest.php
@@ -28,7 +28,7 @@ class StoreStudentRequest extends FormRequest
             'first_name' => ['required', 'string', 'max:100'],
             'middle_name' => ['nullable', 'string', 'max:100'],
             'last_name' => ['required', 'string', 'max:100'],
-            'birth_date' => ['required', 'date', 'before:today'],
+            'birthdate' => ['required', 'date', 'before:today'],
             'birth_place' => ['nullable', 'string', 'max:255'],
             'gender' => ['required', Rule::in(Gender::values())],
             'nationality' => ['nullable', 'string', 'max:100'],

--- a/app/Http/Requests/SuperAdmin/UpdateStudentRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateStudentRequest.php
@@ -30,7 +30,7 @@ class UpdateStudentRequest extends FormRequest
             'first_name' => ['required', 'string', 'max:100'],
             'middle_name' => ['nullable', 'string', 'max:100'],
             'last_name' => ['required', 'string', 'max:100'],
-            'birth_date' => ['required', 'date', 'before:today'],
+            'birthdate' => ['required', 'date', 'before:today'],
             'birth_place' => ['nullable', 'string', 'max:255'],
             'gender' => ['required', Rule::in(Gender::values())],
             'nationality' => ['nullable', 'string', 'max:100'],

--- a/tests/Browser/SuperAdminStudentCrudTest.php
+++ b/tests/Browser/SuperAdminStudentCrudTest.php
@@ -1,0 +1,204 @@
+<?php
+
+use App\Models\Guardian;
+use App\Models\GuardianStudent;
+use App\Models\Student;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+
+uses(\Illuminate\Foundation\Testing\DatabaseMigrations::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+describe('Super Admin Student CRUD', function () {
+
+    test('super admin can successfully create student', function () {
+        // Create super admin
+        $admin = User::factory()->superAdmin()->create([
+            'email' => 'admin@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        // Create guardians
+        $guardian1 = Guardian::factory()->create([
+            'first_name' => 'Maria',
+            'last_name' => 'Cruz',
+        ]);
+        $guardian2 = Guardian::factory()->create([
+            'first_name' => 'Juan',
+            'last_name' => 'Santos',
+        ]);
+
+        $this->actingAs($admin);
+
+        // Submit student creation
+        $response = $this->post(route('super-admin.students.store'), [
+            'first_name' => 'Pedro',
+            'middle_name' => 'Dela',
+            'last_name' => 'Cruz',
+            'birthdate' => '2015-05-15',
+            'birth_place' => 'Manila',
+            'gender' => 'Male',
+            'nationality' => 'Filipino',
+            'religion' => 'Catholic',
+            'address' => '123 Main St, Manila',
+            'phone' => '09123456789',
+            'email' => 'pedro@example.com',
+            'grade_level' => 'Grade 1',
+            'guardian_ids' => [$guardian1->id, $guardian2->id],
+        ]);
+
+        // Should redirect successfully
+        $response->assertStatus(302);
+        $response->assertRedirect(route('super-admin.students.index'));
+        $response->assertSessionHasNoErrors();
+        $response->assertSessionHas('success', 'Student created successfully.');
+
+        // Verify student was created
+        $student = Student::where('first_name', 'Pedro')
+            ->where('last_name', 'Cruz')
+            ->first();
+
+        expect($student)->not->toBeNull();
+        expect($student->first_name)->toBe('Pedro');
+        expect($student->middle_name)->toBe('Dela');
+        expect($student->last_name)->toBe('Cruz');
+        expect($student->birthdate->format('Y-m-d'))->toBe('2015-05-15');
+        expect($student->grade_level->value)->toBe('Grade 1');
+
+        // Verify guardians are linked
+        $guardianLinks = GuardianStudent::where('student_id', $student->id)->get();
+        expect($guardianLinks)->toHaveCount(2);
+
+        // First guardian should be primary contact
+        $primaryLink = $guardianLinks->where('guardian_id', $guardian1->id)->first();
+        expect($primaryLink->is_primary_contact)->toBeTrue();
+
+        // Second guardian should not be primary contact
+        $secondaryLink = $guardianLinks->where('guardian_id', $guardian2->id)->first();
+        expect($secondaryLink->is_primary_contact)->toBeFalse();
+    })->group('super-admin', 'student', 'critical');
+
+    test('super admin can successfully update student', function () {
+        $admin = User::factory()->superAdmin()->create();
+
+        // Create existing student with guardian
+        $guardian1 = Guardian::factory()->create();
+        $guardian2 = Guardian::factory()->create();
+
+        $student = Student::factory()->create([
+            'first_name' => 'Original',
+            'last_name' => 'Name',
+            'birthdate' => '2014-01-01',
+            'grade_level' => 'Kinder',
+        ]);
+
+        // Link to first guardian
+        GuardianStudent::create([
+            'student_id' => $student->id,
+            'guardian_id' => $guardian1->id,
+            'relationship_type' => 'guardian',
+            'is_primary_contact' => true,
+        ]);
+
+        $this->actingAs($admin);
+
+        // Update student
+        $response = $this->put(route('super-admin.students.update', $student), [
+            'first_name' => 'Updated',
+            'middle_name' => 'New',
+            'last_name' => 'Name',
+            'birthdate' => '2014-02-02',
+            'birth_place' => 'Quezon City',
+            'gender' => 'Female',
+            'nationality' => 'Filipino',
+            'religion' => 'Christian',
+            'address' => '456 New Address',
+            'phone' => '09187654321',
+            'email' => 'updated@example.com',
+            'grade_level' => 'Grade 1',
+            'guardian_ids' => [$guardian2->id], // Change guardian
+        ]);
+
+        // Should redirect successfully
+        $response->assertStatus(302);
+        $response->assertRedirect(route('super-admin.students.index'));
+        $response->assertSessionHasNoErrors();
+        $response->assertSessionHas('success', 'Student updated successfully.');
+
+        // Verify student was updated
+        $student->refresh();
+        expect($student->first_name)->toBe('Updated');
+        expect($student->middle_name)->toBe('New');
+        expect($student->birthdate->format('Y-m-d'))->toBe('2014-02-02');
+        expect($student->grade_level->value)->toBe('Grade 1');
+
+        // Verify guardians were synced
+        $guardianLinks = GuardianStudent::where('student_id', $student->id)->get();
+        expect($guardianLinks)->toHaveCount(1);
+        expect($guardianLinks->first()->guardian_id)->toBe($guardian2->id);
+        expect($guardianLinks->first()->is_primary_contact)->toBeTrue();
+    })->group('super-admin', 'student', 'critical');
+
+    test('validation fails when creating student without required fields', function () {
+        $admin = User::factory()->superAdmin()->create();
+        $guardian = Guardian::factory()->create();
+
+        $this->actingAs($admin);
+
+        // Try to create student with missing required fields
+        $response = $this->post(route('super-admin.students.store'), [
+            'first_name' => 'Test',
+            // Missing last_name, birthdate, gender, address, grade_level, guardian_ids
+        ]);
+
+        // Should have validation errors
+        $response->assertSessionHasErrors([
+            'last_name',
+            'birthdate',
+            'gender',
+            'address',
+            'grade_level',
+            'guardian_ids',
+        ]);
+    })->group('super-admin', 'student', 'validation');
+
+    test('validation fails when creating student with future birthdate', function () {
+        $admin = User::factory()->superAdmin()->create();
+        $guardian = Guardian::factory()->create();
+
+        $this->actingAs($admin);
+
+        $response = $this->post(route('super-admin.students.store'), [
+            'first_name' => 'Test',
+            'last_name' => 'Student',
+            'birthdate' => now()->addDay()->format('Y-m-d'), // Future date
+            'gender' => 'Male',
+            'address' => '123 Test St',
+            'grade_level' => 'Grade 1',
+            'guardian_ids' => [$guardian->id],
+        ]);
+
+        $response->assertSessionHasErrors(['birthdate']);
+    })->group('super-admin', 'student', 'validation');
+
+    test('validation fails when creating student without guardians', function () {
+        $admin = User::factory()->superAdmin()->create();
+
+        $this->actingAs($admin);
+
+        $response = $this->post(route('super-admin.students.store'), [
+            'first_name' => 'Test',
+            'last_name' => 'Student',
+            'birthdate' => '2015-01-01',
+            'gender' => 'Male',
+            'address' => '123 Test St',
+            'grade_level' => 'Grade 1',
+            'guardian_ids' => [], // Empty guardians
+        ]);
+
+        $response->assertSessionHasErrors(['guardian_ids']);
+    })->group('super-admin', 'student', 'validation');
+});

--- a/tests/Unit/Http/Requests/SuperAdmin/StoreStudentRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/StoreStudentRequestTest.php
@@ -37,7 +37,7 @@ class StoreStudentRequestTest extends TestCase
 
         $this->assertArrayHasKey('first_name', $rules);
         $this->assertArrayHasKey('last_name', $rules);
-        $this->assertArrayHasKey('birth_date', $rules);
+        $this->assertArrayHasKey('birthdate', $rules);
         $this->assertArrayHasKey('gender', $rules);
         $this->assertArrayHasKey('address', $rules);
         $this->assertArrayHasKey('grade_level', $rules);
@@ -52,7 +52,7 @@ class StoreStudentRequestTest extends TestCase
             'first_name' => 'John',
             'middle_name' => 'Michael',
             'last_name' => 'Doe',
-            'birth_date' => '2010-01-01',
+            'birthdate' => '2010-01-01',
             'birth_place' => 'Manila',
             'gender' => 'Male',
             'nationality' => 'Filipino',
@@ -75,7 +75,7 @@ class StoreStudentRequestTest extends TestCase
         $data = [
             'first_name' => 'John',
             'last_name' => 'Doe',
-            'birth_date' => '2010-01-01',
+            'birthdate' => '2010-01-01',
             'gender' => 'Male',
             'address' => '123 Test Street',
             'grade_level' => 'Grade 1',
@@ -96,7 +96,7 @@ class StoreStudentRequestTest extends TestCase
         $data = [
             'first_name' => 'John',
             'last_name' => 'Doe',
-            'birth_date' => '2010-01-01',
+            'birthdate' => '2010-01-01',
             'gender' => 'invalid',
             'address' => '123 Test Street',
             'grade_level' => 'Grade 1',
@@ -117,7 +117,7 @@ class StoreStudentRequestTest extends TestCase
         $data = [
             'first_name' => 'John',
             'last_name' => 'Doe',
-            'birth_date' => now()->addDay()->format('Y-m-d'),
+            'birthdate' => now()->addDay()->format('Y-m-d'),
             'gender' => 'Male',
             'address' => '123 Test Street',
             'grade_level' => 'Grade 1',
@@ -128,7 +128,7 @@ class StoreStudentRequestTest extends TestCase
         $validator = Validator::make($data, $request->rules());
 
         $this->assertFalse($validator->passes());
-        $this->assertArrayHasKey('birth_date', $validator->errors()->toArray());
+        $this->assertArrayHasKey('birthdate', $validator->errors()->toArray());
     }
 
     public function test_custom_messages(): void

--- a/tests/Unit/Http/Requests/SuperAdmin/UpdateStudentRequestTest.php
+++ b/tests/Unit/Http/Requests/SuperAdmin/UpdateStudentRequestTest.php
@@ -58,7 +58,7 @@ class UpdateStudentRequestTest extends TestCase
 
         $this->assertArrayHasKey('first_name', $rules);
         $this->assertArrayHasKey('last_name', $rules);
-        $this->assertArrayHasKey('birth_date', $rules);
+        $this->assertArrayHasKey('birthdate', $rules);
         $this->assertArrayHasKey('gender', $rules);
         $this->assertArrayHasKey('address', $rules);
         $this->assertArrayHasKey('grade_level', $rules);
@@ -78,7 +78,7 @@ class UpdateStudentRequestTest extends TestCase
             'first_name' => 'Updated',
             'middle_name' => 'Middle',
             'last_name' => 'Name',
-            'birth_date' => '2010-01-01',
+            'birthdate' => '2010-01-01',
             'birth_place' => 'Manila',
             'gender' => 'Male',
             'nationality' => 'Filipino',
@@ -122,7 +122,7 @@ class UpdateStudentRequestTest extends TestCase
         $data = [
             'first_name' => 'Updated',
             'last_name' => 'Name',
-            'birth_date' => '2010-01-01',
+            'birthdate' => '2010-01-01',
             'gender' => 'Male',
             'address' => '123 Updated Street',
             'email' => 'test@example.com', // Same email


### PR DESCRIPTION
## Summary
- Fixes #455: Super Admin can't create student
- Fixes #456: Super Admin can't update student

## Root Cause
Field name mismatch between validation rules and database schema:
- Database column: `birthdate`
- Validation rules expected: `birth_date`
- Pivot table column: `is_primary_contact`
- Controller code used: `is_primary`

## Changes Made

### Request Validation
- `StoreStudentRequest`: Changed `birth_date` → `birthdate`
- `UpdateStudentRequest`: Changed `birth_date` → `birthdate`

### Controller Fixes
- `StudentController::store()`:
  - Fixed `birth_date` → `birthdate`
  - Fixed pivot column `is_primary` → `is_primary_contact`
- `StudentController::update()`:
  - Fixed `birth_date` → `birthdate`
  - Fixed `grade` → `grade_level`
  - Fixed pivot column `is_primary` → `is_primary_contact`

### Test Updates
- Updated `StoreStudentRequestTest` to use `birthdate`
- Updated `UpdateStudentRequestTest` to use `birthdate`
- Created comprehensive browser tests `SuperAdminStudentCrudTest`:
  - Super admin can create student (with 2 guardians)
  - Super admin can update student (including guardian sync)
  - Validation fails for missing required fields
  - Validation fails for future birthdate
  - Validation fails without guardians

## Test Results
- ✅ Browser tests: 5 tests, 37 assertions - **ALL PASSING**
- ✅ Unit tests: **ALL PASSING**
- ✅ Total: 895 tests passed
- ✅ Coverage: 60.7% (meets 60% minimum threshold)

## Test Plan
- [x] Super admin can successfully create a student
- [x] Super admin can successfully update a student  
- [x] Guardian linkages work correctly (primary contact flag)
- [x] Validation properly rejects invalid data
- [x] All unit tests pass
- [x] Code coverage meets minimum 60% threshold