### PR TITLE
feat: Improve superadmin student update and fix UI bugs

### DIFF
--- a/app/Http/Requests/SuperAdmin/UpdateStudentRequest.php
+++ b/app/Http/Requests/SuperAdmin/UpdateStudentRequest.php
@@ -27,19 +27,19 @@ class UpdateStudentRequest extends FormRequest
         $student = $this->route('student');
 
         return [
-            'first_name' => ['required', 'string', 'max:100'],
+            'first_name' => ['sometimes', 'string', 'max:100'],
             'middle_name' => ['nullable', 'string', 'max:100'],
-            'last_name' => ['required', 'string', 'max:100'],
-            'birthdate' => ['required', 'date', 'before:today'],
+            'last_name' => ['sometimes', 'string', 'max:100'],
+            'birthdate' => ['sometimes', 'date', 'before:today'],
             'birth_place' => ['nullable', 'string', 'max:255'],
-            'gender' => ['required', Rule::in(Gender::values())],
+            'gender' => ['sometimes', Rule::in(Gender::values())],
             'nationality' => ['nullable', 'string', 'max:100'],
             'religion' => ['nullable', 'string', 'max:100'],
-            'address' => ['required', 'string', 'max:500'],
+            'address' => ['sometimes', 'string', 'max:500'],
             'phone' => ['nullable', 'string', 'max:20'],
             'email' => ['nullable', 'email', 'unique:students,email,'.$student->id],
-            'grade_level' => ['required', Rule::in(GradeLevel::values())],
-            'guardian_ids' => ['required', 'array', 'min:1'],
+            'grade_level' => ['sometimes', Rule::in(GradeLevel::values())],
+            'guardian_ids' => ['sometimes', 'array', 'min:1'],
             'guardian_ids.*' => ['exists:guardians,id'],
         ];
     }

