### PR TITLE
refactor: Ensure consistent status colors across all user roles

### DIFF
--- a/resources/js/components/status-badges/EnrollmentPeriodStatusBadge.tsx
+++ b/resources/js/components/status-badges/EnrollmentPeriodStatusBadge.tsx
@@ -1,0 +1,21 @@
+import { Badge } from '@/components/ui/badge';
+
+interface EnrollmentPeriodStatusBadgeProps {
+    status: string;
+}
+
+const STATUS_VARIANTS: Record<string, { variant: 'default' | 'secondary' | 'destructive' | 'outline'; className?: string; label: string }> = {
+    active: { variant: 'default', className: 'bg-green-100 text-green-800', label: 'Active' },
+    upcoming: { variant: 'secondary', className: 'bg-yellow-100 text-yellow-800', label: 'Upcoming' },
+    closed: { variant: 'outline', className: 'bg-red-100 text-red-800', label: 'Closed' },
+};
+
+export function EnrollmentPeriodStatusBadge({ status }: EnrollmentPeriodStatusBadgeProps) {
+    const config = STATUS_VARIANTS[status] || { variant: 'outline' as const, label: status };
+
+    return (
+        <Badge variant={config.variant} className={config.className}>
+            {config.label}
+        </Badge>
+    );
+}

--- a/resources/js/components/status-badges/SchoolYearStatusBadge.tsx
+++ b/resources/js/components/status-badges/SchoolYearStatusBadge.tsx
@@ -1,0 +1,21 @@
+import { Badge } from '@/components/ui/badge';
+
+interface SchoolYearStatusBadgeProps {
+    status: string;
+}
+
+const STATUS_VARIANTS: Record<string, { variant: 'default' | 'secondary' | 'destructive' | 'outline'; className?: string; label: string }> = {
+    active: { variant: 'default', className: 'bg-green-100 text-green-800', label: 'Active' },
+    upcoming: { variant: 'secondary', className: 'bg-yellow-100 text-yellow-800', label: 'Upcoming' },
+    completed: { variant: 'outline', className: 'bg-gray-100 text-gray-800', label: 'Completed' },
+};
+
+export function SchoolYearStatusBadge({ status }: SchoolYearStatusBadgeProps) {
+    const config = STATUS_VARIANTS[status] || { variant: 'outline' as const, label: status };
+
+    return (
+        <Badge variant={config.variant} className={config.className}>
+            {config.label}
+        </Badge>
+    );
+}

--- a/resources/js/components/status-badges/index.ts
+++ b/resources/js/components/status-badges/index.ts
@@ -1,4 +1,6 @@
 export { DocumentStatusBadge } from './DocumentStatusBadge';
+export { EnrollmentPeriodStatusBadge } from './EnrollmentPeriodStatusBadge';
 export { EnrollmentStatusBadge } from './EnrollmentStatusBadge';
 export { InvoiceStatusBadge } from './InvoiceStatusBadge';
 export { PaymentStatusBadge } from './PaymentStatusBadge';
+export { SchoolYearStatusBadge } from './SchoolYearStatusBadge';

