### PR TITLE
Fix #479: Implement SystemSetting model with caching and helpers

### DIFF
--- a/app/Console/Commands/CacheSettingsCommand.php
+++ b/app/Console/Commands/CacheSettingsCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Setting;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+class CacheSettingsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'settings:cache {--clear : Clear the settings cache}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Cache system settings for improved performance';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        if ($this->option('clear')) {
+            return $this->clearCache();
+        }
+
+        return $this->cacheSettings();
+    }
+
+    /**
+     * Cache all settings.
+     */
+    protected function cacheSettings(): int
+    {
+        $this->info('Caching system settings...');
+
+        // Clear existing cache first
+        Setting::clearCache();
+
+        // Trigger caching by getting all settings
+        $settings = Setting::all();
+        Cache::put(Setting::CACHE_KEY, $settings->keyBy('key'), Setting::CACHE_TTL);
+
+        // Cache public settings separately
+        $publicSettings = Setting::getPublic();
+        Cache::put(Setting::CACHE_KEY.'_public', $publicSettings, Setting::CACHE_TTL);
+
+        $this->components->info(sprintf('Cached %d settings successfully', $settings->count()));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Clear the settings cache.
+     */
+    protected function clearCache(): int
+    {
+        $this->info('Clearing settings cache...');
+
+        Setting::clearCache();
+
+        $this->components->info('Settings cache cleared successfully');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Helpers/settings.php
+++ b/app/Helpers/settings.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\Setting;
+
+if (! function_exists('setting')) {
+    /**
+     * Get or set a setting value.
+     */
+    function setting(?string $key = null, mixed $default = null): mixed
+    {
+        if ($key === null) {
+            return app(Setting::class);
+        }
+
+        return Setting::get($key, $default);
+    }
+}
+
+if (! function_exists('setting_set')) {
+    /**
+     * Set a setting value.
+     */
+    function setting_set(
+        string $key,
+        mixed $value,
+        ?string $type = null,
+        ?string $description = null,
+        bool $isPublic = false
+    ): bool {
+        return Setting::set($key, $value, $type, $description, $isPublic);
+    }
+}
+
+if (! function_exists('setting_has')) {
+    /**
+     * Check if a setting exists.
+     */
+    function setting_has(string $key): bool
+    {
+        return Setting::has($key);
+    }
+}
+
+if (! function_exists('setting_forget')) {
+    /**
+     * Delete a setting.
+     */
+    function setting_forget(string $key): bool
+    {
+        return Setting::forget($key);
+    }
+}
+
+if (! function_exists('public_settings')) {
+    /**
+     * Get all public settings.
+     */
+    function public_settings(): \Illuminate\Support\Collection
+    {
+        return Setting::getPublic();
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
 
 class Setting extends Model
 {
@@ -34,4 +35,160 @@ class Setting extends Model
     protected $casts = [
         'is_public' => 'boolean',
     ];
+
+    /**
+     * Cache key for settings.
+     */
+    public const CACHE_KEY = 'system_settings';
+
+    /**
+     * Cache TTL in seconds (24 hours).
+     */
+    public const CACHE_TTL = 86400;
+
+    /**
+     * Boot the model.
+     */
+    protected static function booted(): void
+    {
+        static::saved(function () {
+            Cache::forget(self::CACHE_KEY);
+        });
+
+        static::deleted(function () {
+            Cache::forget(self::CACHE_KEY);
+        });
+    }
+
+    /**
+     * Get a setting value by key with type casting.
+     */
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        $settings = Cache::remember(self::CACHE_KEY, self::CACHE_TTL, function () {
+            return self::all()->keyBy('key');
+        });
+
+        $setting = $settings->get($key);
+
+        if (! $setting) {
+            return $default;
+        }
+
+        return self::castValue($setting->value, $setting->type);
+    }
+
+    /**
+     * Set a setting value by key.
+     */
+    public static function set(
+        string $key,
+        mixed $value,
+        ?string $type = null,
+        ?string $description = null,
+        bool $isPublic = false
+    ): bool {
+        $type = $type ?? self::inferType($value);
+        $valueString = self::valueToString($value, $type);
+
+        $setting = self::updateOrCreate(
+            ['key' => $key],
+            [
+                'value' => $valueString,
+                'type' => $type,
+                'description' => $description,
+                'is_public' => $isPublic,
+            ]
+        );
+
+        return $setting->wasRecentlyCreated || $setting->wasChanged();
+    }
+
+    /**
+     * Check if a setting exists.
+     */
+    public static function has(string $key): bool
+    {
+        $settings = Cache::remember(self::CACHE_KEY, self::CACHE_TTL, function () {
+            return self::all()->keyBy('key');
+        });
+
+        return $settings->has($key);
+    }
+
+    /**
+     * Forget a setting by key.
+     */
+    public static function forget(string $key): bool
+    {
+        $deleted = self::where('key', $key)->delete();
+        Cache::forget(self::CACHE_KEY);
+
+        return $deleted > 0;
+    }
+
+    /**
+     * Get all public settings.
+     */
+    public static function getPublic(): \Illuminate\Support\Collection
+    {
+        return Cache::remember(self::CACHE_KEY.'_public', self::CACHE_TTL, function () {
+            return self::where('is_public', true)
+                ->get()
+                ->mapWithKeys(function ($setting) {
+                    return [$setting->key => self::castValue($setting->value, $setting->type)];
+                });
+        });
+    }
+
+    /**
+     * Clear settings cache.
+     */
+    public static function clearCache(): bool
+    {
+        Cache::forget(self::CACHE_KEY);
+        Cache::forget(self::CACHE_KEY.'_public');
+
+        return true;
+    }
+
+    /**
+     * Cast a value to its appropriate type.
+     */
+    protected static function castValue(string $value, string $type): mixed
+    {
+        return match ($type) {
+            'integer', 'int' => (int) $value,
+            'boolean', 'bool' => filter_var($value, FILTER_VALIDATE_BOOLEAN),
+            'float', 'double' => (float) $value,
+            'array', 'json' => json_decode($value, true),
+            default => $value,
+        };
+    }
+
+    /**
+     * Convert a value to string for storage.
+     */
+    protected static function valueToString(mixed $value, string $type): string
+    {
+        return match ($type) {
+            'array', 'json' => json_encode($value),
+            'boolean', 'bool' => $value ? '1' : '0',
+            default => (string) $value,
+        };
+    }
+
+    /**
+     * Infer the type from a value.
+     */
+    protected static function inferType(mixed $value): string
+    {
+        return match (true) {
+            is_bool($value) => 'boolean',
+            is_int($value) => 'integer',
+            is_float($value) => 'float',
+            is_array($value) => 'array',
+            default => 'string',
+        };
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         "pestphp/pest-plugin-laravel": "^4.0"
     },
     "autoload": {
+        "files": [
+            "app/Helpers/settings.php"
+        ],
         "psr-4": {
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",

--- a/tests/Feature/Console/CacheSettingsCommandTest.php
+++ b/tests/Feature/Console/CacheSettingsCommandTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+test('settings:cache command caches all settings', function () {
+    Setting::create(['key' => 'setting1', 'value' => 'value1', 'type' => 'string']);
+    Setting::create(['key' => 'setting2', 'value' => 'value2', 'type' => 'string']);
+    Setting::create(['key' => 'setting3', 'value' => 'value3', 'type' => 'string']);
+
+    $this->artisan('settings:cache')
+        ->expectsOutput('Caching system settings...')
+        ->assertSuccessful();
+
+    expect(Cache::has(Setting::CACHE_KEY))->toBeTrue()
+        ->and(Cache::has(Setting::CACHE_KEY.'_public'))->toBeTrue();
+});
+
+test('settings:cache command caches correct number of settings', function () {
+    Setting::create(['key' => 'setting1', 'value' => 'value1', 'type' => 'string']);
+    Setting::create(['key' => 'setting2', 'value' => 'value2', 'type' => 'string']);
+
+    $this->artisan('settings:cache')
+        ->expectsOutputToContain('Cached 2 settings successfully')
+        ->assertSuccessful();
+});
+
+test('settings:cache command with --clear option clears cache', function () {
+    Setting::create(['key' => 'setting1', 'value' => 'value1', 'type' => 'string']);
+
+    // First cache the settings
+    $this->artisan('settings:cache');
+    expect(Cache::has(Setting::CACHE_KEY))->toBeTrue();
+
+    // Then clear the cache
+    $this->artisan('settings:cache', ['--clear' => true])
+        ->expectsOutput('Clearing settings cache...')
+        ->expectsOutputToContain('Settings cache cleared successfully')
+        ->assertSuccessful();
+
+    expect(Cache::has(Setting::CACHE_KEY))->toBeFalse()
+        ->and(Cache::has(Setting::CACHE_KEY.'_public'))->toBeFalse();
+});
+
+test('settings:cache command caches public settings separately', function () {
+    Setting::create(['key' => 'public1', 'value' => 'value1', 'type' => 'string', 'is_public' => true]);
+    Setting::create(['key' => 'public2', 'value' => 'value2', 'type' => 'string', 'is_public' => true]);
+    Setting::create(['key' => 'private', 'value' => 'value3', 'type' => 'string', 'is_public' => false]);
+
+    $this->artisan('settings:cache')
+        ->assertSuccessful();
+
+    $publicSettings = Cache::get(Setting::CACHE_KEY.'_public');
+
+    expect($publicSettings)->toHaveCount(2)
+        ->and($publicSettings->has('public1'))->toBeTrue()
+        ->and($publicSettings->has('public2'))->toBeTrue()
+        ->and($publicSettings->has('private'))->toBeFalse();
+});
+
+test('settings:cache command works with no settings', function () {
+    $this->artisan('settings:cache')
+        ->expectsOutputToContain('Cached 0 settings successfully')
+        ->assertSuccessful();
+});
+
+test('settings:cache command clears old cache before caching', function () {
+    Setting::create(['key' => 'setting1', 'value' => 'old_value', 'type' => 'string']);
+
+    // Cache first time
+    $this->artisan('settings:cache');
+    $firstCache = Cache::get(Setting::CACHE_KEY);
+
+    // Update setting
+    Setting::where('key', 'setting1')->update(['value' => 'new_value']);
+
+    // Cache again
+    $this->artisan('settings:cache');
+    $secondCache = Cache::get(Setting::CACHE_KEY);
+
+    expect($firstCache->get('setting1')->value)->toBe('old_value')
+        ->and($secondCache->get('setting1')->value)->toBe('new_value');
+});
+
+test('cached settings can be retrieved with Setting::get()', function () {
+    Setting::create(['key' => 'test_key', 'value' => 'test_value', 'type' => 'string']);
+
+    $this->artisan('settings:cache');
+
+    $value = Setting::get('test_key');
+
+    expect($value)->toBe('test_value');
+});
+
+test('cached settings maintain correct types', function () {
+    Setting::create(['key' => 'int_val', 'value' => '42', 'type' => 'integer']);
+    Setting::create(['key' => 'bool_val', 'value' => '1', 'type' => 'boolean']);
+    Setting::create(['key' => 'str_val', 'value' => 'text', 'type' => 'string']);
+
+    $this->artisan('settings:cache');
+
+    expect(Setting::get('int_val'))->toBe(42)
+        ->and(Setting::get('bool_val'))->toBeTrue()
+        ->and(Setting::get('str_val'))->toBe('text');
+});

--- a/tests/Feature/Models/SettingTest.php
+++ b/tests/Feature/Models/SettingTest.php
@@ -1,0 +1,273 @@
+<?php
+
+use App\Models\Setting;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Clear cache before each test
+    Cache::flush();
+});
+
+test('can create a setting', function () {
+    $setting = Setting::create([
+        'key' => 'test_key',
+        'value' => 'test_value',
+        'type' => 'string',
+        'description' => 'Test setting',
+        'is_public' => true,
+    ]);
+
+    expect($setting)->toBeInstanceOf(Setting::class)
+        ->and($setting->key)->toBe('test_key')
+        ->and($setting->value)->toBe('test_value');
+});
+
+test('can get a setting value', function () {
+    Setting::create([
+        'key' => 'test_key',
+        'value' => 'test_value',
+        'type' => 'string',
+    ]);
+
+    $value = Setting::get('test_key');
+
+    expect($value)->toBe('test_value');
+});
+
+test('get returns default when setting does not exist', function () {
+    $value = Setting::get('nonexistent', 'default_value');
+
+    expect($value)->toBe('default_value');
+});
+
+test('can set a setting value', function () {
+    Setting::set('new_key', 'new_value', 'string', 'New setting', true);
+
+    $setting = Setting::where('key', 'new_key')->first();
+
+    expect($setting)->not->toBeNull()
+        ->and($setting->value)->toBe('new_value')
+        ->and($setting->type)->toBe('string')
+        ->and($setting->description)->toBe('New setting')
+        ->and($setting->is_public)->toBeTrue();
+});
+
+test('set updates existing setting', function () {
+    Setting::create([
+        'key' => 'existing_key',
+        'value' => 'old_value',
+        'type' => 'string',
+    ]);
+
+    Setting::set('existing_key', 'new_value');
+
+    $setting = Setting::where('key', 'existing_key')->first();
+
+    expect($setting->value)->toBe('new_value');
+});
+
+test('has returns true for existing setting', function () {
+    Setting::create([
+        'key' => 'existing_key',
+        'value' => 'value',
+        'type' => 'string',
+    ]);
+
+    expect(Setting::has('existing_key'))->toBeTrue();
+});
+
+test('has returns false for non-existing setting', function () {
+    expect(Setting::has('nonexistent'))->toBeFalse();
+});
+
+test('can forget a setting', function () {
+    Setting::create([
+        'key' => 'to_delete',
+        'value' => 'value',
+        'type' => 'string',
+    ]);
+
+    $result = Setting::forget('to_delete');
+
+    expect($result)->toBeTrue()
+        ->and(Setting::where('key', 'to_delete')->exists())->toBeFalse();
+});
+
+test('forget returns false when setting does not exist', function () {
+    $result = Setting::forget('nonexistent');
+
+    expect($result)->toBeFalse();
+});
+
+test('can get public settings only', function () {
+    Setting::create(['key' => 'public1', 'value' => 'value1', 'type' => 'string', 'is_public' => true]);
+    Setting::create(['key' => 'public2', 'value' => 'value2', 'type' => 'string', 'is_public' => true]);
+    Setting::create(['key' => 'private', 'value' => 'value3', 'type' => 'string', 'is_public' => false]);
+
+    $publicSettings = Setting::getPublic();
+
+    expect($publicSettings)->toHaveCount(2)
+        ->and($publicSettings->has('public1'))->toBeTrue()
+        ->and($publicSettings->has('public2'))->toBeTrue()
+        ->and($publicSettings->has('private'))->toBeFalse();
+});
+
+test('casts integer values correctly', function () {
+    Setting::create(['key' => 'int_value', 'value' => '42', 'type' => 'integer']);
+
+    $value = Setting::get('int_value');
+
+    expect($value)->toBe(42)
+        ->and($value)->toBeInt();
+});
+
+test('casts boolean values correctly', function () {
+    Setting::create(['key' => 'bool_true', 'value' => '1', 'type' => 'boolean']);
+    Setting::create(['key' => 'bool_false', 'value' => '0', 'type' => 'boolean']);
+
+    expect(Setting::get('bool_true'))->toBeTrue()
+        ->and(Setting::get('bool_false'))->toBeFalse();
+});
+
+test('casts float values correctly', function () {
+    Setting::create(['key' => 'float_value', 'value' => '3.14', 'type' => 'float']);
+
+    $value = Setting::get('float_value');
+
+    expect($value)->toBe(3.14)
+        ->and($value)->toBeFloat();
+});
+
+test('casts array values correctly', function () {
+    Setting::create([
+        'key' => 'array_value',
+        'value' => json_encode(['key1' => 'value1', 'key2' => 'value2']),
+        'type' => 'array',
+    ]);
+
+    $value = Setting::get('array_value');
+
+    expect($value)->toBeArray()
+        ->and($value)->toHaveKey('key1')
+        ->and($value['key1'])->toBe('value1');
+});
+
+test('set infers type from value', function () {
+    Setting::set('string_val', 'text');
+    Setting::set('int_val', 42);
+    Setting::set('bool_val', true);
+    Setting::set('float_val', 3.14);
+    Setting::set('array_val', ['a' => 'b']);
+
+    expect(Setting::where('key', 'string_val')->first()->type)->toBe('string')
+        ->and(Setting::where('key', 'int_val')->first()->type)->toBe('integer')
+        ->and(Setting::where('key', 'bool_val')->first()->type)->toBe('boolean')
+        ->and(Setting::where('key', 'float_val')->first()->type)->toBe('float')
+        ->and(Setting::where('key', 'array_val')->first()->type)->toBe('array');
+});
+
+test('settings are cached', function () {
+    Setting::create(['key' => 'cached_key', 'value' => 'cached_value', 'type' => 'string']);
+
+    // First call should query database
+    $value1 = Setting::get('cached_key');
+
+    // Second call should use cache
+    $value2 = Setting::get('cached_key');
+
+    expect($value1)->toBe('cached_value')
+        ->and($value2)->toBe('cached_value')
+        ->and(Cache::has(Setting::CACHE_KEY))->toBeTrue();
+});
+
+test('cache is cleared when setting is saved', function () {
+    Setting::create(['key' => 'test_key', 'value' => 'old_value', 'type' => 'string']);
+
+    // Trigger cache
+    Setting::get('test_key');
+    expect(Cache::has(Setting::CACHE_KEY))->toBeTrue();
+
+    // Update setting
+    $setting = Setting::where('key', 'test_key')->first();
+    $setting->update(['value' => 'new_value']);
+
+    // Cache should be cleared
+    expect(Cache::has(Setting::CACHE_KEY))->toBeFalse();
+});
+
+test('cache is cleared when setting is deleted', function () {
+    Setting::create(['key' => 'test_key', 'value' => 'value', 'type' => 'string']);
+
+    // Trigger cache
+    Setting::get('test_key');
+    expect(Cache::has(Setting::CACHE_KEY))->toBeTrue();
+
+    // Delete setting
+    Setting::forget('test_key');
+
+    // Cache should be cleared
+    expect(Cache::has(Setting::CACHE_KEY))->toBeFalse();
+});
+
+test('clearCache clears both setting caches', function () {
+    Setting::create(['key' => 'test_key', 'value' => 'value', 'type' => 'string', 'is_public' => true]);
+
+    // Trigger both caches
+    Setting::get('test_key');
+    Setting::getPublic();
+
+    expect(Cache::has(Setting::CACHE_KEY))->toBeTrue()
+        ->and(Cache::has(Setting::CACHE_KEY.'_public'))->toBeTrue();
+
+    // Clear caches
+    Setting::clearCache();
+
+    expect(Cache::has(Setting::CACHE_KEY))->toBeFalse()
+        ->and(Cache::has(Setting::CACHE_KEY.'_public'))->toBeFalse();
+});
+
+test('helper function setting() works', function () {
+    Setting::create(['key' => 'helper_test', 'value' => 'helper_value', 'type' => 'string']);
+
+    expect(setting('helper_test'))->toBe('helper_value')
+        ->and(setting('nonexistent', 'default'))->toBe('default');
+});
+
+test('helper function setting_set() works', function () {
+    setting_set('helper_key', 'helper_value', 'string', 'Helper description', true);
+
+    $setting = Setting::where('key', 'helper_key')->first();
+
+    expect($setting)->not->toBeNull()
+        ->and($setting->value)->toBe('helper_value')
+        ->and($setting->description)->toBe('Helper description')
+        ->and($setting->is_public)->toBeTrue();
+});
+
+test('helper function setting_has() works', function () {
+    Setting::create(['key' => 'exists', 'value' => 'value', 'type' => 'string']);
+
+    expect(setting_has('exists'))->toBeTrue()
+        ->and(setting_has('not_exists'))->toBeFalse();
+});
+
+test('helper function setting_forget() works', function () {
+    Setting::create(['key' => 'to_forget', 'value' => 'value', 'type' => 'string']);
+
+    expect(setting_forget('to_forget'))->toBeTrue()
+        ->and(Setting::where('key', 'to_forget')->exists())->toBeFalse();
+});
+
+test('helper function public_settings() works', function () {
+    Setting::create(['key' => 'public', 'value' => 'value', 'type' => 'string', 'is_public' => true]);
+    Setting::create(['key' => 'private', 'value' => 'value', 'type' => 'string', 'is_public' => false]);
+
+    $publicSettings = public_settings();
+
+    expect($publicSettings)->toHaveCount(1)
+        ->and($publicSettings->has('public'))->toBeTrue()
+        ->and($publicSettings->has('private'))->toBeFalse();
+});


### PR DESCRIPTION
## Summary

This PR implements a comprehensive settings management system with caching, typed casting, and helper functions for issue #479.

### Features

**Enhanced Setting Model:**
- Automatic caching layer using Laravel Cache (24-hour TTL)
- Type casting support for string, integer, boolean, float, and array values
- Auto-clear cache on model save/delete using Laravel model events
- Separate caching strategy for public settings

**Static Methods:**
- `Setting::get(, )` - Get setting with type casting
- `Setting::set(, , , , )` - Set/update setting
- `Setting::has()` - Check if setting exists
- `Setting::forget()` - Delete setting
- `Setting::getPublic()` - Get all public settings
- `Setting::clearCache()` - Clear all caches

**Helper Functions:**
- `setting(, )` - Get setting value
- `setting_set(, , ...)` - Set setting value
- `setting_has()` - Check existence
- `setting_forget()` - Delete setting
- `public_settings()` - Get public settings

**Artisan Command:**
- `php artisan settings:cache` - Cache all settings for performance
- `php artisan settings:cache --clear` - Clear settings cache

**Automatic Type Inference:**
- Automatically infers type from value when not explicitly provided
- Converts values to proper PHP types when retrieved

### Testing

**24 Setting Model Tests:**
- Create, get, set, update, delete operations
- Type casting (string, int, bool, float, array)
- Cache management and invalidation
- Public settings filtering
- Helper function testing

**8 Command Tests:**
- Cache command with various scenarios
- Cache clearing functionality
- Type preservation after caching

All tests passing: **32 tests, 83 assertions**

### CI/CD Status

All checks passed:
- ✅ PHP syntax
- ✅ Code style (Pint)
- ✅ Static analysis (PHPStan)
- ✅ Security audit
- ✅ Asset build (Vite)
- ✅ TypeScript
- ✅ Prettier
- ✅ Browser smoke tests
- ✅ Test suite with 60%+ coverage

Closes #479