--- a/resources/js/components/ui/confirmation-dialog.tsx
+++ b/resources/js/components/ui/confirmation-dialog.tsx
@@ -43,7 +43,7 @@ export function ConfirmationDialog({
                         onClick={onConfirm}
                         className={
                             variant === 'destructive'
-                                ? 'bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                                ? 'bg-destructive text-white hover:bg-destructive/90'
                                 : ''
                         }
                     >

--- a/resources/js/pages/shared/tuition.tsx
+++ b/resources/js/pages/shared/tuition.tsx
@@ -1,10 +1,12 @@
 import Heading from '@/components/heading';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/react';
 import { CalendarDays, DollarSign, MapPin } from 'lucide-react';
+import { useState } from 'react';
 
 interface GradeLevelFeeDetail {
     tuition: number;
@@ -13,6 +15,14 @@ interface GradeLevelFeeDetail {
     library: number;
     sports: number;
     total: number;
+    payment_plans: Record<
+        string,
+        {
+            label: string;
+            installments: number;
+            amount_per_installment: number;
+        }
+    >;
 }
 
 interface PaymentPlanDetail {
@@ -41,6 +51,8 @@ export default function Tuition({ gradeLevelFees, settings, paymentPlans }: Prop
         },
     ];
 
+    const [selectedPaymentPlan, setSelectedPaymentPlan] = useState<string>(paymentPlans[0]?.value || '');
+
     const parseCurrency = (amount: number) => amount || 0;
 
     const formatCurrency = (amount: number) => {
@@ -64,46 +76,69 @@ export default function Tuition({ gradeLevelFees, settings, paymentPlans }: Prop
                             <CardTitle>Grade Level Fees Reference</CardTitle>
                         </CardHeader>
                         <CardContent>
+                            <div className="mb-4 flex items-center gap-2">
+                                <span className="text-sm font-medium">View by Payment Plan:</span>
+                                <Select value={selectedPaymentPlan} onValueChange={setSelectedPaymentPlan}>
+                                    <SelectTrigger className="w-[180px]">
+                                        <SelectValue placeholder="Select a plan" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {paymentPlans.map((plan) => (
+                                            <SelectItem key={plan.value} value={plan.value}>
+                                                {plan.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
                             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-                                {Object.entries(gradeLevelFees).map(([level, fees]) => (
-                                    <Card key={level} className="p-4">
-                                        <CardTitle className="mb-2 text-lg">{level}</CardTitle>
-                                        <Separator className="my-2" />
-                                        <div className="space-y-1 text-sm">
-                                            <div className="flex justify-between">
-                                                <span>Tuition Fee:</span>
-                                                <span className="font-medium">{formatCurrency(parseCurrency(fees.tuition))}</span>
-                                            </div>
-                                            <div className="flex justify-between">
-                                                <span>Miscellaneous Fee:</span>
-                                                <span className="font-medium">{formatCurrency(parseCurrency(fees.miscellaneous))}</span>
-                                            </div>
-                                            {parseCurrency(fees.laboratory) > 0 && (
-                                                <div className="flex justify-between">
-                                                    <span>Laboratory Fee:</span>
-                                                    <span className="font-medium">{formatCurrency(parseCurrency(fees.laboratory))}</span>
-                                                </div>
-                                            )}
-                                            {parseCurrency(fees.library) > 0 && (
-                                                <div className="flex justify-between">
-                                                    <span>Library Fee:</span>
-                                                    <span className="font-medium">{formatCurrency(parseCurrency(fees.library))}</span>
-                                                </div>
-                                            )}
-                                            {parseCurrency(fees.sports) > 0 && (
-                                                <div className="flex justify-between">
-                                                    <span>Sports Fee:</span>
-                                                    <span className="font-medium">{formatCurrency(parseCurrency(fees.sports))}</span>
-                                                </div>
-                                            )}
+                                {Object.entries(gradeLevelFees).map(([level, fees]) => {
+                                    const planDetails = fees.payment_plans[selectedPaymentPlan];
+                                    return (
+                                        <Card key={level} className="p-4">
+                                            <CardTitle className="mb-2 text-lg">{level}</CardTitle>
                                             <Separator className="my-2" />
-                                            <div className="flex justify-between font-semibold">
-                                                <span>Total:</span>
-                                                <span>{formatCurrency(parseCurrency(fees.total))}</span>
+                                            <div className="space-y-1 text-sm">
+                                                <div className="flex justify-between">
+                                                    <span>Tuition Fee:</span>
+                                                    <span className="font-medium">{formatCurrency(parseCurrency(fees.tuition))}</span>
+                                                </div>
+                                                <div className="flex justify-between">
+                                                    <span>Miscellaneous Fee:</span>
+                                                    <span className="font-medium">{formatCurrency(parseCurrency(fees.miscellaneous))}</span>
+                                                </div>
+                                                {parseCurrency(fees.laboratory) > 0 && (
+                                                    <div className="flex justify-between">
+                                                        <span>Laboratory Fee:</span>
+                                                        <span className="font-medium">{formatCurrency(parseCurrency(fees.laboratory))}</span>
+                                                    </div>
+                                                )}
+                                                {parseCurrency(fees.library) > 0 && (
+                                                    <div className="flex justify-between">
+                                                        <span>Library Fee:</span>
+                                                        <span className="font-medium">{formatCurrency(parseCurrency(fees.library))}</span>
+                                                    </div>
+                                                )}
+                                                {parseCurrency(fees.sports) > 0 && (
+                                                    <div className="flex justify-between">
+                                                        <span>Sports Fee:</span>
+                                                        <span className="font-medium">{formatCurrency(parseCurrency(fees.sports))}</span>
+                                                    </div>
+                                                )}
+                                                <Separator className="my-2" />
+                                                <div className="flex justify-between font-semibold">
+                                                    <span>Total per {planDetails?.label || 'Installment'}:</span>
+                                                    <span>{formatCurrency(parseCurrency(planDetails?.amount_per_installment || 0))}</span>
+                                                </div>
+                                                {planDetails && planDetails.installments > 1 && (
+                                                    <p className="text-right text-xs text-muted-foreground">
+                                                        ({planDetails.installments} installments)
+                                                    </p>
+                                                )}
                                             </div>
-                                        </div>
-                                    </Card>
-                                ))}
+                                        </Card>
+                                    );
+                                })}
                             </div>
                         </CardContent>
                     </Card>

--- a/resources/js/pages/super-admin/receipts/edit.tsx
+++ b/resources/js/pages/super-admin/receipts/edit.tsx
@@ -51,10 +51,10 @@ interface Props {
 
 export default function ReceiptEdit({ receipt, payments, invoices }: Props) {
     const { data, setData, put, processing, errors, wasSuccessful } = useForm({
-        payment_id: receipt.payment_id?.toString() || '',
-        invoice_id: receipt.invoice_id?.toString() || '',
+        payment_id: receipt.payment_id?.toString() || null,
+        invoice_id: receipt.invoice_id?.toString() || null,
         receipt_date: receipt.receipt_date || '',
-        amount: receipt.amount.toString() || '',
+        amount: receipt.amount?.toString() || '',
         payment_method: receipt.payment_method || '',
         notes: receipt.notes || '',
     });
@@ -91,12 +91,15 @@ export default function ReceiptEdit({ receipt, payments, invoices }: Props) {
                         >
                             <div>
                                 <Label>Payment (Optional)</Label>
-                                <Select value={data.payment_id} onValueChange={(value) => setData('payment_id', value)}>
+                                <Select
+                                    value={data.payment_id || ''}
+                                    onValueChange={(value) => setData('payment_id', value === 'none-selected' ? null : value)}
+                                >
                                     <SelectTrigger>
                                         <SelectValue placeholder="Select a payment" />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem value="">None</SelectItem>
+                                        <SelectItem value="none-selected">None</SelectItem>
                                         {payments.map((payment) => {
                                             const student = payment.invoice?.enrollment?.student;
                                             return (
@@ -113,12 +116,15 @@ export default function ReceiptEdit({ receipt, payments, invoices }: Props) {
 
                             <div>
                                 <Label>Invoice (Optional)</Label>
-                                <Select value={data.invoice_id} onValueChange={(value) => setData('invoice_id', value)}>
+                                <Select
+                                    value={data.invoice_id || ''}
+                                    onValueChange={(value) => setData('invoice_id', value === 'none-selected' ? null : value)}
+                                >
                                     <SelectTrigger>
                                         <SelectValue placeholder="Select an invoice" />
                                     </SelectTrigger>
                                     <SelectContent>
-                                        <SelectItem value="">None</SelectItem>
+                                        <SelectItem value="none-selected">None</SelectItem>
                                         {invoices.map((invoice) => {
                                             const student = invoice.enrollment?.student;
                                             return (

--- a/resources/js/pages/super-admin/students/edit.tsx
+++ b/resources/js/pages/super-admin/students/edit.tsx
@@ -55,7 +55,7 @@ export default function StudentEdit({ student, guardians, gradelevels }: Props) 
         address: student.address,
         phone: student.phone,
         email: student.email,
-        grade: student.grade,
+        grade_level: student.grade,
         guardian_ids: student.guardians.map((g) => g.id),
     });
 
@@ -183,8 +183,8 @@ export default function StudentEdit({ student, guardians, gradelevels }: Props) 
                                 </div>
                                 <div>
                                     <Label htmlFor="grade">Grade</Label>
-                                    <Select value={data.grade} onValueChange={(value) => setData('grade', value)}>
-                                        <SelectTrigger className={errors.grade ? 'border-red-500' : ''}>
+                                    <Select value={data.grade_level} onValueChange={(value) => setData('grade_level', value)}>
+                                        <SelectTrigger className={errors.grade_level ? 'border-red-500' : ''}>
                                             <SelectValue placeholder="Select Grade Level" />
                                         </SelectTrigger>
                                         <SelectContent>
@@ -195,7 +195,7 @@ export default function StudentEdit({ student, guardians, gradelevels }: Props) 
                                             ))}
                                         </SelectContent>
                                     </Select>
-                                    {errors.grade && <p className="mt-1 text-sm text-red-500">{errors.grade}</p>}
+                                    {errors.grade_level && <p className="mt-1 text-sm text-red-500">{errors.grade_level}</p>}
                                 </div>
                                 <div className="col-span-full">
                                     <Label htmlFor="address">Address</Label>


### PR DESCRIPTION
This commit addresses several issues related to the superadmin panel:

- **Student Update Functionality:**
  - Made the validation rules for updating a student more flexible by using `sometimes` instead of `required` in `app/Http/Requests/SuperAdmin/UpdateStudentRequest.php`. This allows for partial updates of student information.
  - Updated the `StudentController` (`app/Http/Controllers/SuperAdmin/StudentController.php`) to correctly handle partial updates, preventing an "Undefined array key" error.
  - Corrected a data mismatch in the "Edit Student" form (`resources/js/pages/super-admin/students/edit.tsx`), ensuring the `grade_level` is correctly handled.

- **Receipts Module UI Fix:**
  - Fixed a bug in the "Delete guardian modal" where the delete button text was not visible (`resources/js/components/ui/confirmation-dialog.tsx`).
  - Fixed a JavaScript error (white screen) on the "Edit Receipt" page (`resources/js/pages/super-admin/receipts/edit.tsx`) by adding a null check for `receipt.amount`.
  - Fixed a TypeScript error related to `Select.Item` in `resources/js/pages/super-admin/receipts/edit.tsx` by handling `null` values correctly.

- **Tuition Page Enhancement:**
  - Modified the `TuitionController` (`app/Http/Controllers/TuitionController.php`) to calculate and structure tuition fees for each grade level across all available payment plans (Annual, Semestral, Monthly).
  - Updated the `shared/tuition.tsx` component to display these fees based on a selected payment plan using a dropdown.

## Summary

<!-- Short description of the change. Include the issue number if applicable. -->

Closes: #

## Checklist

- [ ] My code follows the project style (pint, eslint)
- [ ] I added tests for my changes
- [ ] I updated documentation where necessary

## Acceptance criteria

<!-- Describe the acceptance criteria or how to validate the change locally. -->

## Notes

<!-- Any additional notes for reviewers (migration steps, seeder, etc.) -->
