### PR TITLE
fix: Add registrar view-only permissions and complete sidebar navigation

### DIFF
--- a/app/Policies/EnrollmentPeriodPolicy.php
+++ b/app/Policies/EnrollmentPeriodPolicy.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\EnrollmentPeriod;
+use App\Models\User;
+
+class EnrollmentPeriodPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator', 'registrar']);
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, EnrollmentPeriod $enrollmentPeriod): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator', 'registrar']);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, EnrollmentPeriod $enrollmentPeriod): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, EnrollmentPeriod $enrollmentPeriod): bool
+    {
+        return $user->hasRole('super_admin');
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, EnrollmentPeriod $enrollmentPeriod): bool
+    {
+        return $user->hasRole('super_admin');
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, EnrollmentPeriod $enrollmentPeriod): bool
+    {
+        return $user->hasRole('super_admin');
+    }
+
+    /**
+     * Determine whether the user can activate the model.
+     */
+    public function activate(User $user, EnrollmentPeriod $enrollmentPeriod): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+
+    /**
+     * Determine whether the user can close the model.
+     */
+    public function close(User $user, EnrollmentPeriod $enrollmentPeriod): bool
+    {
+        return $user->hasAnyRole(['super_admin', 'administrator']);
+    }
+}

--- a/resources/js/components/sidebars/admin-sidebar.tsx
+++ b/resources/js/components/sidebars/admin-sidebar.tsx
@@ -1,9 +1,12 @@
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { logout } from '@/routes';
 import { type NavItem } from '@/types';
