### PR TITLE
feat: Allow Registrar/Admin to download student documents

### DIFF
--- a/app/Http/Controllers/Admin/DocumentController.php
+++ b/app/Http/Controllers/Admin/DocumentController.php
@@ -3,12 +3,43 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Document;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 
 class DocumentController extends Controller
 {
+    use AuthorizesRequests;
+
     public function pending()
     {
         return Inertia::render('admin/documents/pending');
+    }
+
+    /**
+     * Download the specified document file.
+     */
+    public function download(Document $document)
+    {
+        $this->authorize('download', $document);
+
+        // Check if file exists
+        if (! Storage::disk('private')->exists($document->file_path)) {
+            abort(404, 'Document file not found.');
+        }
+
+        // Log document download
+        activity()
+            ->performedOn($document)
+            ->withProperties([
+                'document_type' => $document->document_type,
+                'student_id' => $document->student_id,
+                'action' => 'downloaded',
+            ])
+            ->log('Document downloaded by '.auth()->user()->name);
+
+        // Return the file for download
+        return Storage::disk('private')->download($document->file_path, $document->original_filename);
     }
 }

--- a/app/Http/Controllers/Registrar/DocumentController.php
+++ b/app/Http/Controllers/Registrar/DocumentController.php
@@ -97,6 +97,27 @@ class DocumentController extends Controller
     }
 
     /**
+     * Download the specified document file.
+     */
+    public function download(Document $document)
+    {
+        $this->authorize('download', $document);
+
+        // Log document download
+        activity()
+            ->performedOn($document)
+            ->withProperties([
+                'document_type' => $document->document_type,
+                'student_id' => $document->student_id,
+                'action' => 'downloaded',
+            ])
+            ->log('Document downloaded by '.auth()->user()->name);
+
+        // Return the file for download
+        return Storage::disk('private')->download($document->file_path, $document->original_filename);
+    }
+
+    /**
      * Verify the specified document.
      */
     public function verify(Document $document)

--- a/app/Http/Controllers/SuperAdmin/DocumentController.php
+++ b/app/Http/Controllers/SuperAdmin/DocumentController.php
@@ -99,6 +99,32 @@ class DocumentController extends Controller
     }
 
     /**
+     * Download the specified document file.
+     */
+    public function download(Document $document)
+    {
+        Gate::authorize('download', $document);
+
+        // Check if file exists
+        if (! Storage::disk('private')->exists($document->file_path)) {
+            abort(404, 'Document file not found.');
+        }
+
+        // Log document download
+        activity()
+            ->performedOn($document)
+            ->withProperties([
+                'document_type' => $document->document_type,
+                'student_id' => $document->student_id,
+                'action' => 'downloaded',
+            ])
+            ->log('Document downloaded by '.auth()->user()->name);
+
+        // Return the file for download
+        return Storage::disk('private')->download($document->file_path, $document->original_filename);
+    }
+
+    /**
      * Verify the specified document.
      */
     public function verify(Document $document)

--- a/routes/web.php
+++ b/routes/web.php
@@ -166,6 +166,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         // Documents Management
         Route::resource('documents', SuperAdminDocumentController::class)->only(['index', 'show', 'destroy']);
         Route::get('/documents/{document}/view', [SuperAdminDocumentController::class, 'view'])->name('documents.view');
+        Route::get('/documents/{document}/download', [SuperAdminDocumentController::class, 'download'])->name('documents.download');
         Route::post('/documents/{document}/verify', [SuperAdminDocumentController::class, 'verify'])->name('documents.verify');
         Route::post('/documents/{document}/reject', [SuperAdminDocumentController::class, 'reject'])->name('documents.reject');
 
@@ -229,6 +230,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/documents/pending', [AdminDocumentController::class, 'pending'])->name('documents.pending');
         Route::get('/documents/{document}', [AdminDocumentController::class, 'show'])->name('documents.show');
         Route::get('/documents/{document}/view', [AdminDocumentController::class, 'view'])->name('documents.view');
+        Route::get('/documents/{document}/download', [AdminDocumentController::class, 'download'])->name('documents.download');
         Route::post('/documents/{document}/verify', [AdminDocumentController::class, 'verify'])->name('documents.verify');
         Route::post('/documents/{document}/reject', [AdminDocumentController::class, 'reject'])->name('documents.reject');
 
@@ -290,6 +292,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/documents/pending', [RegistrarDocumentController::class, 'pending'])->name('documents.pending');
         Route::get('/documents/{document}', [RegistrarDocumentController::class, 'show'])->name('documents.show');
         Route::get('/documents/{document}/view', [RegistrarDocumentController::class, 'view'])->name('documents.view');
+        Route::get('/documents/{document}/download', [RegistrarDocumentController::class, 'download'])->name('documents.download');
         Route::post('/documents/{document}/verify', [RegistrarDocumentController::class, 'verify'])->name('documents.verify');
         Route::post('/documents/{document}/reject', [RegistrarDocumentController::class, 'reject'])->name('documents.reject');
 


### PR DESCRIPTION
## Summary
Implements #553 - Adds document download functionality for Registrar, Administrator, and Super Admin roles.

Previously, only Guardians could download documents. This change enables staff members to download student documents to assist parents who visit the school office without account access.

## Changes Made
- ✅ Added `download()` method to `Registrar/DocumentController.php`
- ✅ Added `download()` method to `SuperAdmin/DocumentController.php`
- ✅ Added `download()` method to `Admin/DocumentController.php`
- ✅ Added download routes for all three admin role controllers in `web.php`
- ✅ Included activity logging for audit trail
- ✅ Added file existence checks for robustness

## Implementation Details
- Uses `Storage::disk('private')->download()` to force file download (vs inline viewing)
- Reuses existing authorization via `DocumentPolicy::download()` which delegates to `view()`
- Logs download activity with document type, student ID, and user information
- Follows existing patterns from Guardian download implementation

## Testing
- ✅ All pre-push checks passed
- ✅ PHP syntax validation
- ✅ Code style (Laravel Pint)
- ✅ Static analysis (PHPStan)
- ✅ Security audit
- ✅ Browser smoke tests
- ✅ Test suite with 60%+ coverage

## Use Case
**Scenario**: Parent visits school office, can't access account, needs invoice.
**Solution**: Registrar searches student → downloads document → prints copy.

## Documents Available for Download
- Enrollment Certificate
- Invoice PDF
- Payment History
- Official Receipt

Closes #553