### PR TITLE
feat: Add school logo to downloadable PDF documents

### DIFF
--- a/resources/views/pdf/enrollment-certificate.blade.php
+++ b/resources/views/pdf/enrollment-certificate.blade.php
@@ -121,6 +121,7 @@
 <body>
     <div class="certificate-container">
         <div class="header">
+            <img src="{{ public_path('images/cbhlc-logo.png') }}" alt="School Logo" style="width: 80px; float: left; margin-right: 20px;">
             <div style="font-size: 14px;">Republic of the Philippines</div>
             <div class="school-name">Christian Bible Heritage Learning Center</div>
             <div>{{ $schoolAddress }}</div>

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -105,6 +105,7 @@
 <body>
     <div class="container">
         <div class="header">
+            <img src="{{ public_path('images/cbhlc-logo.png') }}" alt="School Logo" style="width: 100px; float: left; margin-right: 20px;">
             <div class="school-name">Christian Bible Heritage Learning Center</div>
             <div class="school-address">{{ $schoolAddress }}</div>
             <div class="school-contact">Tel: {{ $schoolPhone }} | Email: {{ $schoolEmail }}</div>

--- a/resources/views/pdf/payment-history.blade.php
+++ b/resources/views/pdf/payment-history.blade.php
@@ -22,6 +22,7 @@
 </head>
 <body>
     <div class="header">
+        <img src="{{ public_path('images/cbhlc-logo.png') }}" alt="School Logo" style="width: 80px; float: left; margin-right: 20px;">
         <div class="school-name">Christian Bible Heritage Learning Center</div>
         <div>{{ $schoolAddress }}</div>
         <div>{{ $schoolPhone }} | {{ $schoolEmail }}</div>

--- a/resources/views/pdf/payment-receipt.blade.php
+++ b/resources/views/pdf/payment-receipt.blade.php
@@ -86,6 +86,7 @@
 <body>
     <div class="receipt-container">
         <div class="header">
+            <img src="{{ public_path('images/cbhlc-logo.png') }}" alt="School Logo" style="width: 80px; float: left; margin-right: 20px;">
             <div class="school-name">Christian Bible Heritage Learning Center</div>
             <div>{{ config('app.school_address', 'Lantapan, Bukidnon') }}</div>
             <div>{{ config('app.school_phone', '') }} | {{ config('app.school_email', 'cbhlc@example.com') }}</div>


### PR DESCRIPTION
This commit introduces the school logo to the header section of all downloadable PDF documents, including invoices, enrollment certificates, payment history reports, and payment receipts.

The logo is referenced from 'public/images/cbhlc-logo.png'. Users should ensure this image file is present in the specified location for the logo to appear correctly in the generated PDFs.

Files modified:
- resources/views/pdf/enrollment-certificate.blade.php
- resources/views/pdf/invoice.blade.php
- resources/views/pdf/payment-history.blade.php
- resources/views/pdf/payment-receipt.blade.php

## Summary

<!-- Short description of the change. Include the issue number if applicable. -->

Closes: #

## Checklist

- [ ] My code follows the project style (pint, eslint)
- [ ] I added tests for my changes
- [ ] I updated documentation where necessary

## Acceptance criteria

<!-- Describe the acceptance criteria or how to validate the change locally. -->

## Notes

<!-- Any additional notes for reviewers (migration steps, seeder, etc.) -->
