### PR TITLE
Fix: Resolve TypeError and 403 errors in various React components and…

### DIFF
--- a/app/Http/Controllers/Guardian/ReceiptController.php
+++ b/app/Http/Controllers/Guardian/ReceiptController.php
@@ -53,9 +53,9 @@ class ReceiptController extends Controller
 
     public function show(Receipt $receipt)
     {
-        Gate::authorize('view', $receipt);
-
         $receipt->load(['payment.invoice.enrollment.student', 'invoice.enrollment.student', 'receivedBy']);
+
+        Gate::authorize('view', $receipt);
 
         return Inertia::render('guardian/receipts/show', [
             'receipt' => $receipt,

--- a/app/Policies/ReceiptPolicy.php
+++ b/app/Policies/ReceiptPolicy.php
@@ -12,7 +12,7 @@ class ReceiptPolicy
      */
     public function viewAny(User $user): bool
     {
-        return $user->hasAnyRole(['super_admin', 'administrator', 'registrar']) || $user->is_active;
+        return $user->hasAnyRole(['super_admin', 'administrator', 'registrar', 'guardian']) || $user->is_active;
     }
 
     /**
@@ -25,6 +25,11 @@ class ReceiptPolicy
         }
 
         if ($user->hasRole('guardian')) {
+            // Ensure the guardian relationship is loaded for the user
+            if (! $user->relationLoaded('guardian')) {
+                $user->load('guardian');
+            }
+
             return $receipt->payment?->invoice?->enrollment?->guardian_id === $user->guardian?->id;
         }
 

--- a/resources/js/pages/guardian/invoices/index.tsx
+++ b/resources/js/pages/guardian/invoices/index.tsx
@@ -75,7 +75,7 @@ export default function GuardianInvoicesIndex({ invoices, filters }: Props) {
     ];
 
     const [sorting, setSorting] = useState<SortingState>(
-        filters.sort_by && filters.sort_direction ? [{ id: filters.sort_by, desc: filters.sort_direction === 'desc' }] : [],
+        filters?.sort_by && filters?.sort_direction ? [{ id: filters.sort_by, desc: filters.sort_direction === 'desc' }] : [],
     );
 
     useEffect(() => {

--- a/resources/js/pages/guardian/payments/index.tsx
+++ b/resources/js/pages/guardian/payments/index.tsx
@@ -60,7 +60,7 @@ export default function PaymentsIndex({ payments }: Props) {
     ];
 
     const [sorting, setSorting] = useState<SortingState>(
-        payments.filters.sort_by && payments.filters.sort_direction
+        payments.filters?.sort_by && payments.filters?.sort_direction
             ? [{ id: payments.filters.sort_by, desc: payments.filters.sort_direction === 'desc' }]
             : [],
     );

--- a/resources/js/pages/guardian/receipts/index.tsx
+++ b/resources/js/pages/guardian/receipts/index.tsx
@@ -74,7 +74,7 @@ export default function ReceiptsIndex({ receipts }: Props) {
     ];
 
     const [sorting, setSorting] = useState<SortingState>(
-        receipts.filters.sort_by && receipts.filters.sort_direction
+        receipts.filters?.sort_by && receipts.filters?.sort_direction
             ? [{ id: receipts.filters.sort_by, desc: receipts.filters.sort_direction === 'desc' }]
             : [],
     );

--- a/resources/js/pages/super-admin/receipts/index.tsx
+++ b/resources/js/pages/super-admin/receipts/index.tsx
@@ -74,7 +74,7 @@ export default function ReceiptsIndex({ receipts }: Props) {
     ];
 
     const [sorting, setSorting] = useState<SortingState>(
-        receipts.filters.sort_by && receipts.filters.sort_direction
+        receipts.filters?.sort_by && receipts.filters?.sort_direction
             ? [{ id: receipts.filters.sort_by, desc: receipts.filters.sort_direction === 'desc' }]
             : [],
     );

--- a/resources/js/pages/super-admin/school-years/index.tsx
+++ b/resources/js/pages/super-admin/school-years/index.tsx
@@ -46,7 +46,7 @@ export default function SchoolYearsIndex({ schoolYears, activeSchoolYear }: Prop
     ];
 
     const [sorting, setSorting] = useState<SortingState>(
-        schoolYears.filters.sort_by && schoolYears.filters.sort_direction
+        schoolYears.filters?.sort_by && schoolYears.filters?.sort_direction
             ? [{ id: schoolYears.filters.sort_by, desc: schoolYears.filters.sort_direction === 'desc' }]
             : [],
     );

--- a/resources/js/pages/super-admin/settings/index.tsx
+++ b/resources/js/pages/super-admin/settings/index.tsx
@@ -40,7 +40,7 @@ export default function SettingsIndex({ settings }: Props) {
     ];
 
     const [sorting, setSorting] = useState<SortingState>(
-        settings.filters.sort_by && settings.filters.sort_direction
+        settings.filters?.sort_by && settings.filters?.sort_direction
             ? [{ id: settings.filters.sort_by, desc: settings.filters.sort_direction === 'desc' }]
             : [],
     );

--- a/tests/Feature/Policies/ReceiptPolicyTest.php
+++ b/tests/Feature/Policies/ReceiptPolicyTest.php
@@ -33,11 +33,11 @@ it('allows registrar to view any receipts', function () {
     expect($this->policy->viewAny($user))->toBeTrue();
 });
 
-it('denies other roles from viewing any receipts', function () {
+it('allows guardian to view any receipts', function () {
     $user = User::factory()->create();
     $user->assignRole('guardian');
 
-    expect($this->policy->viewAny($user))->toBeFalse();
+    expect($this->policy->viewAny($user))->toBeTrue();
 });
 
 it('allows super_admin to view a receipt', function () {


### PR DESCRIPTION
… policies

This commit addresses several issues:
- Corrected TypeError: Cannot read properties of undefined (reading 'sort_by') in:
  - resources/js/pages/guardian/invoices/index.tsx
  - resources/js/pages/guardian/payments/index.tsx
  - resources/js/pages/guardian/receipts/index.tsx
  - resources/js/pages/super-admin/receipts/index.tsx
  - resources/js/pages/super-admin/school-years/index.tsx
  - resources/js/pages/super-admin/settings/index.tsx by adding optional chaining to filter access.

- Resolved 403 (Forbidden) error for guardians viewing receipts by:
  - Correcting the comparison in  for  user.
  - Eager-loading necessary relationships in  before authorization check.
  - Including 'guardian' role in  method of .

## Summary

<!-- Short description of the change. Include the issue number if applicable. -->

Closes: #

## Checklist

- [ ] My code follows the project style (pint, eslint)
- [ ] I added tests for my changes
- [ ] I updated documentation where necessary

## Acceptance criteria

<!-- Describe the acceptance criteria or how to validate the change locally. -->

## Notes

<!-- Any additional notes for reviewers (migration steps, seeder, etc.) -->
