### PR TITLE
fix: Improve notification text visibility in dark mode

### DIFF
--- a/resources/js/components/notifications-dropdown.tsx
+++ b/resources/js/components/notifications-dropdown.tsx
@@ -146,15 +146,15 @@ export default function NotificationsDropdown({ notifications }: Props) {
                         notifications.map((notification) => (
                             <DropdownMenuItem
                                 key={notification.id}
-                                className={`flex cursor-pointer flex-col items-start gap-1 p-3 ${!notification.read_at ? 'bg-blue-50' : ''}`}
+                                className={`flex cursor-pointer flex-col items-start gap-1 p-3 ${!notification.read_at ? 'bg-blue-50 dark:bg-blue-950/30' : ''}`}
                                 onClick={() => handleNotificationClick(notification)}
                             >
                                 <div className="flex w-full items-start justify-between gap-2">
                                     <div className="flex-1">
-                                        <p className="text-sm font-semibold">{getNotificationTitle(notification)}</p>
+                                        <p className="text-sm font-semibold text-foreground">{getNotificationTitle(notification)}</p>
                                         <p className="text-xs text-muted-foreground">{notification.data.message}</p>
                                     </div>
-                                    {!notification.read_at && <div className="h-2 w-2 rounded-full bg-blue-600" />}
+                                    {!notification.read_at && <div className="h-2 w-2 rounded-full bg-blue-600 dark:bg-blue-400" />}
                                 </div>
                                 <div className="flex w-full items-center justify-between">
                                     <span className="text-xs text-muted-foreground">{formatDate(notification.created_at)}</span>


### PR DESCRIPTION
## Summary
Fixes notification text visibility issues in dark mode where text was not visible due to hardcoded light background colors.

## Changes
- **Added dark mode background variant** for unread notifications: `dark:bg-blue-950/30`
- **Added `text-foreground` class** to notification title for automatic theme adaptation
- **Added dark mode variant** for unread indicator dot: `dark:bg-blue-400`

## Before
- Notification texts were invisible/unreadable in dark mode
- Unread notifications had hardcoded `bg-blue-50` without dark mode support
- Unread indicator dot was too dim in dark mode

## After
- Notification texts are clearly visible in both light and dark modes
- Unread notifications have proper dark mode background (`dark:bg-blue-950/30`)
- Unread indicator dot is bright and visible (`dark:bg-blue-400`)
- Text colors adapt automatically to theme changes

## Testing
- ✅ Lint-staged checks passed (Prettier, ESLint)
- Manual testing required:
  1. Log in as Super Admin
  2. Navigate to Profile Settings → Appearance
  3. Toggle Dark Mode
  4. Click notification bell
  5. Verify all notification texts are clearly visible

## Fixes
Closes #612