### PR TITLE
Add Pest v4 browser tests for Registrar workflows

### DIFF
--- a/resources/js/pages/registrar/students/students-table.tsx
+++ b/resources/js/pages/registrar/students/students-table.tsx
@@ -86,19 +86,20 @@ export const columns: ColumnDef<Student>[] = [
     {
         accessorKey: 'name',
         header: 'Name',
-        accessorFn: (row) => `${row.first_name} ${row.middle_name.charAt(0)}. ${row.last_name}`,
+        accessorFn: (row) => `${row.first_name} ${row.middle_name ? row.middle_name.charAt(0) + '. ' : ''}${row.last_name}`,
         cell: ({ row }) => {
             const student = row.original;
             return (
                 <div>
-                    <div>{`${student.first_name} ${student.middle_name.charAt(0)}. ${student.last_name}`}</div>
+                    <div>{`${student.first_name} ${student.middle_name ? student.middle_name.charAt(0) + '. ' : ''}${student.last_name}`}</div>
                     <div className="text-xs text-muted-foreground">{student.address}</div>
                 </div>
             );
         },
         filterFn: (row, id, value) => {
             const student = row.original;
-            const fullName = `${student.first_name} ${student.middle_name.charAt(0)}. ${student.last_name}`.toLowerCase();
+            const fullName =
+                `${student.first_name} ${student.middle_name ? student.middle_name.charAt(0) + '. ' : ''}${student.last_name}`.toLowerCase();
             return fullName.includes(value.toLowerCase());
         },
     },

--- a/tests/Browser/RegistrarBrowserTest.php
+++ b/tests/Browser/RegistrarBrowserTest.php
@@ -103,6 +103,25 @@ describe('Registrar Browser Tests - Enrollment Management', function () {
 });
 
 describe('Registrar Browser Tests - Student Management', function () {
+    test('registrar can view students list page', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create([
+            'first_name' => 'Alice',
+            'middle_name' => null,
+            'last_name' => 'StudentList',
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit('/registrar/students')
+            ->waitForText('Students')
+            ->assertSee('Alice StudentList');
+    })->group('registrar-browser', 'critical');
+
     test('registrar can view student details page directly', function () {
         $registrar = User::factory()->registrar()->create([
             'email' => 'registrar@test.com',
@@ -120,6 +139,34 @@ describe('Registrar Browser Tests - Student Management', function () {
         visit("/registrar/students/{$student->id}")
             ->waitForText('Bob StudentDetail')
             ->assertSee('Bob StudentDetail');
+    })->group('registrar-browser', 'critical');
+
+    test('registrar can search students by name', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        Student::factory()->create([
+            'first_name' => 'FindMe',
+            'middle_name' => null,
+            'last_name' => 'SearchTest',
+        ]);
+
+        Student::factory()->create([
+            'first_name' => 'Other',
+            'middle_name' => null,
+            'last_name' => 'Student',
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit('/registrar/students')
+            ->waitForText('Students')
+            ->type('[placeholder="Filter by name..."]', 'FindMe')
+            ->wait(1)
+            ->assertSee('FindMe SearchTest')
+            ->assertDontSee('Other Student');
     })->group('registrar-browser', 'critical');
 });
 

--- a/tests/Browser/RegistrarBrowserTest.php
+++ b/tests/Browser/RegistrarBrowserTest.php
@@ -1,0 +1,201 @@
+<?php
+
+use App\Enums\EnrollmentStatus;
+use App\Models\Enrollment;
+use App\Models\Guardian;
+use App\Models\Student;
+use App\Models\User;
+use Database\Seeders\RolesAndPermissionsSeeder;
+
+uses(\Illuminate\Foundation\Testing\DatabaseMigrations::class);
+
+beforeEach(function () {
+    $this->seed(RolesAndPermissionsSeeder::class);
+});
+
+describe('Registrar Browser Tests - Dashboard', function () {
+    test('registrar can view dashboard', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit('/registrar/dashboard')
+            ->waitForText('Dashboard')
+            ->assertSee('Dashboard');
+    })->group('registrar-browser', 'critical');
+});
+
+describe('Registrar Browser Tests - Enrollment Management', function () {
+    test('registrar can view enrollments list', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create([
+            'first_name' => 'John',
+            'middle_name' => null,
+            'last_name' => 'TestStudent',
+        ]);
+
+        Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'status' => EnrollmentStatus::PENDING,
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit('/registrar/enrollments')
+            ->waitForText('Enrollments')
+            ->assertSee('John TestStudent');
+    })->group('registrar-browser', 'critical');
+
+    test('registrar can view enrollment details page directly', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create([
+            'first_name' => 'Jane',
+            'middle_name' => null,
+            'last_name' => 'DetailTest',
+        ]);
+
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'status' => EnrollmentStatus::PENDING,
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit("/registrar/enrollments/{$enrollment->id}")
+            ->waitForText('Jane DetailTest')
+            ->assertSee('Jane DetailTest');
+    })->group('registrar-browser', 'critical');
+
+    test('registrar can see enrollment status badge', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create([
+            'first_name' => 'Status',
+            'middle_name' => null,
+            'last_name' => 'BadgeTest',
+        ]);
+
+        Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'status' => EnrollmentStatus::PENDING,
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit('/registrar/enrollments')
+            ->waitForText('Enrollments')
+            ->assertSee('pending'); // Status badge text
+    })->group('registrar-browser', 'critical');
+});
+
+describe('Registrar Browser Tests - Student Management', function () {
+    test('registrar can view student details page directly', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create([
+            'first_name' => 'Bob',
+            'middle_name' => null,
+            'last_name' => 'StudentDetail',
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit("/registrar/students/{$student->id}")
+            ->waitForText('Bob StudentDetail')
+            ->assertSee('Bob StudentDetail');
+    })->group('registrar-browser', 'critical');
+});
+
+describe('Registrar Browser Tests - Authorization', function () {
+    test('registrar cannot access super admin routes', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit('/super-admin/dashboard')
+            ->wait(1)
+            // Should be redirected or see 403
+            ->assertDontSee('Super Admin Dashboard');
+    })->group('registrar-browser', 'critical');
+});
+
+describe('Registrar Browser Tests - Complete Workflows', function () {
+    test('registrar can view enrollment details and see student information', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $guardian = Guardian::factory()->create([
+            'first_name' => 'Parent',
+            'last_name' => 'Guardian',
+        ]);
+
+        $student = Student::factory()->create([
+            'first_name' => 'Complete',
+            'middle_name' => null,
+            'last_name' => 'Workflow',
+        ]);
+
+        $enrollment = Enrollment::factory()->create([
+            'student_id' => $student->id,
+            'guardian_id' => $guardian->id,
+            'status' => EnrollmentStatus::PENDING,
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit("/registrar/enrollments/{$enrollment->id}")
+            ->waitForText('Complete Workflow')
+            ->assertSee('Complete Workflow')
+            ->assertSee('Parent Guardian')
+            ->assertSee('pending');
+    })->group('registrar-browser', 'critical');
+
+    test('registrar can view student with enrollment history', function () {
+        $registrar = User::factory()->registrar()->create([
+            'email' => 'registrar@test.com',
+            'password' => bcrypt('password'),
+        ]);
+
+        $student = Student::factory()->create([
+            'first_name' => 'History',
+            'middle_name' => null,
+            'last_name' => 'Student',
+        ]);
+
+        Enrollment::factory()->count(2)->create([
+            'student_id' => $student->id,
+            'status' => EnrollmentStatus::ENROLLED,
+        ]);
+
+        $this->actingAs($registrar);
+
+        visit("/registrar/students/{$student->id}")
+            ->waitForText('History Student')
+            ->assertSee('History Student')
+            ->wait(1)
+            // Should see enrollment information
+            ->assertSee('Enrollment');
+    })->group('registrar-browser', 'critical');
+});


### PR DESCRIPTION
## Summary
- Added **10 comprehensive browser tests** using Pest v4 native browser testing
- **Fixed critical bug** preventing student list page from loading
- All tests interact with actual rendered pages via real browser
- All tests passing ✅

## Bug Fixed 🐛
**JavaScript Error on Student List Page:**
- **Issue:** Cannot read properties of null reading charAt
- **Root Cause:** Code in students-table.tsx tried to access middle_name.charAt without null check
- **Impact:** Student list page completely broken - could not load
- **Fix:** Added null checks in 3 places (accessorFn, cell, filterFn)
- **Files Changed:** resources/js/pages/registrar/students/students-table.tsx

## Browser Tests Added (10 passing)
These are REAL browser tests that interact with rendered UI:

### Dashboard (1 test)
✅ Dashboard viewing and access

### Enrollment Management (3 tests)
✅ Enrollment list viewing
✅ Enrollment details page navigation
✅ Enrollment status badge display

### Student Management (3 tests)
✅ Student list page viewing (now works after bug fix!)
✅ Student details page viewing
✅ Student search functionality

### Authorization (1 test)
✅ Registrar cannot access super admin routes

### Complete Workflows (2 tests)
✅ Viewing enrollment with student and guardian info
✅ Viewing student with enrollment history

## Test Results
```
Tests:    10 passed (23 assertions)
Duration: 19.94s
```

## Technical Details
- Uses Pest v4 built-in browser testing (not Dusk)
- Tests use visit(), waitForText(), assertSee() for real browser interactions
- Each test logs in as registrar and tests actual user workflows
- Tests catch real bugs (like the null middle_name issue)
