### PR TITLE
Revert "Fix: Display 'birthdate' correctly on Guardian Enrollment Show page"

### DIFF
--- a/resources/js/pages/guardian/enrollments/show.tsx
+++ b/resources/js/pages/guardian/enrollments/show.tsx
@@ -14,7 +14,7 @@ interface Enrollment {
         first_name: string;
         last_name: string;
         student_id: string;
-        birthdate: string;
+        birth_date: string;
         gender: string;
         address: string;
         phone: string;


### PR DESCRIPTION
Reverts st4rboy1/cbhlc#632