### PR TITLE
fix: update dependency workflow permissions and action versions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,11 +11,13 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -40,8 +42,9 @@ jobs:
         run: composer audit
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update dependencies to latest secure versions'
           title: 'chore: update dependencies for security patches'
           body: |


### PR DESCRIPTION
- Add explicit GITHUB_TOKEN to checkout and create-pull-request steps
- Upgrade peter-evans/create-pull-request to v6 (fixes Node 20 deprecation)
- Add actions:write permission for workflow execution
- Fixes: 'GitHub Actions is not permitted to create or approve pull requests' error

## Summary

<!-- Short description of the change. Include the issue number if applicable. -->

Closes: #

## Checklist

- [ ] My code follows the project style (pint, eslint)
- [ ] I added tests for my changes
- [ ] I updated documentation where necessary

## Acceptance criteria

<!-- Describe the acceptance criteria or how to validate the change locally. -->

## Notes

<!-- Any additional notes for reviewers (migration steps, seeder, etc.) -->
