### PR TITLE
Fix #459: Allow guardians to delete students from their account

### DIFF
--- a/app/Policies/StudentPolicy.php
+++ b/app/Policies/StudentPolicy.php
@@ -69,7 +69,17 @@ class StudentPolicy
      */
     public function delete(User $user, Student $student): bool
     {
-        return $user->hasAnyRole(['super_admin', 'administrator']);
+        // Super admins and administrators can delete any student
+        if ($user->hasAnyRole(['super_admin', 'administrator'])) {
+            return true;
+        }
+
+        // Guardians can delete (remove) students they are associated with
+        if ($user->hasRole('guardian') && $user->guardian) {
+            return $student->guardians()->where('guardians.id', $user->guardian->id)->exists();
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Browser/Issue459Test.php
+++ b/tests/Browser/Issue459Test.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Models\Guardian;
+use App\Models\GuardianStudent;
+use App\Models\Student;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+test('guardian can remove student from their account (no active enrollments)', function () {
+    // Seed roles and permissions
+    $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+
+    // Create a guardian user
+    $user = User::factory()->create();
+    $user->assignRole('guardian');
+
+    $guardianModel = Guardian::factory()->create(['user_id' => $user->id]);
+
+    // Create a student linked to this guardian
+    $student = Student::factory()->create([
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+    ]);
+
+    GuardianStudent::create([
+        'guardian_id' => $guardianModel->id,
+        'student_id' => $student->id,
+        'relationship_type' => 'mother',
+        'is_primary_contact' => true,
+    ]);
+
+    // Try to delete the student (remove from guardian's account)
+    $response = actingAs($user)
+        ->delete("/guardian/students/{$student->id}");
+
+    // Should redirect to students index with success message
+    $response->assertRedirect('/guardian/students');
+    $response->assertSessionHas('success', 'Student removed from your account successfully.');
+
+    // Verify the guardian-student relationship was removed
+    expect(GuardianStudent::where('guardian_id', $guardianModel->id)
+        ->where('student_id', $student->id)
+        ->exists())->toBeFalse();
+
+    // Verify the student still exists in the system
+    expect(Student::find($student->id))->not->toBeNull();
+})->group('browser', 'bug', 'issue-459');
+
+test('guardian cannot remove student with active enrollments', function () {
+    // Seed roles and permissions
+    $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+
+    // Create a guardian user
+    $user = User::factory()->create();
+    $user->assignRole('guardian');
+
+    $guardianModel = Guardian::factory()->create(['user_id' => $user->id]);
+
+    // Create a student with an active enrollment
+    $student = Student::factory()->create();
+
+    GuardianStudent::create([
+        'guardian_id' => $guardianModel->id,
+        'student_id' => $student->id,
+        'relationship_type' => 'father',
+        'is_primary_contact' => true,
+    ]);
+
+    // Create an active enrollment
+    \App\Models\Enrollment::factory()->create([
+        'student_id' => $student->id,
+        'guardian_id' => $guardianModel->id,
+        'status' => \App\Enums\EnrollmentStatus::ENROLLED,
+    ]);
+
+    // Try to delete the student
+    $response = actingAs($user)
+        ->delete("/guardian/students/{$student->id}");
+
+    // Should redirect back with error message
+    $response->assertRedirect("/guardian/students/{$student->id}");
+    $response->assertSessionHas('error', 'Cannot remove student with active or pending enrollments.');
+
+    // Verify the guardian-student relationship still exists
+    expect(GuardianStudent::where('guardian_id', $guardianModel->id)
+        ->where('student_id', $student->id)
+        ->exists())->toBeTrue();
+})->group('browser', 'bug', 'issue-459');


### PR DESCRIPTION
## Summary
Fixed the StudentPolicy to allow guardians to remove students from their account. Previously, only super_admin and administrator roles could delete students, which blocked guardians from using the "Remove Student" feature even though the controller logic was designed to handle guardian deletions.

## Changes Made
- **app/Policies/StudentPolicy.php**: Updated `delete()` method to allow guardians to delete students linked to their account, following the same authorization pattern as the `update()` method
- **tests/Browser/Issue459Test.php**: Created comprehensive browser tests covering:
  - Guardian can remove student when no active enrollments exist
  - Guardian cannot remove student with active/pending enrollments
  - Student record persists in system after guardian removes relationship

## Technical Details
The controller's `destroy()` method already had the correct logic to only remove the guardian-student relationship (not the actual student record), but the policy was incorrectly blocking guardians from accessing this functionality.

The fix ensures that:
1. Guardians can only delete students they are associated with
2. The actual student record remains in the system
3. Only the guardian-student relationship is removed
4. Students with active enrollments cannot be removed

## Test Results
- ✅ All 907 tests pass
- ✅ New browser tests verify the fix works correctly
- ✅ Pre-push checks passed (PHP syntax, Pint, PHPStan, security audit, Vite, TypeScript, Prettier, browser tests, coverage 60%+)

## Related Issue
Closes #459