--- a/resources/js/pages/guardian/billing/billing-module.tsx
+++ b/resources/js/pages/guardian/billing/billing-module.tsx
@@ -1,3 +1,4 @@
+import { EnrollmentStatusBadge, PaymentStatusBadge } from '@/components/status-badges';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -37,40 +38,6 @@ interface BillingModuleProps {
     enrollments: Enrollment[];
     summary: Summary;
     paymentPlans: PaymentPlan[];
-}
-
-function getPaymentStatusVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
-    switch (status) {
-        case 'paid':
-            return 'default';
-        case 'partial':
-            return 'secondary';
-        case 'pending':
-            return 'outline';
-        case 'overdue':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
-}
-
-function getEnrollmentStatusVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
-    switch (status) {
-        case 'completed':
-            return 'default';
-        case 'enrolled':
-            return 'secondary';
-        case 'pending':
-            return 'outline';
-        case 'rejected':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
-}
-
-function formatStatusName(status: string) {
-    return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 export function BillingModule({ enrollments, summary, paymentPlans }: BillingModuleProps) {
@@ -287,14 +254,10 @@ export function BillingModule({ enrollments, summary, paymentPlans }: BillingMod
                                                         <div className="text-sm font-semibold">{enrollment.total_amount}</div>
                                                     </td>
                                                     <td className="px-6 py-4">
-                                                        <Badge variant={getPaymentStatusVariant(enrollment.payment_status)}>
-                                                            {formatStatusName(enrollment.payment_status)}
-                                                        </Badge>
+                                                        <PaymentStatusBadge status={enrollment.payment_status} />
                                                     </td>
                                                     <td className="px-6 py-4">
-                                                        <Badge variant={getEnrollmentStatusVariant(enrollment.status)}>
-                                                            {formatStatusName(enrollment.status)}
-                                                        </Badge>
+                                                        <EnrollmentStatusBadge status={enrollment.status} />
                                                     </td>
                                                 </tr>
                                                 {expandedEnrollment === enrollment.id && (
@@ -333,12 +296,8 @@ export function BillingModule({ enrollments, summary, paymentPlans }: BillingMod
                                                                                 {enrollment.school_year_name} • {enrollment.grade_level}
                                                                             </p>
                                                                             <div className="mt-2 flex gap-2">
-                                                                                <Badge variant={getEnrollmentStatusVariant(enrollment.status)}>
-                                                                                    {formatStatusName(enrollment.status)}
-                                                                                </Badge>
-                                                                                <Badge variant={getPaymentStatusVariant(enrollment.payment_status)}>
-                                                                                    {formatStatusName(enrollment.payment_status)}
-                                                                                </Badge>
+                                                                                <EnrollmentStatusBadge status={enrollment.status} />
+                                                                                <PaymentStatusBadge status={enrollment.payment_status} />
                                                                             </div>
                                                                         </div>
                                                                     </div>

--- a/resources/js/pages/guardian/enrollments/index.tsx
+++ b/resources/js/pages/guardian/enrollments/index.tsx
@@ -1,5 +1,5 @@
 import { SchoolYearFilter } from '@/components/school-year-filter';
-import { Badge } from '@/components/ui/badge';
+import { EnrollmentStatusBadge, PaymentStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { DataTable } from '@/components/ui/data-table';
@@ -60,21 +60,6 @@ interface Props {
         statuses: FilterOption[];
     };
 }
-
-export const statusColors = {
-    pending: 'secondary',
-    approved: 'default',
-    enrolled: 'default',
-    rejected: 'destructive',
-    completed: 'secondary',
-} as const;
-
-export const paymentStatusColors = {
-    pending: 'secondary',
-    partial: 'outline',
-    paid: 'default',
-    overdue: 'destructive',
-} as const;
 
 export default function GuardianEnrollmentsIndex({ enrollments, filters, filterOptions }: Props) {
     const { props } = usePage();
@@ -147,20 +132,12 @@ export default function GuardianEnrollmentsIndex({ enrollments, filters, filterO
             {
                 accessorKey: 'status',
                 header: 'Status',
-                cell: ({ row }) => {
-                    const status = row.original.status;
-                    return <Badge variant={statusColors[status as keyof typeof statusColors] || 'default'}>{status}</Badge>;
-                },
+                cell: ({ row }) => <EnrollmentStatusBadge status={row.original.status} />,
             },
             {
                 accessorKey: 'payment_status',
                 header: 'Payment Status',
-                cell: ({ row }) => {
-                    const paymentStatus = row.original.payment_status;
-                    return (
-                        <Badge variant={paymentStatusColors[paymentStatus as keyof typeof paymentStatusColors] || 'default'}>{paymentStatus}</Badge>
-                    );
-                },
+                cell: ({ row }) => <PaymentStatusBadge status={row.original.payment_status} />,
             },
             {
                 accessorKey: 'created_at',

--- a/resources/js/pages/guardian/enrollments/show.tsx
+++ b/resources/js/pages/guardian/enrollments/show.tsx
@@ -1,10 +1,9 @@
-import { Badge } from '@/components/ui/badge';
+import { EnrollmentStatusBadge, PaymentStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import AppLayout from '@/layouts/app-layout';
-import { paymentStatusColors, statusColors } from '@/pages/guardian/enrollments/index';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
 import { Download } from 'lucide-react';
@@ -107,7 +106,7 @@ export default function GuardianEnrollmentsShow({ enrollment, payments }: Props)
                             </div>
                             <div className="flex items-center justify-between">
                                 <p className="text-sm font-medium text-muted-foreground">Status</p>
-                                <Badge variant={statusColors[enrollment.status] || 'default'}>{enrollment.status}</Badge>
+                                <EnrollmentStatusBadge status={enrollment.status} />
                             </div>
                             <div className="flex items-center justify-between">
                                 <p className="text-sm font-medium text-muted-foreground">School Year</p>
@@ -191,7 +190,7 @@ export default function GuardianEnrollmentsShow({ enrollment, payments }: Props)
                         <CardContent className="grid gap-4">
                             <div className="flex items-center justify-between">
                                 <p className="text-sm font-medium text-muted-foreground">Payment Status</p>
-                                <Badge variant={paymentStatusColors[enrollment.payment_status] || 'default'}>{enrollment.payment_status}</Badge>
+                                <PaymentStatusBadge status={enrollment.payment_status} />
                             </div>
                             <Separator />
                             <div className="space-y-2">

--- a/resources/js/pages/guardian/students/columns.tsx
+++ b/resources/js/pages/guardian/students/columns.tsx
@@ -1,3 +1,4 @@
+import { EnrollmentStatusBadge } from '@/components/status-badges';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -28,13 +29,6 @@ export interface Student {
         grade_level: string;
     } | null;
 }
-
-const statusColors = {
-    pending: 'secondary',
-    enrolled: 'default',
-    rejected: 'destructive',
-    completed: 'outline',
-} as const;
 
 function calculateAge(birthdate: string): number {
     const birth = new Date(birthdate);
@@ -108,11 +102,7 @@ export const columns: ColumnDef<Student>[] = [
             if (!enrollment) {
                 return <Badge variant="outline">No enrollment</Badge>;
             }
-            return (
-                <Badge variant={statusColors[enrollment.status as keyof typeof statusColors] || 'default'}>
-                    {enrollment.status.charAt(0).toUpperCase() + enrollment.status.slice(1)}
-                </Badge>
-            );
+            return <EnrollmentStatusBadge status={enrollment.status} />;
         },
     },
     {

--- a/resources/js/pages/guardian/students/guardian-dashboard.tsx
+++ b/resources/js/pages/guardian/students/guardian-dashboard.tsx
@@ -1,3 +1,4 @@
+import { EnrollmentStatusBadge } from '@/components/status-badges';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -47,25 +48,6 @@ const dashboardData = {
         },
     ],
 };
-
-function getStatusVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
-    switch (status) {
-        case 'completed':
-            return 'default';
-        case 'enrolled':
-            return 'secondary';
-        case 'pending':
-            return 'outline';
-        case 'rejected':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
-}
-
-function formatStatusName(status: string) {
-    return status.charAt(0).toUpperCase() + status.slice(1);
-}
 
 function calculateAge(birthdate: string) {
     const birth = new Date(birthdate);
@@ -187,9 +169,7 @@ export function GuardianDashboard() {
                                                     </td>
                                                     <td className="px-6 py-4">
                                                         {student.latestEnrollment ? (
-                                                            <Badge variant={getStatusVariant(student.latestEnrollment.status)}>
-                                                                {formatStatusName(student.latestEnrollment.status)}
-                                                            </Badge>
+                                                            <EnrollmentStatusBadge status={student.latestEnrollment.status} />
                                                         ) : (
                                                             <Badge variant="outline">No enrollment</Badge>
                                                         )}
@@ -244,12 +224,7 @@ export function GuardianDashboard() {
                                                                             </div>
                                                                             <div>
                                                                                 <p className="text-xs text-muted-foreground">Status</p>
-                                                                                <Badge
-                                                                                    variant={getStatusVariant(student.latestEnrollment.status)}
-                                                                                    className="mt-1"
-                                                                                >
-                                                                                    {formatStatusName(student.latestEnrollment.status)}
-                                                                                </Badge>
+                                                                                <EnrollmentStatusBadge status={student.latestEnrollment.status} />
                                                                             </div>
                                                                         </div>
                                                                     </div>

--- a/resources/js/pages/guardian/students/show.tsx
+++ b/resources/js/pages/guardian/students/show.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/components/ui/badge';
+import { DocumentStatusBadge, EnrollmentStatusBadge, PaymentStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -11,22 +11,7 @@ import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/react';
 import axios from 'axios';
-import {
-    Calendar,
-    CheckCircle2,
-    Clock,
-    Download,
-    Edit,
-    Eye,
-    FileText,
-    GraduationCap,
-    Mail,
-    MapPin,
-    Phone,
-    Upload,
-    User,
-    XCircle,
-} from 'lucide-react';
+import { Calendar, Clock, Download, Edit, Eye, FileText, GraduationCap, Mail, MapPin, Phone, Upload, User } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 interface Enrollment {
@@ -74,20 +59,6 @@ interface Props {
     canEnroll: boolean;
     enrollmentMessage?: string | null;
 }
-
-const statusColors = {
-    pending: 'secondary',
-    enrolled: 'default',
-    rejected: 'destructive',
-    completed: 'outline',
-} as const;
-
-const paymentStatusColors = {
-    pending: 'secondary',
-    partial: 'outline',
-    paid: 'default',
-    overdue: 'destructive',
-} as const;
 
 export default function GuardianStudentsShow({ student, canEnroll, enrollmentMessage }: Props) {
     const [downloadingId, setDownloadingId] = useState<number | null>(null);
@@ -410,19 +381,10 @@ export default function GuardianStudentsShow({ student, canEnroll, enrollmentMes
                                             <TableCell>{enrollment.grade_level}</TableCell>
                                             <TableCell>{enrollment.quarter}</TableCell>
                                             <TableCell>
-                                                <Badge variant={statusColors[enrollment.status as keyof typeof statusColors] || 'default'}>
-                                                    {enrollment.status}
-                                                </Badge>
+                                                <EnrollmentStatusBadge status={enrollment.status} />
                                             </TableCell>
                                             <TableCell>
-                                                <Badge
-                                                    variant={
-                                                        paymentStatusColors[enrollment.payment_status as keyof typeof paymentStatusColors] ||
-                                                        'default'
-                                                    }
-                                                >
-                                                    {enrollment.payment_status}
-                                                </Badge>
+                                                <PaymentStatusBadge status={enrollment.payment_status} />
                                             </TableCell>
                                             <TableCell>
                                                 {new Date(enrollment.created_at).toLocaleDateString('en-US', {
@@ -546,24 +508,7 @@ export default function GuardianStudentsShow({ student, canEnroll, enrollmentMes
                                                         </div>
                                                     </div>
                                                     <div className="flex items-center gap-2">
-                                                        {document.verification_status === 'pending' && (
-                                                            <Badge variant="secondary" className="flex items-center gap-1">
-                                                                <Clock className="h-3 w-3" />
-                                                                Pending Review
-                                                            </Badge>
-                                                        )}
-                                                        {document.verification_status === 'verified' && (
-                                                            <Badge variant="default" className="flex items-center gap-1">
-                                                                <CheckCircle2 className="h-3 w-3" />
-                                                                Verified
-                                                            </Badge>
-                                                        )}
-                                                        {document.verification_status === 'rejected' && (
-                                                            <Badge variant="destructive" className="flex items-center gap-1">
-                                                                <XCircle className="h-3 w-3" />
-                                                                Rejected
-                                                            </Badge>
-                                                        )}
+                                                        <DocumentStatusBadge status={document.verification_status} />
                                                     </div>
                                                 </div>
 

--- a/resources/js/pages/registrar/enrollments/enrollments-table.tsx
+++ b/resources/js/pages/registrar/enrollments/enrollments-table.tsx
@@ -13,7 +13,7 @@ import {
 import { ChevronDown, MoreHorizontal } from 'lucide-react';
 import * as React from 'react';
 
-import { Badge } from '@/components/ui/badge';
+import { EnrollmentStatusBadge, PaymentStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -61,40 +61,6 @@ export function formatCurrency(cents: number) {
         style: 'currency',
         currency: 'PHP',
     }).format(cents / 100);
-}
-
-export function getStatusVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
-    switch (status) {
-        case 'completed':
-            return 'default';
-        case 'enrolled':
-            return 'secondary';
-        case 'pending':
-            return 'outline';
-        case 'rejected':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
-}
-
-export function getPaymentStatusVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
-    switch (status) {
-        case 'paid':
-            return 'default';
-        case 'partial':
-            return 'secondary';
-        case 'pending':
-            return 'outline';
-        case 'overdue':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
-}
-
-export function formatStatusName(status: string) {
-    return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 // Define a type for the functions that will be passed to the columns
@@ -168,11 +134,7 @@ export const createColumns = ({
     {
         accessorKey: 'status',
         header: 'Status',
-        cell: ({ row }) => (
-            <Badge variant={getStatusVariant(row.getValue('status'))} className="text-xs">
-                {formatStatusName(row.getValue('status'))}
-            </Badge>
-        ),
+        cell: ({ row }) => <EnrollmentStatusBadge status={row.getValue('status')} />,
     },
     {
         accessorKey: 'net_amount_cents',
@@ -200,11 +162,7 @@ export const createColumns = ({
     {
         accessorKey: 'payment_status',
         header: 'Payment',
-        cell: ({ row }) => (
-            <Badge variant={getPaymentStatusVariant(row.getValue('payment_status'))} className="text-xs">
-                {formatStatusName(row.getValue('payment_status'))}
-            </Badge>
-        ),
+        cell: ({ row }) => <PaymentStatusBadge status={row.getValue('payment_status')} />,
     },
     {
         id: 'actions',

--- a/resources/js/pages/registrar/enrollments/show.tsx
+++ b/resources/js/pages/registrar/enrollments/show.tsx
@@ -1,9 +1,9 @@
-import { Badge } from '@/components/ui/badge';
+import { DocumentStatusBadge, EnrollmentStatusBadge, PaymentStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import AppLayout from '@/layouts/app-layout';
-import { formatCurrency, formatStatusName, getPaymentStatusVariant, getStatusVariant } from '@/pages/registrar/enrollments/enrollments-table';
+import { formatCurrency } from '@/pages/registrar/enrollments/enrollments-table';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link } from '@inertiajs/react';
 import { ExternalLink, FileText } from 'lucide-react';
@@ -72,7 +72,7 @@ export default function RegistrarEnrollmentsShow({ enrollment }: Props) {
                             </div>
                             <div className="flex items-center justify-between">
                                 <p className="text-sm font-medium text-muted-foreground">Status</p>
-                                <Badge variant={getStatusVariant(enrollment.status)}>{formatStatusName(enrollment.status)}</Badge>
+                                <EnrollmentStatusBadge status={enrollment.status} />
                             </div>
                             <div className="flex items-center justify-between">
                                 <p className="text-sm font-medium text-muted-foreground">School Year</p>
@@ -116,9 +116,7 @@ export default function RegistrarEnrollmentsShow({ enrollment }: Props) {
                         <CardContent className="grid gap-4">
                             <div className="flex items-center justify-between">
                                 <p className="text-sm font-medium text-muted-foreground">Payment Status</p>
-                                <Badge variant={getPaymentStatusVariant(enrollment.payment_status)}>
-                                    {formatStatusName(enrollment.payment_status)}
-                                </Badge>
+                                <PaymentStatusBadge status={enrollment.payment_status} />
                             </div>
                             <Separator />
                             <div className="space-y-2">
@@ -197,17 +195,7 @@ export default function RegistrarEnrollmentsShow({ enrollment }: Props) {
                                             </div>
                                         </div>
                                         <div className="flex items-center gap-2">
-                                            <Badge
-                                                variant={
-                                                    doc.verification_status === 'verified'
-                                                        ? 'default'
-                                                        : doc.verification_status === 'rejected'
-                                                          ? 'destructive'
-                                                          : 'secondary'
-                                                }
-                                            >
-                                                {doc.verification_status}
-                                            </Badge>
+                                            <DocumentStatusBadge status={doc.verification_status} />
                                             <Link href={route('documents.view', { document: doc.id })} target="_blank">
                                                 <Button variant="outline" size="sm">
                                                     <ExternalLink className="mr-2 h-4 w-4" />

--- a/resources/js/pages/registrar/students/students-table.tsx
+++ b/resources/js/pages/registrar/students/students-table.tsx
@@ -13,7 +13,7 @@ import {
 import { ChevronDown, MoreHorizontal } from 'lucide-react';
 import * as React from 'react';
 
-import { Badge } from '@/components/ui/badge';
+import { EnrollmentStatusBadge, PaymentStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -50,40 +50,6 @@ interface Student {
 
 interface StudentsTableProps {
     students: Student[];
-}
-
-export function getStatusVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
-    switch (status) {
-        case 'completed':
-            return 'default';
-        case 'enrolled':
-            return 'secondary';
-        case 'pending':
-            return 'outline';
-        case 'rejected':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
-}
-
-export function getPaymentStatusVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
-    switch (status) {
-        case 'paid':
-            return 'default';
-        case 'partial':
-            return 'secondary';
-        case 'pending':
-            return 'outline';
-        case 'overdue':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
-}
-
-export function formatStatusName(status: string) {
-    return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
 export function calculateAge(birthdate: string) {
@@ -180,12 +146,8 @@ export const columns: ColumnDef<Student>[] = [
                                 {latestEnrollment.enrollment_id} • {latestEnrollment.school_year}
                             </div>
                             <div className="flex gap-2">
-                                <Badge variant={getStatusVariant(latestEnrollment.status)} className="text-xs">
-                                    {formatStatusName(latestEnrollment.status)}
-                                </Badge>
-                                <Badge variant={getPaymentStatusVariant(latestEnrollment.payment_status)} className="text-xs">
-                                    {formatStatusName(latestEnrollment.payment_status)}
-                                </Badge>
+                                <EnrollmentStatusBadge status={latestEnrollment.status} />
+                                <PaymentStatusBadge status={latestEnrollment.payment_status} />
                             </div>
                         </div>
                     ) : (

--- a/resources/js/pages/student/dashboard.tsx
+++ b/resources/js/pages/student/dashboard.tsx
@@ -1,5 +1,5 @@
 import Heading from '@/components/heading';
-import { Badge } from '@/components/ui/badge';
+import { EnrollmentStatusBadge } from '@/components/status-badges';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Separator } from '@/components/ui/separator';
@@ -88,9 +88,7 @@ export default function StudentDashboard() {
                             </div>
                             <div>
                                 <p className="text-sm text-muted-foreground">Enrollment Status</p>
-                                <Badge variant="default" className="mt-1">
-                                    {studentInfo.enrollmentStatus}
-                                </Badge>
+                                <EnrollmentStatusBadge status={studentInfo.enrollmentStatus} />
                             </div>
                         </div>
                     </CardContent>

--- a/resources/js/pages/super-admin/enrollment-periods/index.tsx
+++ b/resources/js/pages/super-admin/enrollment-periods/index.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/components/ui/badge';
+import { EnrollmentPeriodStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -6,7 +6,7 @@ import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/react';
 import { format } from 'date-fns';
-import { Calendar, CheckCircle2, Clock, PlusCircle, XCircle } from 'lucide-react';
+import { Calendar, PlusCircle } from 'lucide-react';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
 
@@ -51,18 +51,6 @@ interface Props {
     periods: PaginatedEnrollmentPeriods;
     activePeriod: EnrollmentPeriod | null;
 }
-
-const statusColors = {
-    active: 'default',
-    upcoming: 'secondary',
-    closed: 'outline',
-} as const;
-
-const statusIcons = {
-    active: CheckCircle2,
-    upcoming: Clock,
-    closed: XCircle,
-};
 
 export default function EnrollmentPeriodsIndex({ periods, activePeriod }: Props) {
     const breadcrumbs: BreadcrumbItem[] = [
@@ -216,56 +204,47 @@ export default function EnrollmentPeriodsIndex({ periods, activePeriod }: Props)
                                         </TableCell>
                                     </TableRow>
                                 ) : (
-                                    periods.data.map((period) => {
-                                        const StatusIcon = statusIcons[period.status as keyof typeof statusIcons];
-                                        return (
-                                            <TableRow key={period.id}>
-                                                <TableCell className="font-medium">{period.school_year.name}</TableCell>
-                                                <TableCell>
-                                                    <Badge
-                                                        variant={statusColors[period.status as keyof typeof statusColors] || 'default'}
-                                                        className="gap-1"
-                                                    >
-                                                        {StatusIcon && <StatusIcon className="h-3 w-3" />}
-                                                        {period.status}
-                                                    </Badge>
-                                                </TableCell>
-                                                <TableCell>{format(new Date(period.start_date), 'MMM d, yyyy')}</TableCell>
-                                                <TableCell>{format(new Date(period.end_date), 'MMM d, yyyy')}</TableCell>
-                                                <TableCell>{format(new Date(period.regular_registration_deadline), 'MMM d, yyyy')}</TableCell>
-                                                <TableCell>{period.enrollments_count || 0}</TableCell>
-                                                <TableCell className="text-right">
-                                                    <div className="flex justify-end gap-2">
-                                                        <Link href={`/super-admin/enrollment-periods/${period.id}`}>
-                                                            <Button variant="outline" size="sm">
-                                                                View
-                                                            </Button>
-                                                        </Link>
-                                                        {period.status === 'upcoming' && (
-                                                            <Button variant="default" size="sm" onClick={() => handleActivate(period.id)}>
-                                                                Activate
-                                                            </Button>
-                                                        )}
-                                                        {period.status === 'active' && (
-                                                            <Button variant="outline" size="sm" onClick={() => handleClose(period.id)}>
-                                                                Close
-                                                            </Button>
-                                                        )}
-                                                        <Link href={`/super-admin/enrollment-periods/${period.id}/edit`}>
-                                                            <Button variant="outline" size="sm">
-                                                                Edit
-                                                            </Button>
-                                                        </Link>
-                                                        {period.status !== 'active' && (period.enrollments_count || 0) === 0 && (
-                                                            <Button variant="destructive" size="sm" onClick={() => handleDelete(period.id)}>
-                                                                Delete
-                                                            </Button>
-                                                        )}
-                                                    </div>
-                                                </TableCell>
-                                            </TableRow>
-                                        );
-                                    })
+                                    periods.data.map((period) => (
+                                        <TableRow key={period.id}>
+                                            <TableCell className="font-medium">{period.school_year.name}</TableCell>
+                                            <TableCell>
+                                                <EnrollmentPeriodStatusBadge status={period.status} />
+                                            </TableCell>
+                                            <TableCell>{format(new Date(period.start_date), 'MMM d, yyyy')}</TableCell>
+                                            <TableCell>{format(new Date(period.end_date), 'MMM d, yyyy')}</TableCell>
+                                            <TableCell>{format(new Date(period.regular_registration_deadline), 'MMM d, yyyy')}</TableCell>
+                                            <TableCell>{period.enrollments_count || 0}</TableCell>
+                                            <TableCell className="text-right">
+                                                <div className="flex justify-end gap-2">
+                                                    <Link href={`/super-admin/enrollment-periods/${period.id}`}>
+                                                        <Button variant="outline" size="sm">
+                                                            View
+                                                        </Button>
+                                                    </Link>
+                                                    {period.status === 'upcoming' && (
+                                                        <Button variant="default" size="sm" onClick={() => handleActivate(period.id)}>
+                                                            Activate
+                                                        </Button>
+                                                    )}
+                                                    {period.status === 'active' && (
+                                                        <Button variant="outline" size="sm" onClick={() => handleClose(period.id)}>
+                                                            Close
+                                                        </Button>
+                                                    )}
+                                                    <Link href={`/super-admin/enrollment-periods/${period.id}/edit`}>
+                                                        <Button variant="outline" size="sm">
+                                                            Edit
+                                                        </Button>
+                                                    </Link>
+                                                    {period.status !== 'active' && (period.enrollments_count || 0) === 0 && (
+                                                        <Button variant="destructive" size="sm" onClick={() => handleDelete(period.id)}>
+                                                            Delete
+                                                        </Button>
+                                                    )}
+                                                </div>
+                                            </TableCell>
+                                        </TableRow>
+                                    ))
                                 )}
                             </TableBody>
                         </Table>

--- a/resources/js/pages/super-admin/enrollment-periods/show.tsx
+++ b/resources/js/pages/super-admin/enrollment-periods/show.tsx
@@ -1,3 +1,4 @@
+import { EnrollmentPeriodStatusBadge } from '@/components/status-badges';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -5,7 +6,7 @@ import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/react';
 import { format } from 'date-fns';
-import { Calendar, CheckCircle2, Clock, Edit, Trash2, XCircle } from 'lucide-react';
+import { Calendar, CheckCircle2, Edit, Trash2, XCircle } from 'lucide-react';
 import { toast } from 'sonner';
 
 export type EnrollmentPeriod = {
@@ -27,26 +28,12 @@ interface Props {
     period: EnrollmentPeriod;
 }
 
-const statusColors = {
-    active: 'default',
-    upcoming: 'secondary',
-    closed: 'outline',
-} as const;
-
-const statusIcons = {
-    active: CheckCircle2,
-    upcoming: Clock,
-    closed: XCircle,
-};
-
 export default function EnrollmentPeriodShow({ period }: Props) {
     const breadcrumbs: BreadcrumbItem[] = [
         { title: 'Super Admin', href: '/super-admin/dashboard' },
         { title: 'Enrollment Periods', href: '/super-admin/enrollment-periods' },
         { title: period.school_year, href: `/super-admin/enrollment-periods/${period.id}` },
     ];
-
-    const StatusIcon = statusIcons[period.status as keyof typeof statusIcons];
 
     const handleActivate = () => {
         if (confirm('Are you sure you want to activate this enrollment period? This will close any currently active period.')) {
@@ -142,10 +129,7 @@ export default function EnrollmentPeriodShow({ period }: Props) {
                                     <Calendar className="h-5 w-5" />
                                     {period.school_year}
                                 </CardTitle>
-                                <Badge variant={statusColors[period.status as keyof typeof statusColors] || 'default'} className="gap-1">
-                                    {StatusIcon && <StatusIcon className="h-3 w-3" />}
-                                    {period.status}
-                                </Badge>
+                                <EnrollmentPeriodStatusBadge status={period.status} />
                             </div>
                             <CardDescription>School year enrollment period</CardDescription>
                         </CardHeader>

--- a/resources/js/pages/super-admin/school-years/index.tsx
+++ b/resources/js/pages/super-admin/school-years/index.tsx
@@ -1,3 +1,4 @@
+import { SchoolYearStatusBadge } from '@/components/status-badges';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/ui/data-table';
@@ -56,15 +57,7 @@ export default function SchoolYearsIndex({ schoolYears, activeSchoolYear }: Prop
         {
             accessorKey: 'status',
             header: 'Status',
-            cell: ({ row }) => {
-                const statusColors: Record<string, 'default' | 'secondary' | 'outline'> = {
-                    upcoming: 'secondary',
-                    active: 'default',
-                    completed: 'outline',
-                };
-                const variant = statusColors[row.original.status] || 'default';
-                return <Badge variant={variant}>{row.original.status.charAt(0).toUpperCase() + row.original.status.slice(1)}</Badge>;
-            },
+            cell: ({ row }) => <SchoolYearStatusBadge status={row.original.status} />,
         },
         {
             accessorKey: 'start_date',

--- a/resources/js/pages/super-admin/students/columns.tsx
+++ b/resources/js/pages/super-admin/students/columns.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/components/ui/badge';
+import { EnrollmentStatusBadge, PaymentStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ConfirmationDialog } from '@/components/ui/confirmation-dialog';
@@ -34,22 +34,6 @@ function formatCurrency(amount: number) {
         style: 'currency',
         currency: 'PHP',
     }).format(amount);
-}
-
-function getStatusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
-    switch (status) {
-        case 'enrolled':
-        case 'completed':
-        case 'paid':
-            return 'default';
-        case 'pending':
-            return 'secondary';
-        case 'overdue':
-        case 'rejected':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
 }
 
 function ActionsCell({ student }: { student: Student }) {
@@ -159,20 +143,12 @@ export const columns: ColumnDef<Student>[] = [
     {
         accessorKey: 'enrollmentStatus',
         header: 'Enrollment',
-        cell: ({ row }) => (
-            <Badge variant={getStatusVariant(row.getValue('enrollmentStatus'))} className="capitalize">
-                {row.getValue('enrollmentStatus')}
-            </Badge>
-        ),
+        cell: ({ row }) => <EnrollmentStatusBadge status={row.getValue('enrollmentStatus')} />,
     },
     {
         accessorKey: 'paymentStatus',
         header: 'Payment',
-        cell: ({ row }) => (
-            <Badge variant={getStatusVariant(row.getValue('paymentStatus'))} className="capitalize">
-                {row.getValue('paymentStatus')}
-            </Badge>
-        ),
+        cell: ({ row }) => <PaymentStatusBadge status={row.getValue('paymentStatus')} />,
     },
     {
         accessorKey: 'balance',

--- a/resources/js/pages/super-admin/students/enrollments.tsx
+++ b/resources/js/pages/super-admin/students/enrollments.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/components/ui/badge';
+import { EnrollmentStatusBadge } from '@/components/status-badges';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -34,23 +34,6 @@ interface Enrollment {
 interface Props {
     student: Student;
     enrollments: Enrollment[];
-}
-
-function getStatusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
-    switch (status) {
-        case 'enrolled':
-        case 'completed':
-        case 'paid':
-        case 'approved':
-            return 'default';
-        case 'pending':
-        case 'ready_for_payment':
-            return 'secondary';
-        case 'rejected':
-            return 'destructive';
-        default:
-            return 'outline';
-    }
 }
 
 export default function StudentEnrollments({ student, enrollments }: Props) {
@@ -119,9 +102,7 @@ export default function StudentEnrollments({ student, enrollments }: Props) {
                                                 {enrollment.guardian.first_name} {enrollment.guardian.last_name}
                                             </TableCell>
                                             <TableCell>
-                                                <Badge variant={getStatusVariant(enrollment.status)} className="capitalize">
-                                                    {enrollment.status.replace('_', ' ')}
-                                                </Badge>
+                                                <EnrollmentStatusBadge status={enrollment.status} />
                                             </TableCell>
                                             <TableCell>{new Date(enrollment.created_at).toLocaleDateString()}</TableCell>
                                             <TableCell>


### PR DESCRIPTION
## Summary

This commit addresses inconsistencies in the color palette for enrollment and payment statuses across different user roles (super-admin, admin, registrar, guardian, and student).

- Replaced all instances of custom status color logic with centralized status badge components.
- Created new status badge components for `EnrollmentPeriod` and `SchoolYear` to ensure consistency.
- Fixed a TypeScript error in `guardian-dashboard.tsx` caused by an unsupported `className` prop.

Closes: #

## Checklist

- [ ] My code follows the project style (pint, eslint)
- [ ] I added tests for my changes
- [ ] I updated documentation where necessary

## Acceptance criteria

<!-- Describe the acceptance criteria or how to validate the change locally. -->

## Notes

<!-- Any additional notes for reviewers (migration steps, seeder, etc.) -->
