### PR TITLE
Fix #478: Create system_settings and setting_history migrations

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -7,6 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 class Setting extends Model
 {
     /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'system_settings';
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var list<string>
@@ -14,5 +21,17 @@ class Setting extends Model
     protected $fillable = [
         'key',
         'value',
+        'type',
+        'description',
+        'is_public',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_public' => 'boolean',
     ];
 }

--- a/database/migrations/2025_11_01_183753_rename_settings_to_system_settings_and_create_history.php
+++ b/database/migrations/2025_11_01_183753_rename_settings_to_system_settings_and_create_history.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Rename settings table to system_settings
+        Schema::rename('settings', 'system_settings');
+
+        // Add additional fields to system_settings
+        Schema::table('system_settings', function (Blueprint $table) {
+            $table->string('type', 50)->default('string')->after('value'); // string, integer, boolean, json
+            $table->text('description')->nullable()->after('type');
+            $table->boolean('is_public')->default(false)->after('description'); // Whether setting is publicly accessible
+        });
+
+        // Create setting_history table for audit trail
+        Schema::create('setting_history', function (Blueprint $table) {
+            $table->id();
+            $table->string('key');
+            $table->text('old_value')->nullable();
+            $table->text('new_value')->nullable();
+            $table->foreignId('changed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('changed_at');
+            $table->index(['key', 'changed_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Drop history table
+        Schema::dropIfExists('setting_history');
+
+        // Remove additional fields from system_settings
+        Schema::table('system_settings', function (Blueprint $table) {
+            $table->dropColumn(['type', 'description', 'is_public']);
+        });
+
+        // Rename back to settings
+        Schema::rename('system_settings', 'settings');
+    }
+};

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -12,14 +12,107 @@ class SettingsSeeder extends Seeder
      */
     public function run(): void
     {
-        Setting::updateOrCreate(['key' => 'payment_location'], ['value' => 'Visit the school cashier\'s office during business hours.']);
-        Setting::updateOrCreate(['key' => 'payment_hours'], ['value' => 'Monday to Friday, 8:00 AM - 5:00 PM']);
-        Setting::updateOrCreate(['key' => 'payment_methods'], ['value' => 'Cash or Check (Face-to-face payment only)']);
-        Setting::updateOrCreate(['key' => 'payment_note'], ['value' => 'Please bring this tuition statement and a valid ID when making payment.']);
+        // Core system settings
+        Setting::updateOrCreate(
+            ['key' => 'school_name'],
+            [
+                'value' => 'Christian Bible Heritage Learning Center',
+                'type' => 'string',
+                'description' => 'Official school name displayed throughout the system',
+                'is_public' => true,
+            ]
+        );
 
-        Setting::updateOrCreate(['key' => 'school_name'], ['value' => 'Christian Bible Heritage Learning Center']);
-        Setting::updateOrCreate(['key' => 'school_address'], ['value' => '123 School St, City, Country']);
-        Setting::updateOrCreate(['key' => 'school_phone'], ['value' => '(02) 123-4567']);
-        Setting::updateOrCreate(['key' => 'school_email'], ['value' => 'info@cbhlc.edu']);
+        Setting::updateOrCreate(
+            ['key' => 'timezone'],
+            [
+                'value' => 'Asia/Manila',
+                'type' => 'string',
+                'description' => 'Default timezone for the system',
+                'is_public' => false,
+            ]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'items_per_page'],
+            [
+                'value' => '10',
+                'type' => 'integer',
+                'description' => 'Number of items to display per page in listings',
+                'is_public' => false,
+            ]
+        );
+
+        // School contact information
+        Setting::updateOrCreate(
+            ['key' => 'school_address'],
+            [
+                'value' => '123 School St, City, Country',
+                'type' => 'string',
+                'description' => 'School physical address',
+                'is_public' => true,
+            ]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'school_phone'],
+            [
+                'value' => '(02) 123-4567',
+                'type' => 'string',
+                'description' => 'School contact phone number',
+                'is_public' => true,
+            ]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'school_email'],
+            [
+                'value' => 'info@cbhlc.edu',
+                'type' => 'string',
+                'description' => 'School contact email address',
+                'is_public' => true,
+            ]
+        );
+
+        // Payment settings
+        Setting::updateOrCreate(
+            ['key' => 'payment_location'],
+            [
+                'value' => 'Visit the school cashier\'s office during business hours.',
+                'type' => 'string',
+                'description' => 'Payment location information',
+                'is_public' => true,
+            ]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'payment_hours'],
+            [
+                'value' => 'Monday to Friday, 8:00 AM - 5:00 PM',
+                'type' => 'string',
+                'description' => 'Payment office hours',
+                'is_public' => true,
+            ]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'payment_methods'],
+            [
+                'value' => 'Cash or Check (Face-to-face payment only)',
+                'type' => 'string',
+                'description' => 'Accepted payment methods',
+                'is_public' => true,
+            ]
+        );
+
+        Setting::updateOrCreate(
+            ['key' => 'payment_note'],
+            [
+                'value' => 'Please bring this tuition statement and a valid ID when making payment.',
+                'type' => 'string',
+                'description' => 'Additional payment instructions',
+                'is_public' => true,
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR implements the settings database migrations and seeders for issue #478.

### Changes

- **Migration**: Rename  table to  and add metadata fields
  - Added  field (string, integer, boolean, json)
  - Added  field for setting documentation
  - Added  field to control public accessibility
- **Migration**: Create  table for audit trail
  - Tracks old/new values for all setting changes
  - Records who changed the setting and when
  - Indexed by key and changed_at for efficient queries
- **Model**: Updated  model to reference new  table
- **Seeder**: Enhanced with core settings including:
  - : Christian Bible Heritage Learning Center
  - : Asia/Manila
  - : 10
  - All payment and contact information settings

### Database Schema

**system_settings table:**
- id, key (unique), value, type, description, is_public, timestamps

**setting_history table:**
- id, key, old_value, new_value, changed_by (FK to users), changed_at, index

### Testing

All CI/CD checks passed:
- ✅ PHP syntax
- ✅ Code style (Pint)
- ✅ Static analysis (PHPStan)
- ✅ Security audit
- ✅ Asset build (Vite)
- ✅ TypeScript
- ✅ Prettier
- ✅ Browser smoke tests
- ✅ Test suite with 60%+ coverage

Closes #478