### PR TITLE
Fix #528: Guardian DocumentController index returns Inertia page instead of JSON

### DIFF
--- a/app/Http/Controllers/Guardian/DocumentController.php
+++ b/app/Http/Controllers/Guardian/DocumentController.php
@@ -13,6 +13,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class DocumentController extends Controller
@@ -22,7 +24,7 @@ class DocumentController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index(Student $student): JsonResponse
+    public function index(Student $student): InertiaResponse
     {
         $this->authorize('view', $student);
 
@@ -31,7 +33,8 @@ class DocumentController extends Controller
             ->latest('upload_date')
             ->get();
 
-        return response()->json([
+        return Inertia::render('guardian/students/documents/index', [
+            'student' => $student->only(['id', 'first_name', 'middle_name', 'last_name', 'student_id']),
             'documents' => $documents,
         ]);
     }

--- a/tests/Feature/Guardian/DocumentControllerTest.php
+++ b/tests/Feature/Guardian/DocumentControllerTest.php
@@ -134,10 +134,14 @@ test('guardian can list documents for their student', function () {
     Document::factory()->count(3)->create(['student_id' => $this->student->id]);
 
     $response = $this->actingAs($this->guardian)
-        ->getJson(route('guardian.students.documents.index', $this->student));
+        ->get(route('guardian.students.documents.index', $this->student));
 
     $response->assertStatus(200)
-        ->assertJsonCount(3, 'documents');
+        ->assertInertia(fn ($page) => $page
+            ->component('guardian/students/documents/index')
+            ->has('documents', 3)
+            ->has('student')
+        );
 });
 
 test('guardian cannot list documents for student they do not own', function () {
@@ -145,7 +149,7 @@ test('guardian cannot list documents for student they do not own', function () {
     Document::factory()->count(3)->create(['student_id' => $otherStudent->id]);
 
     $response = $this->actingAs($this->guardian)
-        ->getJson(route('guardian.students.documents.index', $otherStudent));
+        ->get(route('guardian.students.documents.index', $otherStudent));
 
     $response->assertStatus(403);
 });


### PR DESCRIPTION
## Summary
Fixes #528 - Changes `Guardian/DocumentController::index()` to return an Inertia page instead of JSON response.

This was the root cause of issue #528 where clicking document notifications showed raw JSON instead of the rendered documents page.

## Problem
PR #531 fixed the notification routing to redirect correctly, but the destination endpoint (`/guardian/students/{student}/documents`) was still returning JSON instead of rendering the Inertia page.

## Changes Made
### Backend
- ✅ Changed `DocumentController::index()` return type from `JsonResponse` to `InertiaResponse`
- ✅ Updated method to render `guardian/students/documents/index` Inertia component
- ✅ Added proper Inertia imports

### Tests  
- ✅ Updated `DocumentControllerTest` to expect Inertia response instead of JSON
- ✅ Changed from `getJson()` to `get()` for index route tests
- ✅ Updated assertions to check for Inertia component and props

## Why the Browser Test Didn't Catch This
The browser test in `Issue528NotificationRoutingTest.php` only verified the notification redirect behavior, but never **followed the redirect** to check what the destination returned. The feature test was actually **validating the buggy behavior** by expecting JSON with `getJson()`.

## Testing
- ✅ All pre-push checks passed
- ✅ PHP syntax, code style (Pint), static analysis (PHPStan)
- ✅ Security audit passed
- ✅ Browser smoke tests passed  
- ✅ Full test suite passed with 60%+ coverage
- ✅ Updated tests now correctly verify Inertia page rendering

## Verification
Users can now click document notifications and see the proper rendered documents page instead of raw JSON.

Closes #528