### PR TITLE
Fix wayfinder:generate permission errors

### DIFF
--- a/scripts/fix-permissions.sh
+++ b/scripts/fix-permissions.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Fix permissions for Laravel Sail development environment
+# This script should be run after cloning the repository or when
+# encountering permission errors with wayfinder:generate
+
+echo "Fixing permissions for Laravel Sail..."
+
+# Fix permissions for resources/js directory (wayfinder generates TypeScript files here)
+./vendor/bin/sail exec laravel.test chown -R sail:sail resources/js
+
+# Fix permissions for storage and bootstrap/cache directories
+./vendor/bin/sail exec laravel.test chown -R sail:sail storage bootstrap/cache
+
+echo "Permissions fixed successfully!"
+echo ""
+echo "You can now run: ./vendor/bin/sail npm run dev"


### PR DESCRIPTION
## Summary

Fixes permission errors when running `php artisan wayfinder:generate` which prevented the vite dev server from starting.

## Problem

After cloning the repository or when certain file permissions get reset, the `wayfinder:generate` command would fail with:

```
Error: Command failed: php artisan wayfinder:generate --with-form
file_put_contents(/var/www/html/resources/js/actions/Laravel/index.ts): Failed to open stream: Permission denied
```

This caused `npm run dev` to fail immediately on startup.

## Solution

Created `scripts/fix-permissions.sh` that developers can run to fix ownership of:
- `resources/js` directory (where wayfinder generates TypeScript files)
- `storage` and `bootstrap/cache` directories (standard Laravel permissions)

## Usage

After cloning the repository, run:

```bash
./scripts/fix-permissions.sh
```

Then start the dev server:

```bash
./vendor/bin/sail npm run dev
```

## Testing

- ✅ Verified wayfinder:generate runs successfully after fix
- ✅ Verified npm run dev starts without errors
- ✅ All pre-push checks passed