+import { Link, router } from '@inertiajs/react';
 import {
     Banknote,
+    BarChart3,
     Calendar,
     CalendarDays,
     DollarSign,
@@ -12,6 +15,7 @@ import {
     GraduationCap,
     History,
     LayoutGrid,
+    LogOut,
     ReceiptText,
     School,
     Settings,
@@ -89,6 +93,11 @@ const mainNavItems: NavItem[] = [
         icon: School,
     },
     {
+        title: 'Reports',
+        href: '/admin/reports',
+        icon: BarChart3,
+    },
+    {
         title: 'Audit Logs',
         href: '/admin/audit-logs',
         icon: History,
@@ -106,6 +115,10 @@ const mainNavItems: NavItem[] = [
 ];
 
 export function AdminSidebar() {
+    const handleLogout = () => {
+        router.flushAll();
+    };
+
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>
@@ -123,6 +136,16 @@ export function AdminSidebar() {
             </SidebarContent>
 
             <SidebarFooter>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton asChild tooltip="Log out">
+                            <Link href={logout()} method="post" as="button" onClick={handleLogout}>
+                                <LogOut />
+                                <span>Log out</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
                 <NavUser />
             </SidebarFooter>
         </Sidebar>

--- a/resources/js/components/sidebars/guardian-sidebar.tsx
+++ b/resources/js/components/sidebars/guardian-sidebar.tsx
@@ -1,8 +1,10 @@
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { logout } from '@/routes';
 import { type NavItem } from '@/types';
-import { CreditCard, FileCheck, FileText, GraduationCap, LayoutGrid, Settings, Users } from 'lucide-react';
+import { Link, router } from '@inertiajs/react';
+import { CreditCard, FileCheck, FileText, GraduationCap, LayoutGrid, LogOut, Settings, Users } from 'lucide-react';
 import AppLogo from '../app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -60,6 +62,10 @@ const secondaryNavItems: NavItem[] = [
 ];
 
 export function GuardianSidebar() {
+    const handleLogout = () => {
+        router.flushAll();
+    };
+
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>
@@ -79,6 +85,16 @@ export function GuardianSidebar() {
             </SidebarContent>
 
             <SidebarFooter>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton asChild tooltip="Log out">
+                            <Link href={logout()} method="post" as="button" onClick={handleLogout}>
+                                <LogOut />
+                                <span>Log out</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
                 <NavUser />
             </SidebarFooter>
         </Sidebar>

--- a/resources/js/components/sidebars/registrar-sidebar.tsx
+++ b/resources/js/components/sidebars/registrar-sidebar.tsx
@@ -1,8 +1,23 @@
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { logout } from '@/routes';
 import { type NavItem } from '@/types';
-import { BadgeDollarSign, FileCheck, GraduationCap, LayoutGrid, Receipt, ReceiptText, Settings, Users } from 'lucide-react';
+import { Link, router } from '@inertiajs/react';
+import {
+    BadgeDollarSign,
+    Calendar,
+    CalendarDays,
+    FileCheck,
+    GraduationCap,
+    LayoutGrid,
+    LogOut,
+    Receipt,
+    ReceiptText,
+    Settings,
+    ShieldCheck,
+    Users,
+} from 'lucide-react';
 import AppLogo from '../app-logo';
 
 const mainNavItems: NavItem[] = [
@@ -20,6 +35,21 @@ const mainNavItems: NavItem[] = [
         title: 'Students',
         href: '/registrar/students',
         icon: Users,
+    },
+    {
+        title: 'Guardians',
+        href: '/registrar/guardians',
+        icon: ShieldCheck,
+    },
+    {
+        title: 'Enrollment Periods',
+        href: '/registrar/enrollment-periods',
+        icon: Calendar,
+    },
+    {
+        title: 'School Years',
+        href: '/registrar/school-years',
+        icon: CalendarDays,
     },
     {
         title: 'Grade Level Fees',
@@ -54,6 +84,10 @@ const mainNavItems: NavItem[] = [
 ];
 
 export function RegistrarSidebar() {
+    const handleLogout = () => {
+        router.flushAll();
+    };
+
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>
@@ -71,6 +105,16 @@ export function RegistrarSidebar() {
             </SidebarContent>
 
             <SidebarFooter>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton asChild tooltip="Log out">
+                            <Link href={logout()} method="post" as="button" onClick={handleLogout}>
+                                <LogOut />
+                                <span>Log out</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
                 <NavUser />
             </SidebarFooter>
         </Sidebar>

--- a/resources/js/components/sidebars/student-sidebar.tsx
+++ b/resources/js/components/sidebars/student-sidebar.tsx
@@ -1,14 +1,19 @@
 import { NavMain } from '@/components/nav-main';
 import { NavUser } from '@/components/nav-user';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
+import { logout } from '@/routes';
 import { type NavItem, type SharedData } from '@/types';
-import { usePage } from '@inertiajs/react';
-import { ClipboardList, CreditCard, FileCheck, LayoutGrid, Settings } from 'lucide-react';
+import { Link, router, usePage } from '@inertiajs/react';
+import { ClipboardList, CreditCard, FileCheck, LayoutGrid, LogOut, Settings } from 'lucide-react';
 import AppLogo from '../app-logo';
 
 export function StudentSidebar() {
     const { auth } = usePage<SharedData>().props;
     const studentId = auth.user?.student_id;
+
+    const handleLogout = () => {
+        router.flushAll();
+    };
 
     const mainNavItems: NavItem[] = [
         {
@@ -59,6 +64,16 @@ export function StudentSidebar() {
             </SidebarContent>
 
             <SidebarFooter>
+                <SidebarMenu>
+                    <SidebarMenuItem>
+                        <SidebarMenuButton asChild tooltip="Log out">
+                            <Link href={logout()} method="post" as="button" onClick={handleLogout}>
+                                <LogOut />
+                                <span>Log out</span>
+                            </Link>
+                        </SidebarMenuButton>
+                    </SidebarMenuItem>
+                </SidebarMenu>
                 <NavUser />
             </SidebarFooter>
         </Sidebar>

--- a/resources/js/components/sidebars/super-admin-sidebar.tsx
+++ b/resources/js/components/sidebars/super-admin-sidebar.tsx
@@ -6,6 +6,7 @@ import { type NavItem } from '@/types';
 import { Link, router } from '@inertiajs/react';
 import {
     BadgeDollarSign,
+    BarChart3,
     Building2,
     Calendar,
     CalendarDays,
@@ -89,6 +90,11 @@ const mainNavItems: NavItem[] = [
         title: 'School Information',
         href: '/super-admin/school-information',
         icon: Building2,
+    },
+    {
+        title: 'Reports',
+        href: '/super-admin/reports',
+        icon: BarChart3,
     },
     {
         title: 'Audit Logs',

--- a/resources/js/pages/registrar/enrollment-periods/index.tsx
+++ b/resources/js/pages/registrar/enrollment-periods/index.tsx
@@ -4,9 +4,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link, router } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 import { format } from 'date-fns';
-import { Calendar, PlusCircle } from 'lucide-react';
+import { Calendar } from 'lucide-react';
 import { useEffect } from 'react';
 import { toast } from 'sonner';
 
@@ -67,72 +67,13 @@ export default function EnrollmentPeriodsIndex({ periods, activePeriod }: Props)
         }
     }, []);
 
-    const handleActivate = (periodId: number) => {
-        if (confirm('Are you sure you want to activate this enrollment period? This will close any currently active period.')) {
-            router.post(
-                `/registrar/enrollment-periods/${periodId}/activate`,
-                {},
-                {
-                    preserveScroll: true,
-                    onSuccess: () => {
-                        toast.success('Enrollment period activated successfully');
-                    },
-                    onError: () => {
-                        toast.error('Failed to activate enrollment period');
-                    },
-                },
-            );
-        }
-    };
-
-    const handleClose = (periodId: number) => {
-        if (confirm('Are you sure you want to close this enrollment period? This action cannot be undone.')) {
-            router.post(
-                `/registrar/enrollment-periods/${periodId}/close`,
-                {},
-                {
-                    preserveScroll: true,
-                    onSuccess: () => {
-                        toast.success('Enrollment period closed successfully');
-                    },
-                    onError: () => {
-                        toast.error('Failed to close enrollment period');
-                    },
-                },
-            );
-        }
-    };
-
-    const handleDelete = (periodId: number) => {
-        if (confirm('Are you sure you want to delete this enrollment period? This action cannot be undone.')) {
-            router.delete(`/registrar/enrollment-periods/${periodId}`, {
-                preserveScroll: true,
-                onSuccess: () => {
-                    toast.success('Enrollment period deleted successfully');
-                },
-                onError: (errors) => {
-                    const errorMessage = errors.period || 'Failed to delete enrollment period';
-                    toast.error(errorMessage);
-                },
-            });
-        }
-    };
-
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="Enrollment Periods" />
             <div className="px-4 py-6">
-                <div className="mb-6 flex items-center justify-between">
-                    <div>
-                        <h1 className="text-2xl font-bold">Enrollment Periods</h1>
-                        <p className="text-muted-foreground">Manage school year enrollment periods and registration deadlines</p>
-                    </div>
-                    <Link href="/registrar/enrollment-periods/create">
-                        <Button>
-                            <PlusCircle className="mr-2 h-4 w-4" />
-                            Create Period
-                        </Button>
-                    </Link>
+                <div className="mb-6">
+                    <h1 className="text-2xl font-bold">Enrollment Periods</h1>
+                    <p className="text-muted-foreground">View school year enrollment periods and registration deadlines</p>
                 </div>
 
                 {activePeriod && (
@@ -195,11 +136,6 @@ export default function EnrollmentPeriodsIndex({ periods, activePeriod }: Props)
                                             <div className="flex flex-col items-center justify-center text-muted-foreground">
                                                 <Calendar className="mb-2 h-8 w-8" />
                                                 <p>No enrollment periods found</p>
-                                                <Link href="/registrar/enrollment-periods/create" className="mt-2">
-                                                    <Button variant="outline" size="sm">
-                                                        Create your first period
-                                                    </Button>
-                                                </Link>
                                             </div>
                                         </TableCell>
                                     </TableRow>
@@ -215,33 +151,11 @@ export default function EnrollmentPeriodsIndex({ periods, activePeriod }: Props)
                                             <TableCell>{format(new Date(period.regular_registration_deadline), 'MMM d, yyyy')}</TableCell>
                                             <TableCell>{period.enrollments_count || 0}</TableCell>
                                             <TableCell className="text-right">
-                                                <div className="flex justify-end gap-2">
-                                                    <Link href={`/registrar/enrollment-periods/${period.id}`}>
-                                                        <Button variant="outline" size="sm">
-                                                            View
-                                                        </Button>
-                                                    </Link>
-                                                    {period.status === 'upcoming' && (
-                                                        <Button variant="default" size="sm" onClick={() => handleActivate(period.id)}>
-                                                            Activate
-                                                        </Button>
-                                                    )}
-                                                    {period.status === 'active' && (
-                                                        <Button variant="outline" size="sm" onClick={() => handleClose(period.id)}>
-                                                            Close
-                                                        </Button>
-                                                    )}
-                                                    <Link href={`/registrar/enrollment-periods/${period.id}/edit`}>
-                                                        <Button variant="outline" size="sm">
-                                                            Edit
-                                                        </Button>
-                                                    </Link>
-                                                    {period.status !== 'active' && (period.enrollments_count || 0) === 0 && (
-                                                        <Button variant="destructive" size="sm" onClick={() => handleDelete(period.id)}>
-                                                            Delete
-                                                        </Button>
-                                                    )}
-                                                </div>
+                                                <Link href={`/registrar/enrollment-periods/${period.id}`}>
+                                                    <Button variant="outline" size="sm">
+                                                        View
+                                                    </Button>
+                                                </Link>
                                             </TableCell>
                                         </TableRow>
                                     ))

--- a/resources/js/pages/registrar/enrollment-periods/show.tsx
+++ b/resources/js/pages/registrar/enrollment-periods/show.tsx
@@ -1,13 +1,11 @@
 import { EnrollmentPeriodStatusBadge } from '@/components/status-badges';
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link, router } from '@inertiajs/react';
+import { Head } from '@inertiajs/react';
 import { format } from 'date-fns';
-import { Calendar, CheckCircle2, Edit, Trash2, XCircle } from 'lucide-react';
-import { toast } from 'sonner';
+import { Calendar } from 'lucide-react';
 
 export type EnrollmentPeriod = {
     id: number;
@@ -35,89 +33,13 @@ export default function EnrollmentPeriodShow({ period }: Props) {
         { title: period.school_year, href: `/registrar/enrollment-periods/${period.id}` },
     ];
 
-    const handleActivate = () => {
-        if (confirm('Are you sure you want to activate this enrollment period? This will close any currently active period.')) {
-            router.post(
-                `/registrar/enrollment-periods/${period.id}/activate`,
-                {},
-                {
-                    onSuccess: () => {
-                        toast.success('Enrollment period activated successfully');
-                    },
-                    onError: () => {
-                        toast.error('Failed to activate enrollment period');
-                    },
-                },
-            );
-        }
-    };
-
-    const handleClose = () => {
-        if (confirm('Are you sure you want to close this enrollment period? This action cannot be undone.')) {
-            router.post(
-                `/registrar/enrollment-periods/${period.id}/close`,
-                {},
-                {
-                    onSuccess: () => {
-                        toast.success('Enrollment period closed successfully');
-                    },
-                    onError: () => {
-                        toast.error('Failed to close enrollment period');
-                    },
-                },
-            );
-        }
-    };
-
-    const handleDelete = () => {
-        if (confirm('Are you sure you want to delete this enrollment period? This action cannot be undone.')) {
-            router.delete(`/registrar/enrollment-periods/${period.id}`, {
-                onSuccess: () => {
-                    toast.success('Enrollment period deleted successfully');
-                },
-                onError: (errors) => {
-                    const errorMessage = errors.period || 'Failed to delete enrollment period';
-                    toast.error(errorMessage);
-                },
-            });
-        }
-    };
-
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title={`Enrollment Period ${period.school_year}`} />
             <div className="px-4 py-6">
-                <div className="mb-6 flex items-center justify-between">
-                    <div>
-                        <h1 className="text-2xl font-bold">Enrollment Period Details</h1>
-                        <p className="text-muted-foreground">View enrollment period information and settings</p>
-                    </div>
-                    <div className="flex gap-2">
-                        {period.status === 'upcoming' && (
-                            <Button onClick={handleActivate}>
-                                <CheckCircle2 className="mr-2 h-4 w-4" />
-                                Activate
-                            </Button>
-                        )}
-                        {period.status === 'active' && (
-                            <Button variant="outline" onClick={handleClose}>
-                                <XCircle className="mr-2 h-4 w-4" />
-                                Close
-                            </Button>
-                        )}
-                        <Link href={`/registrar/enrollment-periods/${period.id}/edit`}>
-                            <Button variant="outline">
-                                <Edit className="mr-2 h-4 w-4" />
-                                Edit
-                            </Button>
-                        </Link>
-                        {period.status !== 'active' && (period.enrollments_count || 0) === 0 && (
-                            <Button variant="destructive" onClick={handleDelete}>
-                                <Trash2 className="mr-2 h-4 w-4" />
-                                Delete
-                            </Button>
-                        )}
-                    </div>
+                <div className="mb-6">
+                    <h1 className="text-2xl font-bold">Enrollment Period Details</h1>
+                    <p className="text-muted-foreground">View enrollment period information and settings</p>
                 </div>
 
                 <div className="grid gap-6">

--- a/resources/js/pages/registrar/school-years/index.tsx
+++ b/resources/js/pages/registrar/school-years/index.tsx
@@ -4,9 +4,9 @@ import { Button } from '@/components/ui/button';
 import { DataTable } from '@/components/ui/data-table';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
-import { Head, Link, router } from '@inertiajs/react';
+import { Head, router } from '@inertiajs/react';
 import { ColumnDef, SortingState } from '@tanstack/react-table';
-import { Calendar, Plus } from 'lucide-react';
+import { Calendar } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 interface SchoolYear {
@@ -105,14 +105,9 @@ export default function SchoolYearsIndex({ schoolYears, activeSchoolYear }: Prop
             id: 'actions',
             header: 'Actions',
             cell: ({ row }) => (
-                <div className="flex gap-2">
-                    <Button size="sm" variant="outline" onClick={() => router.visit(`/registrar/school-years/${row.original.id}`)}>
-                        View
-                    </Button>
-                    <Button size="sm" variant="outline" onClick={() => router.visit(`/registrar/school-years/${row.original.id}/edit`)}>
-                        Edit
-                    </Button>
-                </div>
+                <Button size="sm" variant="outline" onClick={() => router.visit(`/registrar/school-years/${row.original.id}`)}>
+                    View
+                </Button>
             ),
         },
     ];
@@ -121,22 +116,14 @@ export default function SchoolYearsIndex({ schoolYears, activeSchoolYear }: Prop
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title="School Years" />
             <div className="px-4 py-6">
-                <div className="mb-6 flex items-center justify-between">
-                    <div>
-                        <h1 className="text-2xl font-bold">School Years</h1>
-                        {activeSchoolYear && (
-                            <p className="mt-1 text-sm text-muted-foreground">
-                                <Calendar className="mr-1 inline h-4 w-4" />
-                                Active: {activeSchoolYear.name}
-                            </p>
-                        )}
-                    </div>
-                    <Link href="/registrar/school-years/create">
-                        <Button>
-                            <Plus className="mr-2 h-4 w-4" />
-                            Create School Year
-                        </Button>
-                    </Link>
+                <div className="mb-6">
+                    <h1 className="text-2xl font-bold">School Years</h1>
+                    {activeSchoolYear && (
+                        <p className="mt-1 text-sm text-muted-foreground">
+                            <Calendar className="mr-1 inline h-4 w-4" />
+                            Active: {activeSchoolYear.name}
+                        </p>
+                    )}
                 </div>
                 <DataTable columns={columns} data={schoolYears.data} sorting={sorting} onSortingChange={setSorting} />
             </div>

--- a/resources/js/pages/registrar/school-years/show.tsx
+++ b/resources/js/pages/registrar/school-years/show.tsx
@@ -1,8 +1,7 @@
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import AppLayout from '@/layouts/app-layout';
-import { Head, Link } from '@inertiajs/react';
+import { Head } from '@inertiajs/react';
 import { Calendar, FileText, Users } from 'lucide-react';
 
 interface SchoolYear {
@@ -33,17 +32,12 @@ export default function SchoolYearShow({ schoolYear }: Props) {
         >
             <Head title={schoolYear.name} />
             <div className="px-4 py-6">
-                <div className="mb-6 flex items-center justify-between">
-                    <div>
-                        <h1 className="flex items-center gap-2 text-2xl font-bold">
-                            {schoolYear.name}
-                            {schoolYear.is_active && <Badge>Active</Badge>}
-                        </h1>
-                        <p className="text-muted-foreground">{schoolYear.status}</p>
-                    </div>
-                    <Link href={`/registrar/school-years/${schoolYear.id}/edit`}>
-                        <Button>Edit School Year</Button>
-                    </Link>
+                <div className="mb-6">
+                    <h1 className="flex items-center gap-2 text-2xl font-bold">
+                        {schoolYear.name}
+                        {schoolYear.is_active && <Badge>Active</Badge>}
+                    </h1>
+                    <p className="text-muted-foreground">{schoolYear.status}</p>
                 </div>
 
                 <div className="grid gap-4 md:grid-cols-3">


### PR DESCRIPTION
## Summary
This PR fixes the 403 Forbidden error on registrar enrollment periods by creating the missing `EnrollmentPeriodPolicy` and updates all registrar pages to properly reflect view-only access. It also completes sidebar navigation across all user roles by adding missing navigation items and logout buttons.

## Changes

### Backend
- **Created `EnrollmentPeriodPolicy`** with view-only access for registrars
  - Allows `super_admin`, `administrator`, and `registrar` to view enrollment periods
  - Restricts create/update/delete/activate/close to `super_admin` and `administrator` only

### Sidebar Navigation
- **Added logout buttons** to Admin, Registrar, Guardian, and Student sidebars for consistent UX
- **Added missing navigation items:**
  - Super Admin: Reports
  - Admin: Reports  
  - Registrar: Guardians, Enrollment Periods, School Years

### Frontend (Registrar View-Only)
- **Enrollment Periods pages:** Removed create/edit/delete/activate/close buttons, kept only "View"
- **School Years pages:** Removed create/edit buttons, kept only "View"
- **Updated page descriptions** to reflect view-only access ("View" instead of "Manage")
- **Cleaned up unused imports** and handler functions

## Fixes
- Fixes #403 (403 Forbidden on `/registrar/enrollment-periods`)
- Resolves missing navigation items across all user dashboards
- Ensures consistent logout button accessibility

## Testing
- ✅ All pre-push checks passed (PHP syntax, Pint, PHPStan, security audit)
- ✅ Tests passed with >50% coverage
- ✅ TypeScript and Prettier checks passed
- ✅ Vite build successful