### PR TITLE
Fix #472: Update document validation to JPEG/PNG only

### DIFF
--- a/app/Http/Requests/StoreDocumentRequest.php
+++ b/app/Http/Requests/StoreDocumentRequest.php
@@ -27,37 +27,27 @@ class StoreDocumentRequest extends FormRequest
             'document' => [
                 'required',
                 'file',
-                'mimes:jpeg,jpg,png,pdf',
+                'mimes:jpeg,jpg,png',
                 'max:51200', // 50MB in KB
                 function ($attribute, $value, $fail) {
                     // Verify actual file content, not just extension
                     $mimeType = $value->getMimeType();
-                    $allowedMimes = ['image/jpeg', 'image/png', 'application/pdf'];
+                    $allowedMimes = ['image/jpeg', 'image/png'];
 
                     if (! in_array($mimeType, $allowedMimes)) {
-                        $fail('The file must be a valid image (JPEG or PNG) or PDF document.');
+                        $fail('The file must be a valid JPEG or PNG image.');
 
                         return;
                     }
 
-                    // Check if file is actually an image (for image types)
-                    if (str_starts_with($mimeType, 'image/')) {
-                        try {
-                            $image = getimagesize($value->path());
-                            if ($image === false) {
-                                $fail('The file is not a valid image.');
-                            }
-                        } catch (\Exception $e) {
-                            $fail('The file could not be validated.');
+                    // Check if file is actually an image
+                    try {
+                        $image = getimagesize($value->path());
+                        if ($image === false) {
+                            $fail('The file is not a valid image.');
                         }
-                    }
-
-                    // For PDFs, verify it's actually a PDF (skip in testing to allow fake files)
-                    if ($mimeType === 'application/pdf' && ! app()->environment('testing')) {
-                        $fileContent = file_get_contents($value->path(), false, null, 0, 4);
-                        if ($fileContent !== '%PDF') {
-                            $fail('The file is not a valid PDF document.');
-                        }
+                    } catch (\Exception $e) {
+                        $fail('The file could not be validated.');
                     }
                 },
             ],
@@ -78,7 +68,7 @@ class StoreDocumentRequest extends FormRequest
         return [
             'document.required' => 'Please select a document to upload.',
             'document.file' => 'The uploaded file is not valid.',
-            'document.mimes' => 'Only JPEG, PNG, and PDF files are allowed.',
+            'document.mimes' => 'Only JPEG and PNG image files are allowed.',
             'document.max' => 'The file size must not exceed 50MB.',
             'document_type.required' => 'Please select a document type.',
         ];

--- a/tests/Feature/Guardian/DocumentControllerTest.php
+++ b/tests/Feature/Guardian/DocumentControllerTest.php
@@ -53,7 +53,7 @@ test('guardian can upload document for their student', function () {
     Storage::disk('private')->assertExists($document->file_path);
 });
 
-test('guardian can upload PDF document', function () {
+test('guardian cannot upload PDF document - only JPEG and PNG allowed', function () {
     $file = UploadedFile::fake()->create('form-138.pdf', 2000, 'application/pdf');
 
     $response = $this->actingAs($this->guardian)
@@ -62,8 +62,10 @@ test('guardian can upload PDF document', function () {
             'document_type' => DocumentType::FORM_138->value,
         ]);
 
-    $response->assertStatus(201);
-    expect(Document::first()->mime_type)->toContain('pdf');
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['document']);
+
+    expect(Document::count())->toBe(0);
 });
 
 test('guardian cannot upload document for student they do not own', function () {


### PR DESCRIPTION
## Summary
This PR updates the document upload validation to restrict file types to JPEG and PNG only as specified in issue #472, removing previous PDF support.

## Changes Made

### Validation Updates
- **Modified** `StoreDocumentRequest.php`:
  - Removed 'pdf' from allowed MIME types
  - Simplified validation to only allow `image/jpeg` and `image/png`
  - Removed PDF-specific validation logic
  - Kept max 50MB file size limit (51200 KB)
  - Maintained server-side MIME type checking using `getimagesize()`
  - Updated validation error messages to reflect JPEG/PNG only

### Test Updates
- **Modified** `Guardian/DocumentControllerTest.php`:
  - Changed "guardian can upload PDF document" test to "guardian cannot upload PDF document"
  - Test now verifies PDF uploads are properly rejected with 422 validation error
  - All other tests remain passing

## Backend Endpoints (Already Implemented)

### Guardian Controller
✅ `store()` - Upload document with validation
✅ `show()` - View document details with signed URL
✅ `destroy()` - Delete document (pending/rejected only)

### Registrar Controller
✅ `verify()` - Approve document
✅ `reject()` - Reject document with reason

## Validation Requirements Met
- ✅ JPEG/PNG only (no PDF)
- ✅ Max 50MB file size
- ✅ Server-side MIME type verification
- ✅ Image content validation using `getimagesize()`

## Test Results
All 56 tests passing:
- Guardian controller: 18 tests
- Registrar controller: 38 tests
- Total: 128 assertions

## Technical Notes
- Controllers and routes were already implemented and working correctly
- Only validation rules needed updating to match requirements
- Authorization handled via Laravel policies
- File storage uses Laravel's Storage facade with private disk
- Notifications sent to guardians on verify/reject actions

## Related Issues
Closes #472